### PR TITLE
Improve wakeup logging

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -322,7 +322,7 @@ class KafkaConsumerActor[K, V](settings: ConsumerSettings[K, V]) extends Actor w
     val wakeupTask = context.system.scheduler.scheduleOnce(settings.wakeupTimeout) {
       log.warning(
         "KafkaConsumer poll has exceeded wake up timeout ({}). Waking up consumer to avoid thread starvation.",
-        settings.wakeupTimeout
+        settings.wakeupTimeout.toCoarsest
       )
       if (settings.wakeupDebug && wakeups > settings.maxWakeups / 2) {
         val stacks =
@@ -357,7 +357,7 @@ class KafkaConsumerActor[K, V](settings: ConsumerSettings[K, V]) extends Actor w
               "WakeupException limit exceeded during poll({}), stopping (max-wakeups = {}, wakeup-timeout = {}).",
               timeout,
               settings.maxWakeups,
-              settings.wakeupTimeout
+              settings.wakeupTimeout.toCoarsest
             )
             context.stop(self)
           } else {
@@ -367,7 +367,7 @@ class KafkaConsumerActor[K, V](settings: ConsumerSettings[K, V]) extends Actor w
                 timeout,
                 wakeups,
                 settings.maxWakeups,
-                settings.wakeupTimeout
+                settings.wakeupTimeout.toCoarsest
               )
               if (initialPoll) {
                 log.error(

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -363,8 +363,7 @@ class KafkaConsumerActor[K, V](settings: ConsumerSettings[K, V]) extends Actor w
           } else {
             if (log.isWarningEnabled && wakeups > settings.maxWakeups / 2) {
               log.warning(
-                "Consumer poll({}) interrupted with WakeupException (#{} of max-wakeups = {}, wakeup-timeout = {}). " +
-                (if (w.getMessage != null) s"Message: ${w.getMessage}. " else ""),
+                "Consumer poll({}) interrupted with WakeupException (#{} of max-wakeups = {}, wakeup-timeout = {}).",
                 timeout,
                 wakeups,
                 settings.maxWakeups,


### PR DESCRIPTION
* Delay logging to `maxWakeups / 2`
* Don't log stack trace (but be clear about it happening during poll)
* Log on error level if initial poll fails more than `maxWakeups / 2`, printing bootstrap servers
* Avoid allocation of `FiniteDuration` after committing