### PR TITLE
Issue 272: Multiple Message CommitBatch Update and No Offset Result Conversion

### DIFF
--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -90,6 +90,13 @@ object ConsumerMessage {
     def updated(offset: CommittableOffset): CommittableOffsetBatch
 
     /**
+     * Add/overwite an offset position for the given groupId, topic, partition.
+     * @param offsets Sequence of offsets to add/overwrite offset position for the given groupId, topic, partition.
+     * @return
+     */
+    def updated(offsets: Seq[CommittableOffset]): CommittableOffsetBatch
+
+    /**
      * Scala API: Get current offset positions
      */
     def offsets(): Map[GroupTopicPartition, Long]

--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -11,6 +11,7 @@ import akka.Done
 import akka.kafka.internal.ConsumerStage.CommittableOffsetBatchImpl
 import org.apache.kafka.clients.consumer.ConsumerRecord
 
+import scala.collection.immutable
 import scala.concurrent.Future
 
 /**
@@ -81,7 +82,7 @@ object ConsumerMessage {
   /**
    * For improved efficiency it is good to aggregate several [[CommittableOffset]],
    * using this class, before [[Committable#commitScaladsl committing]] them. Start with
-   * the [[CommittableOffsetBatch$#empty empty] batch.
+   * the [[CommittableOffsetBatch#empty empty]] batch.
    */
   trait CommittableOffsetBatch extends Committable {
     /**

--- a/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
@@ -7,21 +7,36 @@ package akka.kafka
 import java.util
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.regex.Pattern
+
 import akka.actor.{Actor, ActorLogging, ActorRef, Cancellable, Props, Status, Terminated}
 import akka.event.LoggingReceive
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.errors.WakeupException
+
 import scala.collection.JavaConverters._
 import java.util.concurrent.locks.LockSupport
+
+import akka.Done
 import akka.actor.DeadLetterSuppression
+
 import scala.util.control.{NoStackTrace, NonFatal}
 import scala.util.{Failure, Success, Try}
 
 object KafkaConsumerActor {
   case class StoppingException() extends RuntimeException("Kafka consumer is stopping")
-  def props[K, V](settings: ConsumerSettings[K, V]): Props =
-    Props(new KafkaConsumerActor(settings)).withDispatcher(settings.dispatcher)
+
+  def propsWithCommitResult[K, V](
+    settings: ConsumerSettings[K, V]
+  ): Props = {
+    Props(new KafkaConsumerActor(settings, m => Internal.OffsetCommitResult(m.asScala.toMap))).withDispatcher(settings.dispatcher)
+  }
+
+  def props[K, V](
+    settings: ConsumerSettings[K, V]
+  ): Props = {
+    Props(new KafkaConsumerActor(settings, m => Internal.CompletedCommit)).withDispatcher(settings.dispatcher)
+  }
 
   private[kafka] object Internal {
     //requests
@@ -36,9 +51,12 @@ object KafkaConsumerActor {
     final case class Assigned(partition: List[TopicPartition])
     final case class Revoked(partition: List[TopicPartition])
     final case class Messages[K, V](requestId: Int, messages: Iterator[ConsumerRecord[K, V]])
-    final case class Committed(offsets: Map[TopicPartition, OffsetAndMetadata])
+
+    sealed trait CommitResult
+    final case class OffsetCommitResult(result: Map[TopicPartition, OffsetAndMetadata]) extends CommitResult
+    final case object CompletedCommit extends CommitResult
     //internal
-    private[KafkaConsumerActor] final case class Poll[K, V](target: KafkaConsumerActor[K, V]) extends DeadLetterSuppression
+    private[KafkaConsumerActor] final case class Poll[K, V, R](target: KafkaConsumerActor[K, V, R]) extends DeadLetterSuppression
     private val number = new AtomicInteger()
     def nextNumber() = {
       number.incrementAndGet()
@@ -68,7 +86,10 @@ object KafkaConsumerActor {
   }
 }
 
-private[kafka] class KafkaConsumerActor[K, V](settings: ConsumerSettings[K, V])
+private[kafka] class KafkaConsumerActor[K, V, R](
+  settings: ConsumerSettings[K, V],
+  mapCommittedOffsets: util.Map[TopicPartition, OffsetAndMetadata] => R
+)
     extends Actor with ActorLogging {
   import KafkaConsumerActor.Internal._
   import KafkaConsumerActor._
@@ -102,11 +123,11 @@ private[kafka] class KafkaConsumerActor[K, V](settings: ConsumerSettings[K, V])
       val reply = sender()
       commitsInProgress += 1
       consumer.commitAsync(commitMap.asJava, new OffsetCommitCallback {
-        override def onComplete(offsets: util.Map[TopicPartition, OffsetAndMetadata], exception: Exception): Unit = {
+        override def onComplete(committedOffsets: util.Map[TopicPartition, OffsetAndMetadata], exception: Exception): Unit = {
           // this is invoked on the thread calling consumer.poll which will always be the actor, so it is safe
           commitsInProgress -= 1
           if (exception != null) reply ! Status.Failure(exception)
-          else reply ! Committed(offsets.asScala.toMap)
+          else reply ! mapCommittedOffsets(committedOffsets)
         }
       })
       //right now we can not store commits in consumer - https://issues.apache.org/jira/browse/KAFKA-3412

--- a/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/core/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -33,6 +33,8 @@ import org.scalactic.TypeCheckedTripleEquals
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Matchers, WordSpecLike}
 import org.scalatest.Assertions
 
+import scala.concurrent.duration._
+
 class IntegrationSpec extends TestKit(ActorSystem("IntegrationSpec"))
     with WordSpecLike with Matchers with BeforeAndAfterAll with BeforeAndAfterEach
     with TypeCheckedTripleEquals {
@@ -267,9 +269,139 @@ class IntegrationSpec extends TestKit(ActorSystem("IntegrationSpec"))
       val consumerSettings2 = createConsumerSettings(group1)
       val probe2 = createProbe(consumerSettings2, topic1)
 
+      val element = probe2.request(1).expectNext(60.seconds)
+
+      Assertions.assert(element.toInt > 10, "Should start after last element of first batch")
+      probe2.cancel()
+    }
+
+    "consume and commit in unordered batches" in {
+      val topic1 = createTopic(1)
+      val group1 = createGroup(1)
+
+      givenInitializedTopic(topic1)
+
+      Await.result(produce(topic1, 1 to 100), remainingOrDefault)
+      val consumerSettings = createConsumerSettings(group1)
+
+      def consumeAndBatchCommit(topic: String) = {
+        Consumer.committableSource(
+          consumerSettings,
+          TopicSubscription(Set(topic))
+        )
+          .mapAsync(10) { msg =>
+            akka.pattern.after( (scala.util.Random.nextInt(50) + 50).milliseconds, using = system.scheduler ) {
+              Future.successful(msg.committableOffset)
+            }
+          }
+          .batch(max = 10, first => CommittableOffsetBatch.empty.updated(first)) {
+            (batch, elem) => batch.updated(elem)
+          }
+          .mapAsync(1)(_.commitScaladsl())
+          .toMat(TestSink.probe)(Keep.both).run()
+      }
+
+      val (control, probe) = consumeAndBatchCommit(topic1)
+
+      //give it time to aggregate the first batch
+      probe.ensureSubscription()
+      probe.expectNoMsg(1.seconds)
+
+      // Request one batch
+      probe.request(1).expectNextN(1)
+
+      probe.cancel()
+      Await.result(control.isShutdown, remainingOrDefault)
+
+      // Resume consumption
+      val consumerSettings2 = createConsumerSettings(group1)
+      val probe2 = createProbe(consumerSettings2, topic1)
+
       val element = probe2.request(1).expectNext(60 seconds)
 
-      Assertions.assert(element.toInt > 1, "Should start after first element")
+      Assertions.assert(element.toInt > 10, "Should start after last element of first batch")
+      probe2.cancel()
+    }
+
+    "consume and commit in grouped batches" in {
+      val topic1 = createTopic(1)
+      val group1 = createGroup(1)
+
+      givenInitializedTopic(topic1)
+
+      Await.result(produce(topic1, 1 to 100), remainingOrDefault)
+      val consumerSettings = createConsumerSettings(group1)
+
+      def consumeAndBatchCommit(topic: String) = {
+        Consumer.committableSource(
+          consumerSettings,
+          TopicSubscription(Set(topic))
+        )
+          .map { msg => msg.committableOffset }
+          .groupedWithin(10, 1.seconds)
+          .map { elems =>
+            CommittableOffsetBatch.empty.updated(elems)
+          }
+          .mapAsync(1)(_.commitScaladsl())
+          .toMat(TestSink.probe)(Keep.both).run()
+      }
+
+      val (control, probe) = consumeAndBatchCommit(topic1)
+
+      // Request one batch
+      probe.request(1).expectNextN(1)
+
+      probe.cancel()
+      Await.result(control.isShutdown, remainingOrDefault)
+
+      // Resume consumption
+      val consumerSettings2 = createConsumerSettings(group1)
+      val probe2 = createProbe(consumerSettings2, topic1)
+
+      val element = probe2.request(1).expectNext(60 seconds)
+
+      Assertions.assert(element.toInt > 10, "Should start after last element of first batch")
+      probe2.cancel()
+    }
+
+    "consume and commit in unordered grouped batches" in {
+      val topic1 = createTopic(1)
+      val group1 = createGroup(1)
+
+      givenInitializedTopic(topic1)
+
+      Await.result(produce(topic1, 1 to 100), remainingOrDefault)
+      val consumerSettings = createConsumerSettings(group1)
+
+      def consumeAndBatchCommit(topic: String) = {
+        Consumer.committableSource(
+          consumerSettings,
+          TopicSubscription(Set(topic))
+        )
+          .map { msg => msg.committableOffset }
+          .groupedWithin(10, 1.seconds)
+          .map { elems =>
+            CommittableOffsetBatch.empty.updated(scala.util.Random.shuffle(elems))
+          }
+          .mapAsync(1)(_.commitScaladsl())
+          .toMat(TestSink.probe)(Keep.both).run()
+      }
+
+      val (control, probe) = consumeAndBatchCommit(topic1)
+
+      // Request one batch
+      probe.request(1).expectNextN(1)
+
+      probe.cancel()
+      Await.result(control.isShutdown, remainingOrDefault)
+
+      // Resume consumption
+      val consumerSettings2 = createConsumerSettings(group1)
+      val probe2 = createProbe(consumerSettings2, topic1)
+
+      val element = probe2.request(1).expectNext(60 seconds)
+
+      Assertions.assert(element.toInt > 10, "Should start after last element of first batch")
       probe2.cancel()
     }
 

--- a/docs/src/test/scala/sample/scaladsl/ConsumerExample.scala
+++ b/docs/src/test/scala/sample/scaladsl/ConsumerExample.scala
@@ -324,7 +324,11 @@ object ExternallyControlledKafkaConsumer extends ConsumerExample {
   def main(args: Array[String]): Unit = {
     // #consumerActor
     //Consumer is represented by actor
-    val consumer: ActorRef = system.actorOf(KafkaConsumerActor.props(consumerSettings))
+    val consumer: ActorRef = system.actorOf(
+      KafkaConsumerActor.propsWithCommitResult(
+        consumerSettings
+      )
+    )
 
     //Manually assign topic partition to it
     Consumer


### PR DESCRIPTION
https://github.com/akka/reactive-kafka/issues/272

Provide method to update commitbatch with multiple values (e.g. when grouping kafka messages), and provide a version of the KafkaConsumerActor that does not convert the commit result to a map.