### PR TITLE
Able to add metadata to the committed offset

### DIFF
--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -65,10 +65,22 @@ object ConsumerMessage {
     def partitionOffset: PartitionOffset
   }
 
+  trait CommittableOffsetMetadata extends CommittableOffset {
+    def metadata: String
+  }
+
   /**
    * Offset position for a groupId, topic, partition.
    */
-  final case class PartitionOffset(key: GroupTopicPartition, offset: Long)
+  final case class PartitionOffset(key: GroupTopicPartition, offset: Long) {
+    def withMetadata(metadata: String) =
+      PartitionOffsetMetadata(key, offset, metadata)
+  }
+
+  /**
+   * Offset position and metadata for a groupId, topic, partition.
+   */
+  final case class PartitionOffsetMetadata(key: GroupTopicPartition, offset: Long, metadata: String)
 
   /**
    * groupId, topic, partition key for an offset position.

--- a/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
@@ -149,6 +149,21 @@ object Consumer {
       .asJava
 
   /**
+   * The `commitWithMetadataSource` makes it possible to add additional metadata (in the form of a string)
+   * when an offset is committed based on the record. This can be useful (for example) to store information about which
+   * node made the commit, what time the commit was made, the timestamp of the record etc.
+   */
+  def commitWithMetadataSource[K, V](
+      settings: ConsumerSettings[K, V],
+      subscription: Subscription,
+      metadataFromRecord: java.util.function.Function[ConsumerRecord[K, V], String]
+  ): Source[CommittableMessage[K, V], Control] =
+    scaladsl.Consumer
+      .commitWithMetadataSource(settings, subscription, (record: ConsumerRecord[K, V]) => metadataFromRecord(record))
+      .mapMaterializedValue(new WrappedConsumerControl(_))
+      .asJava
+
+  /**
    * Convenience for "at-most once delivery" semantics. The offset of each message is committed to Kafka
    * before emitted downstreams.
    */

--- a/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
@@ -162,6 +162,18 @@ object Consumer {
     Source.fromGraph(ConsumerStage.committableSource[K, V](settings, subscription))
 
   /**
+   * The `committableSourceWithMetadata` makes it possible to add additional metadata (in the form of a string)
+   * when an offset is committed based on the record. This can be useful (for example) to store information about which
+   * node made the commit, what time the commit was made, the timestamp of the record etc.
+   */
+  def committableSourceWithMetadata[K, V](
+      settings: ConsumerSettings[K, V],
+      subscription: Subscription,
+      metadataFromRecord: ConsumerRecord[K, V] => String
+  ): Source[CommittableMessage[K, V], Control] =
+    Source.fromGraph(ConsumerStage.committableSourceWithMetadata[K, V](settings, subscription, metadataFromRecord))
+
+  /**
    * Convenience for "at-most once delivery" semantics. The offset of each message is committed to Kafka
    * before it is emitted downstream.
    */

--- a/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
@@ -162,16 +162,16 @@ object Consumer {
     Source.fromGraph(ConsumerStage.committableSource[K, V](settings, subscription))
 
   /**
-   * The `committableSourceWithMetadata` makes it possible to add additional metadata (in the form of a string)
+   * The `commitWithMetadataSource` makes it possible to add additional metadata (in the form of a string)
    * when an offset is committed based on the record. This can be useful (for example) to store information about which
    * node made the commit, what time the commit was made, the timestamp of the record etc.
    */
-  def committableSourceWithMetadata[K, V](
+  def commitWithMetadataSource[K, V](
       settings: ConsumerSettings[K, V],
       subscription: Subscription,
       metadataFromRecord: ConsumerRecord[K, V] => String
   ): Source[CommittableMessage[K, V], Control] =
-    Source.fromGraph(ConsumerStage.committableSourceWithMetadata[K, V](settings, subscription, metadataFromRecord))
+    Source.fromGraph(ConsumerStage.committableSource[K, V](settings, subscription, metadataFromRecord))
 
   /**
    * Convenience for "at-most once delivery" semantics. The offset of each message is committed to Kafka

--- a/docs/src/main/paradox/consumer.md
+++ b/docs/src/main/paradox/consumer.md
@@ -106,6 +106,15 @@ Scala
 Java
 : @@ snip [snip](/tests/src/test/java/docs/javadsl/ConsumerExample.java) { #groupedWithin }
 
+The `Consumer.commitWithMetadataSource` allows you to add metadata to the committed offset based on the last consumed record.
+
+Note that the first offset provided to the consumer during a partition assignment will not contain metadata. This offset can get committed due to a periodic commit refresh (`akka.kafka.consumer.commit-refresh-interval` configuration parmeters) and the commit will not contain metadata.
+
+Scala
+: @@ snip [snip](/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala) { #commitWithMetadata }
+
+Java
+: @@ snip [snip](/tests/src/test/java/docs/javadsl/ConsumerExample.java) { #commitWithMetadata }
 
 If you commit the offset before processing the message you get "at-most-once" delivery semantics, this is provided by `Consumer.atMostOnceSource`. However, `atMostOnceSource` commits the offset for each message and that is rather slow, batching of commits is recommended.
 

--- a/tests/src/test/scala/akka/kafka/internal/ConsumerTest.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConsumerTest.scala
@@ -46,10 +46,13 @@ object ConsumerTest {
 
   def createMessage(seed: Int): CommittableMessage[K, V] = createMessage(seed, "topic")
 
-  def createMessage(seed: Int, topic: String, groupId: String = "group1"): CommittableMessage[K, V] = {
+  def createMessage(seed: Int,
+                    topic: String,
+                    groupId: String = "group1",
+                    metadata: String = ""): CommittableMessage[K, V] = {
     val offset = PartitionOffset(GroupTopicPartition(groupId, topic, 1), seed.toLong)
     val record = new ConsumerRecord(offset.key.topic, offset.key.partition, offset.offset, seed.toString, seed.toString)
-    CommittableMessage(record, ConsumerStage.CommittableOffsetImpl(offset)(null))
+    CommittableMessage(record, ConsumerStage.CommittableOffsetImpl(offset, metadata)(null))
   }
 
   def toRecord(msg: CommittableMessage[K, V]): ConsumerRecord[K, V] = msg.record
@@ -112,6 +115,14 @@ class ConsumerTest(_system: ActorSystem)
                  groupId: String = "group1",
                  topics: Set[String] = Set("topic")): Source[CommittableMessage[K, V], Control] =
     Consumer.committableSource(testSettings(mock.mock, groupId), Subscriptions.topics(topics))
+
+  def testSourceWithMetadata(mock: ConsumerMock[K, V],
+                             metadataFromRecord: ConsumerRecord[K, V] => String,
+                             groupId: String = "group1",
+                             topics: Set[String] = Set("topic")): Source[CommittableMessage[K, V], Control] =
+    Consumer.committableSourceWithMetadata(testSettings(mock.mock, groupId),
+                                           Subscriptions.topics(topics),
+                                           metadataFromRecord)
 
   def testPartitionedSource(
       mock: Consumer[K, V],
@@ -233,6 +244,42 @@ class ConsumerTest(_system: ActorSystem)
           .flatten
           .to[Seq]
       )
+    }
+  }
+
+  it should "commit metadata in message" in {
+    assertAllStagesStopped {
+      val commitLog = new ConsumerMock.LogHandler()
+      val mock = new ConsumerMock[K, V](commitLog)
+
+      val (control, probe) = testSourceWithMetadata(mock, (rec: ConsumerRecord[K, V]) => rec.offset.toString)
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+      val msg = createMessage(1)
+      mock.enqueue(List(toRecord(msg)))
+
+      probe.request(100)
+      val done = probe.expectNext().committableOffset.commitScaladsl()
+
+      awaitAssert {
+        commitLog.calls should have size (1)
+      }
+
+      val (topicPartition, offsetMeta) = commitLog.calls.head._1.head
+      topicPartition.topic should ===(msg.record.topic())
+      topicPartition.partition should ===(msg.record.partition())
+      // committed offset should be the next message the application will consume, i.e. +1
+      offsetMeta.offset should ===(msg.record.offset() + 1)
+      offsetMeta.metadata should ===(msg.record.offset.toString)
+
+      //emulate commit
+      commitLog.calls.head match {
+        case (offsets, callback) => callback.onComplete(offsets.asJava, null)
+      }
+
+      Await.result(done, remainingOrDefault)
+      Await.result(control.shutdown(), remainingOrDefault)
     }
   }
 
@@ -359,6 +406,51 @@ class ConsumerTest(_system: ActorSystem)
       val commitMap = commitLog.calls.head._1
       commitMap(new TopicPartition("topic1", 1)).offset should ===(msgsTopic1.last.record.offset() + 1)
       commitMap(new TopicPartition("topic2", 1)).offset should ===(msgsTopic2.last.record.offset() + 1)
+
+      //emulate commit
+      commitLog.calls.foreach {
+        case (offsets, callback) => callback.onComplete(offsets.asJava, null)
+      }
+
+      Await.result(done, remainingOrDefault)
+      Await.result(control.shutdown(), remainingOrDefault)
+    }
+  }
+
+  it should "support commit batching with metadata" in {
+    assertAllStagesStopped {
+      val commitLog = new ConsumerMock.LogHandler()
+      val mock = new ConsumerMock[K, V](commitLog)
+      val (control, probe) = testSourceWithMetadata(mock,
+                                                    (rec: ConsumerRecord[K, V]) => rec.offset.toString,
+                                                    topics = Set("topic1", "topic2"))
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
+
+      val msgsTopic1 = (1 to 3).map(createMessage(_, "topic1"))
+      val msgsTopic2 = (11 to 13).map(createMessage(_, "topic2"))
+      mock.enqueue(msgsTopic1.map(toRecord))
+      mock.enqueue(msgsTopic2.map(toRecord))
+
+      probe.request(100)
+      val batch = probe
+        .expectNextN(6)
+        .map(_.committableOffset)
+        .foldLeft(CommittableOffsetBatch.empty) { (b, c) =>
+          b.updated(c)
+        }
+
+      val done = batch.commitScaladsl()
+
+      awaitAssert {
+        commitLog.calls should have size (1)
+      }
+
+      val commitMap = commitLog.calls.head._1
+      commitMap(new TopicPartition("topic1", 1)).offset should ===(msgsTopic1.last.record.offset() + 1)
+      commitMap(new TopicPartition("topic2", 1)).offset should ===(msgsTopic2.last.record.offset() + 1)
+      commitMap(new TopicPartition("topic1", 1)).metadata() should ===(msgsTopic1.last.record.offset().toString)
+      commitMap(new TopicPartition("topic2", 1)).metadata() should ===(msgsTopic2.last.record.offset().toString)
 
       //emulate commit
       commitLog.calls.foreach {

--- a/tests/src/test/scala/akka/kafka/internal/ConsumerTest.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConsumerTest.scala
@@ -120,9 +120,9 @@ class ConsumerTest(_system: ActorSystem)
                              metadataFromRecord: ConsumerRecord[K, V] => String,
                              groupId: String = "group1",
                              topics: Set[String] = Set("topic")): Source[CommittableMessage[K, V], Control] =
-    Consumer.committableSourceWithMetadata(testSettings(mock.mock, groupId),
-                                           Subscriptions.topics(topics),
-                                           metadataFromRecord)
+    Consumer.commitWithMetadataSource(testSettings(mock.mock, groupId),
+                                      Subscriptions.topics(topics),
+                                      metadataFromRecord)
 
   def testPartitionedSource(
       mock: Consumer[K, V],


### PR DESCRIPTION
I would like to add metadata based on the ConsumerRecord along with each commit. The issue for this is here: #561

This PR will allow users to pass in a function to the source constructor which will add metadata to each commit based on the consumer record. Each committed offset is guaranteed to contain metadata constructed from the message as long as the commitRefreshInterval is infinite.

If the commitRefreshInterval is not infinite, then when the Consumer is assigned a partition it will also receive an offset without a message. If it has not processed a new message before the end of the interval, it will recommit this offset for this partition without adding metadata.
In order to solve this, we can read the last committed message each time a partition is assigned in order to reconstruct the metadata. This could negatively impact performance so it is not implemented in this PR.