### PR TITLE
Run docker integration tests sequentially

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ jobs:
       jdk: oraclejdk8
 
     - stage: integration
-      env: CMD="tests/dockerComposeTest it:test"
+      env: CMD="dockerComposeTestAll"
       jdk: oraclejdk8
     - env: CMD="benchmarks/dockerComposeTest it:test"
       jdk: oraclejdk8

--- a/build.sbt
+++ b/build.sbt
@@ -191,6 +191,12 @@ lazy val tests = project
     }
   )
 
+commands += Command.command("dockerComposeTestAll") { state ⇒
+  val extracted = Project.extract(state)
+  val (_, allTests) = extracted.runTask(tests / IntegrationTest / definedTestNames, state)
+  allTests.map(test => s"tests/dockerComposeTest it:testOnly $test").foldRight(state)(_ :: _)
+}
+
 lazy val docs = project
   .in(file("docs"))
   .enablePlugins(AkkaParadoxPlugin)


### PR DESCRIPTION
Something is still not quite right here. First test starts alone and finishes. But the the second seems to start too soon.