### PR TITLE
Log to file instead of stdout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,10 @@ stages:
   - name: publish
     if: repo = akka/alpakka-kafka AND ( ( branch = master AND type = push ) OR tag =~ ^v )
 
+after_failure:
+  - docker-compose logs
+  - find . -name "*.log" -exec ./scripts/cat-log.sh {} \;
+
 before_cache:
   - find $HOME/.ivy2/ -name "ivydata-*.properties" -print -delete
   - find $HOME/.sbt   -name "*.lock"               -print -delete

--- a/scripts/cat-log.sh
+++ b/scripts/cat-log.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# ---------- helper script to separate log files in travis build
+printf "\n\n\n"
+ls -lh $1
+printf "\n\n"
+cat $1

--- a/tests/src/test/resources/logback-test.xml
+++ b/tests/src/test/resources/logback-test.xml
@@ -1,4 +1,12 @@
 <configuration>
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>target/kafka.log</file>
+        <append>false</append>
+        <encoder>
+            <pattern>%d{ISO8601} %-5level [%-20.20thread] [%-36.36logger{36}]  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
@@ -17,6 +25,8 @@
     <logger name="org.apache.kafka.clients.NetworkClient" level="ERROR"/>
 
     <root level="DEBUG">
-        <appender-ref ref="STDOUT" />
+        <!--<appender-ref ref="STDOUT" />-->
+        <appender-ref ref="FILE" />
     </root>
+
 </configuration>


### PR DESCRIPTION
Makes the tests log to a file the same way as in the main Alpakka project.
Travis appends the log file on failure to the output.