### PR TITLE
Use reply parameter, don't cast throwaway result

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -482,7 +482,6 @@ class KafkaConsumerActor[K, V](settings: ConsumerSettings[K, V]) extends Actor w
   private def commit(offsets: Map[TopicPartition, Long], reply: ActorRef): Unit = {
     commitRefreshDeadline = nextCommitRefreshDeadline()
     val commitMap = offsets.mapValues(new OffsetAndMetadata(_))
-    val reply = sender()
     commitsInProgress += 1
     val startTime = System.nanoTime()
     consumer.commitAsync(


### PR DESCRIPTION
Inspecting the code to learn more about #266, I found these two inconsistencies:
* The reply parameter in the actor's commit method got ignored
* The `mapTo[Committed]` was ignored anyway