### PR TITLE
Fixing #357 - committableSource now delays consumer shutdown if it has un-committed messages inflight

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -50,6 +50,18 @@ akka.kafka.consumer {
 
   # If commits take longer than this time a warning is logged
   commit-time-warning = 1s
+
+  # The max time we wait for inflight commits after commitableSource shutdown.
+  # Also see max-inflight-commits-on-shutdown
+  # https://github.com/akka/reactive-kafka/issues/357
+  max-delayed-consumer-shutdown = 5s
+
+  # When using commitableSource and shutting down (eg. due to take/takeWhile)
+  # we're delaying consumber shutdown to allow messages already inflight to be commmitted.
+  # We stop the consumber when we have max-inflight-commits-on-shutdown number of
+  # inflight commits left OR the time max-delayed-consumer-shutdown has passed
+  # https://github.com/akka/reactive-kafka/issues/357
+  max-inflight-commits-on-shutdown = 0
   
   # If for any reason KafkaConsumer.poll blocks for longer than the configured
   # poll-timeout then forcefully woken up with KafkaConsumer.wakeup

--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -158,14 +158,16 @@ object ConsumerSettings {
     val stopTimeout = config.getDuration("stop-timeout", TimeUnit.MILLISECONDS).millis
     val closeTimeout = config.getDuration("close-timeout", TimeUnit.MILLISECONDS).millis
     val commitTimeout = config.getDuration("commit-timeout", TimeUnit.MILLISECONDS).millis
+    val maxDelayedConsumerShutdown = config.getDuration("max-delayed-consumer-shutdown", TimeUnit.MILLISECONDS).millis
+    val maxInflightCommitsOnShutdown = config.getLong("max-inflight-commits-on-shutdown")
     val commitTimeWarning = config.getDuration("commit-time-warning", TimeUnit.MILLISECONDS).millis
     val wakeupTimeout = config.getDuration("wakeup-timeout", TimeUnit.MILLISECONDS).millis
     val maxWakeups = config.getInt("max-wakeups")
     val dispatcher = config.getString("use-dispatcher")
     val wakeupDebug = config.getBoolean("wakeup-debug")
     new ConsumerSettings[K, V](properties, keyDeserializer, valueDeserializer,
-      pollInterval, pollTimeout, stopTimeout, closeTimeout, commitTimeout, wakeupTimeout, maxWakeups, dispatcher,
-      commitTimeWarning, wakeupDebug)
+      pollInterval, pollTimeout, stopTimeout, closeTimeout, commitTimeout, maxDelayedConsumerShutdown,
+      maxInflightCommitsOnShutdown, wakeupTimeout, maxWakeups, dispatcher, commitTimeWarning, wakeupDebug)
   }
 
   /**
@@ -258,6 +260,8 @@ class ConsumerSettings[K, V](
     val stopTimeout: FiniteDuration,
     val closeTimeout: FiniteDuration,
     val commitTimeout: FiniteDuration,
+    val maxDelayedConsumerShutdown: FiniteDuration,
+    val maxInflightCommitsOnShutdown: Long,
     val wakeupTimeout: FiniteDuration,
     val maxWakeups: Int,
     val dispatcher: String,
@@ -322,6 +326,12 @@ class ConsumerSettings[K, V](
   def withCommitTimeout(commitTimeout: FiniteDuration): ConsumerSettings[K, V] =
     copy(commitTimeout = commitTimeout)
 
+  def withMaxDelayedConsumerShutdown(maxDelayedConsumerShutdown: FiniteDuration): ConsumerSettings[K, V] =
+    copy(maxDelayedConsumerShutdown = maxDelayedConsumerShutdown)
+
+  def withMaxInflightCommitsOnShutdown(maxInflightCommitsOnShutdown: Long): ConsumerSettings[K, V] =
+    copy(maxInflightCommitsOnShutdown = maxInflightCommitsOnShutdown)
+
   def withCommitWarning(commitTimeWarning: FiniteDuration): ConsumerSettings[K, V] =
     copy(commitTimeWarning = commitTimeWarning)
 
@@ -346,6 +356,8 @@ class ConsumerSettings[K, V](
     stopTimeout: FiniteDuration = stopTimeout,
     closeTimeout: FiniteDuration = closeTimeout,
     commitTimeout: FiniteDuration = commitTimeout,
+    maxDelayedConsumerShutdown: FiniteDuration = maxDelayedConsumerShutdown,
+    maxInflightCommitsOnShutdown: Long = maxInflightCommitsOnShutdown,
     commitTimeWarning: FiniteDuration = commitTimeWarning,
     wakeupTimeout: FiniteDuration = wakeupTimeout,
     maxWakeups: Int = maxWakeups,
@@ -353,8 +365,8 @@ class ConsumerSettings[K, V](
     wakeupDebug: Boolean = wakeupDebug
   ): ConsumerSettings[K, V] =
     new ConsumerSettings[K, V](properties, keyDeserializer, valueDeserializer,
-      pollInterval, pollTimeout, stopTimeout, closeTimeout, commitTimeout, wakeupTimeout,
-      maxWakeups, dispatcher, commitTimeWarning, wakeupDebug)
+      pollInterval, pollTimeout, stopTimeout, closeTimeout, commitTimeout, maxDelayedConsumerShutdown,
+      maxInflightCommitsOnShutdown, wakeupTimeout, maxWakeups, dispatcher, commitTimeWarning, wakeupDebug)
 
   /**
    * Create a `KafkaConsumer` instance from the settings.

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -10,6 +10,7 @@
     <!--<logger name="org.apache.kafka.common.utils.AppInfoParser" level="ERROR"/>-->
     <!--<logger name="org.apache.kafka.clients.NetworkClient" level="ERROR"/>-->
     <!--<logger name="akka.kafka" level="TRACE"/>-->
+    <!--<logger name="akka.kafka.internal.SingleSourceLogic.SingleSourceLogic" level="debug"/>-->
 
     <root level="WARN">
         <appender-ref ref="STDOUT" />

--- a/core/src/test/scala/akka/kafka/internal/ConsumerTest.scala
+++ b/core/src/test/scala/akka/kafka/internal/ConsumerTest.scala
@@ -89,7 +89,7 @@ class ConsumerTest(_system: ActorSystem)
 
   def testSource(mock: ConsumerMock[K, V], groupId: String = "group1", topics: Set[String] = Set("topic")): Source[CommittableMessage[K, V], Control] = {
     val settings = new ConsumerSettings(Map(ConsumerConfig.GROUP_ID_CONFIG -> groupId), Some(new StringDeserializer), Some(new StringDeserializer),
-      1.milli, 1.milli, 1.second, closeTimeout, 1.second, 5.seconds, 3, "akka.kafka.default-dispatcher", 1.second, true) {
+      1.milli, 1.milli, 1.second, closeTimeout, 1.second, 5.seconds, 0, 5.seconds, 3, "akka.kafka.default-dispatcher", 1.second, true) {
       override def createKafkaConsumer(): KafkaConsumer[K, V] = {
         mock.mock
       }
@@ -510,6 +510,7 @@ class ConsumerTest(_system: ActorSystem)
 
       Await.result(done, remainingOrDefault)
       Await.result(stopped, remainingOrDefault)
+      Thread.sleep(20)
       mock.verifyClosed()
     }
   }


### PR DESCRIPTION
Delays the consumer-shutdown either when all inflight messages are committed OR by timing out.

The "when all inflight messages are committed" can be kind of tricky since akka stream is buffering messages.

When using .take( x ) close to the source, we will have no buffered messages.
If you know how many messages are buffered, you can choose to configure 'max-inflight-commits-on-shutdown'.

See test.

It would be great to get some feedback on this PR.

I have tested it in my internal app, and it DO make the take/takeWhile problem go away (https://github.com/akka/reactive-kafka/issues/357)