### PR TITLE
Resolve hostname from gateway ip

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - "9094"
     environment:
-      HOSTNAME_COMMAND: "docker info | grep ^Name: | cut -d' ' -f 2"
+      HOSTNAME_COMMAND: "route -n | awk '/UG[ \t]/{print $$2}'"
       PORT_COMMAND: "docker port `hostname` 9094 | cut -d: -f 2"
       KAFKA_ADVERTISED_LISTENERS: INSIDE://:9092,OUTSIDE://_{HOSTNAME_COMMAND}:_{PORT_COMMAND}
       KAFKA_LISTENERS: INSIDE://:9092,OUTSIDE://:9094


### PR DESCRIPTION
Might help workaround unresolvable "linuxkit" hostname on MacOS.

@ennru this one is for you to test by running `tests/dockerComposeTest it:test` from sbt console.