### PR TITLE
Add support for merging commit batches

### DIFF
--- a/core/src/main/mima-filters/1.0-M1.backwards.excludes
+++ b/core/src/main/mima-filters/1.0-M1.backwards.excludes
@@ -1,2 +1,3 @@
 # new method in sealed trait
 ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.kafka.Subscription.renderStageAttribute")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.kafka.ConsumerMessage#CommittableOffsetBatch.updated")

--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -140,6 +140,11 @@ object ConsumerMessage {
     def updated(offset: CommittableOffset): CommittableOffsetBatch
 
     /**
+     * Add/overwrite offset positions from another batch.
+     */
+    def updated(offset: CommittableOffsetBatch): CommittableOffsetBatch
+
+    /**
      * Scala API: Get current offset positions
      */
     def offsets(): Map[GroupTopicPartition, Long]


### PR DESCRIPTION
I often find it useful to do some grouping on the consumed messages, that is not related to the commit process. However, in order to be able to build an offsets batch at the end of the flow I currently have to keep all `CommittableOffset`s.

 It would be useful if I could already aggregate them into a `CommittableOffsetBatch`, and then aggregate even further to keep commit rate low.

An alternative implementation would be to change `updated` signature to accept `Commitable`, but the comment says that it might be generalized and moved to `akka.stream`, and I'm not sure if merging `CommittableOffsetBatch` with an arbitrary `Commitable` should be supported.