### PR TITLE
Fix rebalance on partitioned source with external offsets

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
@@ -109,7 +109,7 @@ private[kafka] abstract class SubSourceLogic[K, V, Msg](
 
       case Some(getOffsetsFromExternal) =>
         implicit val ec: ExecutionContext = materializer.executionContext
-        getOffsetsFromExternal(formerlyUnknown)
+        getOffsetsFromExternal(assigned)
           .onComplete {
             case Failure(ex) =>
               stageFailCB.invoke(

--- a/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
@@ -279,8 +279,7 @@ class PartitionedSourceSpec(_system: ActorSystem)
     sink.cancel()
   }
 
-  // PENDING: this test illustrates https://github.com/akka/alpakka-kafka/issues/570
-  it should "after revoke request offset for remaining partition" in pendingUntilFixed(assertAllStagesStopped {
+  it should "after revoke request offset for remaining partition" in assertAllStagesStopped {
     val dummy = new Dummy()
 
     var assertGetOffsetsOnAssign: Set[TopicPartition] => Unit = { _ =>
@@ -317,7 +316,7 @@ class PartitionedSourceSpec(_system: ActorSystem)
     subSources1(tp1).runWith(Sink.ignore).futureValue should be(Done)
 
     sink.cancel()
-  })
+  }
 
   it should "seek to given offset" in assertAllStagesStopped {
     val dummy = new Dummy()

--- a/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
@@ -123,6 +123,7 @@ class PartitionedSourcesSpec extends SpecBase(kafkaPort = KafkaPorts.Partitioned
         .runWith(Producer.plainSink(producerDefaults, testProducer))
 
       producer.futureValue shouldBe Done
+      sleep(2.seconds)
       val streamMessages = control.drainAndShutdown().futureValue
       createdSubSources should contain allElementsOf allTps
       streamMessages shouldBe totalMessages
@@ -209,9 +210,8 @@ class PartitionedSourcesSpec extends SpecBase(kafkaPort = KafkaPorts.Partitioned
           consumer1.assignment.size == half && consumer2.assignment.size == half
       }
 
-      eventually {
-        control2 should not be null
-      }
+      control2 should not be null
+      sleep(4.seconds)
       val stream1messages = control.drainAndShutdown().futureValue
       val stream2messages = control2.drainAndShutdown().futureValue
       createdSubSources should contain allElementsOf allTps


### PR DESCRIPTION
This PR fixes #570 with a tiny change in what value is passed to the offset gathering function.

To get there I changed the delaying of the closing of substreams from a local async callback to using a stage timer. Renamed a few methods to better express what they do, and got rid of a call to an async callback in one situation.

The changes can be followed per commit.

Fixes #570 