### PR TITLE
Use named classes for consumer stages and set a name attribute

### DIFF
--- a/core/src/main/mima-filters/1.0-M1.backwards.excludes
+++ b/core/src/main/mima-filters/1.0-M1.backwards.excludes
@@ -1,0 +1,2 @@
+# new method in sealed trait
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.kafka.Subscription.renderStageAttribute")

--- a/core/src/main/scala/akka/kafka/Subscriptions.scala
+++ b/core/src/main/scala/akka/kafka/Subscriptions.scala
@@ -18,6 +18,14 @@ sealed trait Subscription {
 
   /** Configure this actor ref to receive [[akka.kafka.ConsumerRebalanceEvent]] signals */
   def withRebalanceListener(ref: ActorRef): Subscription
+
+  def renderStageAttribute: String
+
+  protected def renderListener: String =
+    rebalanceListener match {
+      case Some(ref) => s" rebalanceListener $ref"
+      case None => ""
+    }
 }
 sealed trait ManualSubscription extends Subscription {
   def withRebalanceListener(ref: ActorRef): ManualSubscription
@@ -40,14 +48,7 @@ object Subscriptions {
       extends AutoSubscription {
     def withRebalanceListener(ref: ActorRef): TopicSubscription =
       TopicSubscription(tps, Some(ref))
-
-    override def toString: String = {
-      val listener = rebalanceListener match {
-        case Some(ref) => s",rebalanceListener=$ref"
-        case None => ""
-      }
-      s"TopicSubscription(${tps.mkString(",")}$listener)"
-    }
+    def renderStageAttribute: String = s"${tps.mkString(" ")}$renderListener"
   }
 
   /** INTERNAL API */
@@ -56,14 +57,7 @@ object Subscriptions {
       extends AutoSubscription {
     def withRebalanceListener(ref: ActorRef): TopicSubscriptionPattern =
       TopicSubscriptionPattern(pattern, Some(ref))
-
-    override def toString: String = {
-      val listener = rebalanceListener match {
-        case Some(ref) => s",rebalanceListener=$ref"
-        case None => ""
-      }
-      s"TopicSubscriptionPattern($pattern$listener)"
-    }
+    def renderStageAttribute: String = s"pattern $pattern$renderListener"
   }
 
   /** INTERNAL API */
@@ -72,15 +66,7 @@ object Subscriptions {
       extends ManualSubscription {
     def withRebalanceListener(ref: ActorRef): Assignment =
       Assignment(tps, Some(ref))
-
-    override def toString: String = {
-      val listener = rebalanceListener match {
-        case Some(ref) => s",rebalanceListener=$ref"
-        case None => ""
-      }
-      s"Assignment(${tps.mkString(",")}$listener)"
-    }
-
+    def renderStageAttribute: String = s"${tps.mkString(" ")}$renderListener"
   }
 
   /** INTERNAL API */
@@ -90,14 +76,8 @@ object Subscriptions {
       extends ManualSubscription {
     def withRebalanceListener(ref: ActorRef): AssignmentWithOffset =
       AssignmentWithOffset(tps, Some(ref))
-
-    override def toString: String = {
-      val listener = rebalanceListener match {
-        case Some(ref) => s",rebalanceListener=$ref"
-        case None => ""
-      }
-      s"AssignmentWithOffset(${tps.map { case (tp, offset) => s"$tp -> offset=$offset" }.mkString(",")}$listener)"
-    }
+    def renderStageAttribute: String =
+      s"${tps.map { case (tp, offset) => s"$tp offset$offset" }.mkString(" ")}$renderListener"
   }
 
   /** INTERNAL API */
@@ -107,14 +87,8 @@ object Subscriptions {
       extends ManualSubscription {
     def withRebalanceListener(ref: ActorRef): AssignmentOffsetsForTimes =
       AssignmentOffsetsForTimes(timestampsToSearch, Some(ref))
-
-    override def toString: String = {
-      val listener = rebalanceListener match {
-        case Some(ref) => s",rebalanceListener=$ref"
-        case None => ""
-      }
-      s"AssignmentOffsetsForTimes(${timestampsToSearch.map { case (tp, timestamp) => s"$tp -> timestamp=$timestamp" }.mkString(",")}$listener)"
-    }
+    def renderStageAttribute: String =
+      s"${timestampsToSearch.map { case (tp, timestamp) => s"$tp timestamp$timestamp" }.mkString(" ")}$renderListener"
   }
 
   /** Creates subscription for given set of topics */

--- a/core/src/main/scala/akka/kafka/Subscriptions.scala
+++ b/core/src/main/scala/akka/kafka/Subscriptions.scala
@@ -40,6 +40,14 @@ object Subscriptions {
       extends AutoSubscription {
     def withRebalanceListener(ref: ActorRef): TopicSubscription =
       TopicSubscription(tps, Some(ref))
+
+    override def toString: String = {
+      val listener = rebalanceListener match {
+        case Some(ref) => s",rebalanceListener=$ref"
+        case None => ""
+      }
+      s"TopicSubscription(${tps.mkString(",")}$listener)"
+    }
   }
 
   /** INTERNAL API */
@@ -48,6 +56,14 @@ object Subscriptions {
       extends AutoSubscription {
     def withRebalanceListener(ref: ActorRef): TopicSubscriptionPattern =
       TopicSubscriptionPattern(pattern, Some(ref))
+
+    override def toString: String = {
+      val listener = rebalanceListener match {
+        case Some(ref) => s",rebalanceListener=$ref"
+        case None => ""
+      }
+      s"TopicSubscriptionPattern($pattern$listener)"
+    }
   }
 
   /** INTERNAL API */
@@ -56,6 +72,15 @@ object Subscriptions {
       extends ManualSubscription {
     def withRebalanceListener(ref: ActorRef): Assignment =
       Assignment(tps, Some(ref))
+
+    override def toString: String = {
+      val listener = rebalanceListener match {
+        case Some(ref) => s",rebalanceListener=$ref"
+        case None => ""
+      }
+      s"Assignment(${tps.mkString(",")}$listener)"
+    }
+
   }
 
   /** INTERNAL API */
@@ -65,6 +90,14 @@ object Subscriptions {
       extends ManualSubscription {
     def withRebalanceListener(ref: ActorRef): AssignmentWithOffset =
       AssignmentWithOffset(tps, Some(ref))
+
+    override def toString: String = {
+      val listener = rebalanceListener match {
+        case Some(ref) => s",rebalanceListener=$ref"
+        case None => ""
+      }
+      s"AssignmentWithOffset(${tps.map { case (tp, offset) => s"$tp -> offset=$offset" }.mkString(",")}$listener)"
+    }
   }
 
   /** INTERNAL API */
@@ -74,6 +107,14 @@ object Subscriptions {
       extends ManualSubscription {
     def withRebalanceListener(ref: ActorRef): AssignmentOffsetsForTimes =
       AssignmentOffsetsForTimes(timestampsToSearch, Some(ref))
+
+    override def toString: String = {
+      val listener = rebalanceListener match {
+        case Some(ref) => s",rebalanceListener=$ref"
+        case None => ""
+      }
+      s"AssignmentOffsetsForTimes(${timestampsToSearch.map { case (tp, timestamp) => s"$tp -> timestamp=$timestamp" }.mkString(",")}$listener)"
+    }
   }
 
   /** Creates subscription for given set of topics */

--- a/core/src/main/scala/akka/kafka/internal/ConsumerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/ConsumerStage.scala
@@ -77,11 +77,11 @@ private[kafka] object ConsumerStage {
       with PlainMessageBuilder[K, V] with MetricsControl
   }
 
-  private[kafka] final class CommittableSource[K, V](
-      settings: ConsumerSettings[K, V],
-      subscription: Subscription,
-      _metadataFromRecord: ConsumerRecord[K, V] => String = (_: ConsumerRecord[K, V]) => OffsetFetchResponse.NO_METADATA
-  ) extends KafkaSourceStage[K, V, CommittableMessage[K, V]](s"CommittableSource $subscription") {
+  private[kafka] final class CommittableSource[K, V](settings: ConsumerSettings[K, V],
+                                                     subscription: Subscription,
+                                                     _metadataFromRecord: ConsumerRecord[K, V] => String =
+                                                       (_: ConsumerRecord[K, V]) => OffsetFetchResponse.NO_METADATA)
+      extends KafkaSourceStage[K, V, CommittableMessage[K, V]](s"CommittableSource $subscription") {
     override protected def logic(shape: SourceShape[CommittableMessage[K, V]]) =
       new SingleSourceLogic[K, V, CommittableMessage[K, V]](shape, settings, subscription)
       with CommittableMessageBuilder[K, V] {

--- a/core/src/main/scala/akka/kafka/internal/ConsumerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/ConsumerStage.scala
@@ -40,7 +40,7 @@ private[kafka] object ConsumerStage {
       getOffsetsOnAssign: Option[Set[TopicPartition] => Future[Map[TopicPartition, Long]]],
       onRevoke: Set[TopicPartition] => Unit
   ) extends KafkaSourceStage[K, V, (TopicPartition, Source[ConsumerRecord[K, V], NotUsed])](
-        s"PlainSubSource $subscription"
+        s"PlainSubSource ${subscription.renderStageAttribute}"
       ) {
     override protected def logic(shape: SourceShape[(TopicPartition, Source[ConsumerRecord[K, V], NotUsed])]) =
       new SubSourceLogic[K, V, ConsumerRecord[K, V]](shape, settings, subscription, getOffsetsOnAssign, onRevoke)
@@ -50,7 +50,7 @@ private[kafka] object ConsumerStage {
   private[kafka] final class CommittableSubSource[K, V](settings: ConsumerSettings[K, V],
                                                         subscription: AutoSubscription)
       extends KafkaSourceStage[K, V, (TopicPartition, Source[CommittableMessage[K, V], NotUsed])](
-        s"CommittableSubSource $subscription"
+        s"CommittableSubSource ${subscription.renderStageAttribute}"
       ) {
     override protected def logic(shape: SourceShape[(TopicPartition, Source[CommittableMessage[K, V], NotUsed])]) =
       new SubSourceLogic[K, V, CommittableMessage[K, V]](shape, settings, subscription)
@@ -65,13 +65,15 @@ private[kafka] object ConsumerStage {
   }
 
   private[kafka] final class PlainSource[K, V](settings: ConsumerSettings[K, V], subscription: Subscription)
-      extends KafkaSourceStage[K, V, ConsumerRecord[K, V]](s"PlainSource $subscription") {
+      extends KafkaSourceStage[K, V, ConsumerRecord[K, V]](s"PlainSource ${subscription.renderStageAttribute}") {
     override protected def logic(shape: SourceShape[ConsumerRecord[K, V]]) =
       new SingleSourceLogic[K, V, ConsumerRecord[K, V]](shape, settings, subscription) with PlainMessageBuilder[K, V]
   }
 
   private[kafka] final class ExternalPlainSource[K, V](consumer: ActorRef, subscription: ManualSubscription)
-      extends KafkaSourceStage[K, V, ConsumerRecord[K, V]](s"ExternalPlainSubSource $subscription") {
+      extends KafkaSourceStage[K, V, ConsumerRecord[K, V]](
+        s"ExternalPlainSubSource ${subscription.renderStageAttribute}"
+      ) {
     override protected def logic(shape: SourceShape[ConsumerRecord[K, V]]) =
       new ExternalSingleSourceLogic[K, V, ConsumerRecord[K, V]](shape, consumer, subscription)
       with PlainMessageBuilder[K, V] with MetricsControl
@@ -81,7 +83,9 @@ private[kafka] object ConsumerStage {
                                                      subscription: Subscription,
                                                      _metadataFromRecord: ConsumerRecord[K, V] => String =
                                                        (_: ConsumerRecord[K, V]) => OffsetFetchResponse.NO_METADATA)
-      extends KafkaSourceStage[K, V, CommittableMessage[K, V]](s"CommittableSource $subscription") {
+      extends KafkaSourceStage[K, V, CommittableMessage[K, V]](
+        s"CommittableSource ${subscription.renderStageAttribute}"
+      ) {
     override protected def logic(shape: SourceShape[CommittableMessage[K, V]]) =
       new SingleSourceLogic[K, V, CommittableMessage[K, V]](shape, settings, subscription)
       with CommittableMessageBuilder[K, V] {
@@ -98,7 +102,9 @@ private[kafka] object ConsumerStage {
                                                              _groupId: String,
                                                              commitTimeout: FiniteDuration,
                                                              subscription: ManualSubscription)
-      extends KafkaSourceStage[K, V, CommittableMessage[K, V]](s"ExternalCommittableSource $subscription") {
+      extends KafkaSourceStage[K, V, CommittableMessage[K, V]](
+        s"ExternalCommittableSource ${subscription.renderStageAttribute}"
+      ) {
     override protected def logic(shape: SourceShape[CommittableMessage[K, V]]) =
       new ExternalSingleSourceLogic[K, V, CommittableMessage[K, V]](shape, consumer, subscription)
       with CommittableMessageBuilder[K, V] {
@@ -113,7 +119,9 @@ private[kafka] object ConsumerStage {
 
   private[kafka] final class TransactionalSource[K, V](consumerSettings: ConsumerSettings[K, V],
                                                        subscription: Subscription)
-      extends KafkaSourceStage[K, V, TransactionalMessage[K, V]](s"TransactionalSource $subscription") {
+      extends KafkaSourceStage[K, V, TransactionalMessage[K, V]](
+        s"TransactionalSource ${subscription.renderStageAttribute}"
+      ) {
     require(consumerSettings.properties(ConsumerConfig.GROUP_ID_CONFIG).nonEmpty,
             "You must define a Consumer group.id.")
 

--- a/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
@@ -142,7 +142,7 @@ object Consumer {
    */
   def plainSource[K, V](settings: ConsumerSettings[K, V],
                         subscription: Subscription): Source[ConsumerRecord[K, V], Control] =
-    Source.fromGraph(ConsumerStage.plainSource[K, V](settings, subscription))
+    Source.fromGraph(new ConsumerStage.PlainSource[K, V](settings, subscription))
 
   /**
    * The `committableSource` makes it possible to commit offset positions to Kafka.
@@ -159,7 +159,7 @@ object Consumer {
    */
   def committableSource[K, V](settings: ConsumerSettings[K, V],
                               subscription: Subscription): Source[CommittableMessage[K, V], Control] =
-    Source.fromGraph(ConsumerStage.committableSource[K, V](settings, subscription))
+    Source.fromGraph(new ConsumerStage.CommittableSource[K, V](settings, subscription))
 
   /**
    * The `commitWithMetadataSource` makes it possible to add additional metadata (in the form of a string)
@@ -171,7 +171,7 @@ object Consumer {
       subscription: Subscription,
       metadataFromRecord: ConsumerRecord[K, V] => String
   ): Source[CommittableMessage[K, V], Control] =
-    Source.fromGraph(ConsumerStage.committableSource[K, V](settings, subscription, metadataFromRecord))
+    Source.fromGraph(new ConsumerStage.CommittableSource[K, V](settings, subscription, metadataFromRecord))
 
   /**
    * Convenience for "at-most once delivery" semantics. The offset of each message is committed to Kafka
@@ -193,7 +193,7 @@ object Consumer {
       settings: ConsumerSettings[K, V],
       subscription: AutoSubscription
   ): Source[(TopicPartition, Source[ConsumerRecord[K, V], NotUsed]), Control] =
-    Source.fromGraph(ConsumerStage.plainSubSource[K, V](settings, subscription))
+    Source.fromGraph(new ConsumerStage.PlainSubSource[K, V](settings, subscription, None, onRevoke = _ => ()))
 
   /**
    * The `plainPartitionedManualOffsetSource` is similar to [[#plainPartitionedSource]] but allows the use of an offset store outside
@@ -208,7 +208,7 @@ object Consumer {
       getOffsetsOnAssign: Set[TopicPartition] => Future[Map[TopicPartition, Long]],
       onRevoke: Set[TopicPartition] => Unit = _ => ()
   ): Source[(TopicPartition, Source[ConsumerRecord[K, V], NotUsed]), Control] =
-    Source.fromGraph(ConsumerStage.plainSubSource[K, V](settings, subscription, Some(getOffsetsOnAssign), onRevoke))
+    Source.fromGraph(new ConsumerStage.PlainSubSource[K, V](settings, subscription, Some(getOffsetsOnAssign), onRevoke))
 
   /**
    * The same as [[#plainPartitionedSource]] but with offset commit support
@@ -217,7 +217,7 @@ object Consumer {
       settings: ConsumerSettings[K, V],
       subscription: AutoSubscription
   ): Source[(TopicPartition, Source[CommittableMessage[K, V], NotUsed]), Control] =
-    Source.fromGraph(ConsumerStage.committableSubSource[K, V](settings, subscription))
+    Source.fromGraph(new ConsumerStage.CommittableSubSource[K, V](settings, subscription))
 
   /**
    * Special source that can use an external `KafkaAsyncConsumer`. This is useful when you have
@@ -225,7 +225,7 @@ object Consumer {
    */
   def plainExternalSource[K, V](consumer: ActorRef,
                                 subscription: ManualSubscription): Source[ConsumerRecord[K, V], Control] =
-    Source.fromGraph(ConsumerStage.externalPlainSource[K, V](consumer, subscription))
+    Source.fromGraph(new ConsumerStage.ExternalPlainSource[K, V](consumer, subscription))
 
   /**
    * The same as [[#plainExternalSource]] but with offset commit support.
@@ -235,7 +235,7 @@ object Consumer {
                                       groupId: String,
                                       commitTimeout: FiniteDuration): Source[CommittableMessage[K, V], Control] =
     Source.fromGraph(
-      ConsumerStage.externalCommittableSource[K, V](
+      new ConsumerStage.ExternalCommittableSource[K, V](
         consumer,
         groupId,
         commitTimeout,

--- a/core/src/main/scala/akka/kafka/scaladsl/Transactional.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Transactional.scala
@@ -28,7 +28,7 @@ object Transactional {
    */
   def source[K, V](settings: ConsumerSettings[K, V],
                    subscription: Subscription): Source[TransactionalMessage[K, V], Control] =
-    Source.fromGraph(ConsumerStage.transactionalSource[K, V](settings, subscription))
+    Source.fromGraph(new ConsumerStage.TransactionalSource[K, V](settings, subscription))
 
   /**
    * Sink that is aware of the [[ConsumerMessage.TransactionalMessage.partitionOffset]] from a [[Transactional.source]].  It will

--- a/tests/src/test/scala/akka/kafka/internal/SubscriptionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/SubscriptionsSpec.scala
@@ -33,9 +33,15 @@ class SubscriptionsSpec extends WordSpec with Matchers {
       )
     }
 
-    "be readable for assignments with timestamp" in {
-      encode(Subscriptions.assignmentOffsetsForTimes(Map(new TopicPartition("topic1", 1) -> 12345L))) should be(
-        "topic1-1+timestamp12345"
+    "be readable for multiple assignments with offset" in {
+      encode(Subscriptions.assignmentWithOffset(Map(new TopicPartition("topic1", 1) -> 123L, new TopicPartition("A-Topic-Name", 2) -> 456L))) should be(
+        "topic1-1+offset123+A-Topic-Name-2+offset456"
+      )
+    }
+
+    "be readable for multiple assignments with timestamp" in {
+      encode(Subscriptions.assignmentOffsetsForTimes(Map(new TopicPartition("topic1", 1) -> 12345L, new TopicPartition("Another0Topic", 1) -> 998822L))) should be(
+        "topic1-1+timestamp12345+Another0Topic-1+timestamp998822"
       )
     }
   }

--- a/tests/src/test/scala/akka/kafka/internal/SubscriptionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/SubscriptionsSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.internal
+
+import java.net.URLEncoder
+
+import akka.kafka.{Subscription, Subscriptions}
+import akka.util.ByteString
+import org.apache.kafka.common.TopicPartition
+import org.scalatest.{Matchers, WordSpec}
+
+class SubscriptionsSpec extends WordSpec with Matchers {
+
+  "URL encoded subscription" should {
+    "be readable for topics" in {
+      encode(Subscriptions.topics(Set("topic1", "topic2"))) should be("topic1+topic2")
+    }
+
+    "be readable for patterns" in {
+      encode(Subscriptions.topicPattern("topic.*")) should be("pattern+topic.*")
+    }
+
+    "be readable for assignments" in {
+      encode(Subscriptions.assignment(Set(new TopicPartition("topic1", 1)))) should be("topic1-1")
+    }
+
+    "be readable for assignments with offset" in {
+      encode(Subscriptions.assignmentWithOffset(Map(new TopicPartition("topic1", 1) -> 123L))) should be(
+        "topic1-1+offset123"
+      )
+    }
+
+    "be readable for assignments with timestamp" in {
+      encode(Subscriptions.assignmentOffsetsForTimes(Map(new TopicPartition("topic1", 1) -> 12345L))) should be(
+        "topic1-1+timestamp12345"
+      )
+    }
+  }
+
+  private def encode(subscription: Subscription) =
+    URLEncoder.encode(subscription.renderStageAttribute, ByteString.UTF_8)
+
+}


### PR DESCRIPTION
This makes the consumer stage implementations non-anonymous classes so that logging and debugging information becomes more useful.
Furthermore, do all consumer stages get the `Name` attribute set which even contains a subscription description. For that description to become more compact, the subscription implementations got specific `toString` methods.

Another useful refactoring could be to make the classes top-level instead of within the `ConsumerStage` object, but I refrained from doing altogether in one PR.

Fixes #569 