### PR TITLE
Use previousStableVersion for mima checks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,7 +120,7 @@ lazy val core = project
       "org.scalatest" %% "scalatest" % scalatestVersion % "it",
       "com.spotify" % "docker-client" % "8.11.5" % "it",
     ),
-    mimaPreviousArtifacts := (20 to 20).map(minor => organization.value %% name.value % s"0.$minor").toSet,
+    mimaPreviousArtifacts := previousStableVersion.value.map(organization.value %% name.value % _).toSet,
     makePomConfiguration := makePomConfiguration.value.withConfigurations(Configurations.defaultMavenConfigurations),
   )
   .settings(Defaults.itSettings)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.0.0")
+addSbtPlugin("com.dwijnand" % "sbt-dynver" % "3.0.0+4-1be64920")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0")


### PR DESCRIPTION
This allows us to not have a manual step in the release process to update `mimaPreviousArtifacts` after every release.