### PR TITLE
Simplify pause/resume logic

### DIFF
--- a/tests/src/test/scala/akka/kafka/internal/ConsumerTest.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConsumerTest.scala
@@ -71,7 +71,7 @@ class ConsumerTest(_system: ActorSystem)
   implicit val m = ActorMaterializer(ActorMaterializerSettings(_system).withFuzzing(true))
   implicit val stageStoppingTimeout = StageStoppingTimeout(15.seconds)
   implicit val ec = _system.dispatcher
-  val messages = (1 to 10000).map(createMessage)
+  val messages = (1 to 1000).map(createMessage)
 
   def checkMessagesReceiving(msgss: Seq[Seq[CommittableMessage[K, V]]]): Unit = {
     val mock = new ConsumerMock[K, V]()
@@ -91,8 +91,8 @@ class ConsumerTest(_system: ActorSystem)
       Map(ConsumerConfig.GROUP_ID_CONFIG -> groupId),
       Some(new StringDeserializer),
       Some(new StringDeserializer),
-      1.milli,
-      1.milli,
+      pollInterval = 10.millis,
+      pollTimeout = 10.millis,
       1.second,
       closeTimeout,
       1.second,

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -28,6 +28,8 @@ import scala.util.Success
 
 class IntegrationSpec extends SpecBase(kafkaPort = KafkaPorts.IntegrationSpec) with Inside {
 
+  implicit val patience = PatienceConfig(500.millis, 50.millis)
+
   def createKafkaConfig: EmbeddedKafkaConfig =
     EmbeddedKafkaConfig(kafkaPort,
                         zooKeeperPort,

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -577,6 +577,8 @@ class IntegrationSpec extends SpecBase(kafkaPort = KafkaPorts.IntegrationSpec) w
         .to(TestSink.probe)
         .run()
 
+      // Wait a tiny bit to avoid a race on "not yet initialized: only setHandler is allowed in GraphStageLogic constructor"
+      sleep(1.milli)
       val metrics: Future[Map[MetricName, Metric]] = control.metrics
       metrics.futureValue should not be 'empty
 


### PR DESCRIPTION
While investigating #549, I've discovered some improvements to the pause/resume logic.
This PR changes to use the newish Timers support to schedule polling, as well.