### PR TITLE
Able to add metadata to the committed offset

### DIFF
--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaConsumerBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaConsumerBenchmarks.scala
@@ -76,7 +76,7 @@ object ReactiveKafkaConsumerBenchmarks extends LazyLogging {
         m.commitScaladsl().map(_ => m)(ExecutionContexts.sameThreadExecutionContext)
       }
       .toMat(Sink.foreach { batch =>
-        if (batch.offsets().head._2 >= fixture.msgCount - 1)
+        if (batch.offsets().head._2.offset >= fixture.msgCount - 1)
           promise.complete(Success(()))
       })(Keep.left)
       .run()
@@ -98,7 +98,7 @@ object ReactiveKafkaConsumerBenchmarks extends LazyLogging {
         m.committableOffset.commitScaladsl().map(_ => m)(ExecutionContexts.sameThreadExecutionContext)
       }
       .toMat(Sink.foreach { msg =>
-        if (msg.committableOffset.partitionOffset.offset >= fixture.msgCount - 1)
+        if (msg.committableOffset.partitionOffset.offset.offset >= fixture.msgCount - 1)
           promise.complete(Success(()))
       })(Keep.left)
       .run()

--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -10,7 +10,7 @@ import java.util.concurrent.CompletionStage
 
 import akka.Done
 import akka.kafka.internal.ConsumerStage.CommittableOffsetBatchImpl
-import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.{ConsumerRecord, OffsetAndMetadata}
 
 import scala.concurrent.Future
 
@@ -68,7 +68,7 @@ object ConsumerMessage {
   /**
    * Offset position for a groupId, topic, partition.
    */
-  final case class PartitionOffset(key: GroupTopicPartition, offset: Long)
+  final case class PartitionOffset(key: GroupTopicPartition, offset: OffsetAndMetadata)
 
   /**
    * groupId, topic, partition key for an offset position.
@@ -130,12 +130,12 @@ object ConsumerMessage {
     /**
      * Scala API: Get current offset positions
      */
-    def offsets(): Map[GroupTopicPartition, Long]
+    def offsets(): Map[GroupTopicPartition, OffsetAndMetadata]
 
     /**
      * Java API: Get current offset positions
      */
-    def getOffsets(): JMap[GroupTopicPartition, Long]
+    def getOffsets(): JMap[GroupTopicPartition, OffsetAndMetadata]
   }
 
 }

--- a/tests/src/test/scala/akka/kafka/internal/ProducerTest.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ProducerTest.scala
@@ -73,7 +73,8 @@ class ProducerTest(_system: ActorSystem)
   def toMessage(tuple: (Record, RecordMetadata)) = Message(tuple._1, NotUsed)
   def toTxMessage(tuple: (Record, RecordMetadata)) =
     Message(tuple._1,
-            ConsumerMessage.PartitionOffset(GroupTopicPartition(group, tuple._1.topic(), 1), tuple._2.offset()))
+            ConsumerMessage.PartitionOffset(GroupTopicPartition(group, tuple._1.topic(), 1),
+                                            new OffsetAndMetadata(tuple._2.offset())))
   def result(r: Record, m: RecordMetadata) = Result(m, Message(r, NotUsed))
   val toResult = (result _).tupled
 
@@ -557,7 +558,7 @@ class ProducerMock[K, V](handler: ProducerMock.Handler[K, V])(implicit ec: Execu
 
   def verifyTxCommit(po: ConsumerMessage.PartitionOffset) = {
     val inOrder = Mockito.inOrder(mock)
-    val offsets = Map(new TopicPartition(po.key.topic, po.key.partition) -> new OffsetAndMetadata(po.offset + 1)).asJava
+    val offsets = Map(new TopicPartition(po.key.topic, po.key.partition) -> new OffsetAndMetadata(po.offset.offset + 1)).asJava
     inOrder.verify(mock).sendOffsetsToTransaction(offsets, po.key.groupId)
     inOrder.verify(mock).commitTransaction()
     inOrder.verify(mock).beginTransaction()
@@ -565,7 +566,7 @@ class ProducerMock[K, V](handler: ProducerMock.Handler[K, V])(implicit ec: Execu
 
   def verifyTxCommitWhenShutdown(po: ConsumerMessage.PartitionOffset) = {
     val inOrder = Mockito.inOrder(mock)
-    val offsets = Map(new TopicPartition(po.key.topic, po.key.partition) -> new OffsetAndMetadata(po.offset + 1)).asJava
+    val offsets = Map(new TopicPartition(po.key.topic, po.key.partition) -> new OffsetAndMetadata(po.offset.offset + 1)).asJava
     inOrder.verify(mock).sendOffsetsToTransaction(offsets, po.key.groupId)
     inOrder.verify(mock).commitTransaction()
   }


### PR DESCRIPTION
I would like to add metadata based on the ConsumerRecord along with each commit. The issue for this is here: https://github.com/akka/alpakka-kafka/issues/561

This PR will allow users to pass in a function to the source constructor which will add metadata to each commit based on the consumer record. Each committed offset is guaranteed to contain metadata constructed from the message as long as the commitRefreshInterval is infinite.

If the commitRefreshInterval is not infinite, then when the Consumer is assigned a partition it will also receive an offset without a message. If it has not processed a new message before the end of the interval, it will recommit this offset for this partition without adding metadata.
In order to solve this, we can read the last committed message each time a partition is assigned in order to reconstruct the metadata. This could negatively impact performance so it is not implemented in this PR.