### PR TITLE
Seek to the last unemitted offset after subsource is cancelled

### DIFF
--- a/tests/src/test/resources/logback-test.xml
+++ b/tests/src/test/resources/logback-test.xml
@@ -33,7 +33,7 @@
     <logger name="org.apache.kafka.clients.NetworkClient" level="ERROR"/>
 
     <root level="DEBUG">
-        <!--<appender-ref ref="STDOUT" />-->
+        <!--appender-ref ref="STDOUT" /-->
         <appender-ref ref="FILE" />
     </root>
 


### PR DESCRIPTION
This is an attempt to address the situation reported in https://github.com/akka/alpakka-kafka/issues/382#issuecomment-412092233 where a number of messages are skipped when the partition SubSource is closed.

This PR adds last unemitted element propagation from a SubSourceStage back to SubSourceLogic which then seeks the partition to the last unemitted offset.