### PR TITLE
Join single source logics into one

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/BaseSingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/BaseSingleSourceLogic.scala
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.internal
+
+import akka.actor.{ActorRef, Terminated}
+import akka.kafka.Subscriptions.{Assignment, AssignmentOffsetsForTimes, AssignmentWithOffset}
+import akka.kafka.{ConsumerFailed, ManualSubscription}
+import akka.stream.SourceShape
+import akka.stream.stage.GraphStageLogic.StageActor
+import akka.stream.stage.{GraphStageLogic, OutHandler, StageLogging}
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.TopicPartition
+
+import scala.annotation.tailrec
+import scala.concurrent.{ExecutionContext, Future}
+
+private[kafka] abstract class BaseSingleSourceLogic[K, V, Msg](
+    val shape: SourceShape[Msg]
+) extends GraphStageLogic(shape)
+    with PromiseControl
+    with MetricsControl
+    with StageLogging
+    with MessageBuilder[K, V, Msg] {
+
+  override protected def executionContext: ExecutionContext = materializer.executionContext
+  protected def consumerFuture: Future[ActorRef]
+  protected final var consumerActor: ActorRef = _
+  protected var sourceActor: StageActor = _
+  protected var tps = Set.empty[TopicPartition]
+  private var buffer: Iterator[ConsumerRecord[K, V]] = Iterator.empty
+  private var requested = false
+  private var requestId = 0
+
+  override def preStart(): Unit = {
+    super.preStart()
+
+    consumerActor = createConsumerActor()
+
+    sourceActor = getStageActor {
+      case (_, msg: KafkaConsumerActor.Internal.Messages[K, V]) =>
+        // might be more than one in flight when we assign/revoke tps
+        if (msg.requestId == requestId)
+          requested = false
+        // do not use simple ++ because of https://issues.scala-lang.org/browse/SI-9766
+        if (buffer.hasNext) {
+          buffer = buffer ++ msg.messages
+        } else {
+          buffer = msg.messages
+        }
+        pump()
+      case (_, Terminated(ref)) if ref == consumerActor =>
+        failStage(new ConsumerFailed())
+    }
+    sourceActor.watch(consumerActor)
+
+    configureSubscription()
+  }
+
+  protected def createConsumerActor(): ActorRef
+
+  protected def configureSubscription(): Unit
+
+  protected def configureManualSubscription(subscription: ManualSubscription): Unit = subscription match {
+    case Assignment(topics, _) =>
+      consumerActor.tell(KafkaConsumerActor.Internal.Assign(topics), sourceActor.ref)
+      tps ++= topics
+    case AssignmentWithOffset(topics, _) =>
+      consumerActor.tell(KafkaConsumerActor.Internal.AssignWithOffset(topics), sourceActor.ref)
+      tps ++= topics.keySet
+    case AssignmentOffsetsForTimes(topics, _) =>
+      consumerActor.tell(KafkaConsumerActor.Internal.AssignOffsetsForTimes(topics), sourceActor.ref)
+      tps ++= topics.keySet
+  }
+
+  @tailrec
+  private def pump(): Unit =
+    if (isAvailable(shape.out)) {
+      if (buffer.hasNext) {
+        val msg = buffer.next()
+        push(shape.out, createMessage(msg))
+        pump()
+      } else if (!requested && tps.nonEmpty) {
+        requestMessages()
+      }
+    }
+
+  protected def requestMessages(): Unit = {
+    requested = true
+    requestId += 1
+    log.debug("Requesting messages, requestId: {}, partitions: {}", requestId, tps)
+    consumerActor.tell(KafkaConsumerActor.Internal.RequestMessages(requestId, tps), sourceActor.ref)
+  }
+
+  setHandler(shape.out, new OutHandler {
+    override def onPull(): Unit =
+      pump()
+
+    override def onDownstreamFinish(): Unit =
+      performShutdown()
+  })
+
+  override def postStop(): Unit = {
+    onShutdown()
+    super.postStop()
+  }
+
+  def performShutdown(): Unit
+
+}

--- a/core/src/main/scala/akka/kafka/internal/ExternalSingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/ExternalSingleSourceLogic.scala
@@ -5,104 +5,28 @@
 
 package akka.kafka.internal
 
-import akka.actor.{ActorRef, Terminated}
-import akka.kafka.Subscriptions.{Assignment, AssignmentOffsetsForTimes, AssignmentWithOffset}
-import akka.kafka.{ConsumerFailed, ManualSubscription}
+import akka.actor.ActorRef
+import akka.kafka.ManualSubscription
 import akka.stream.SourceShape
-import akka.stream.stage.GraphStageLogic.StageActor
-import akka.stream.stage.{GraphStageLogic, OutHandler, StageLogging}
-import org.apache.kafka.clients.consumer.ConsumerRecord
-import org.apache.kafka.common.TopicPartition
 
-import scala.annotation.tailrec
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 private[kafka] abstract class ExternalSingleSourceLogic[K, V, Msg](
-    val shape: SourceShape[Msg],
-    val consumerActor: ActorRef,
+    shape: SourceShape[Msg],
+    _consumerActor: ActorRef,
     subscription: ManualSubscription
-) extends GraphStageLogic(shape)
-    with PromiseControl
-    with MetricsControl
-    with MessageBuilder[K, V, Msg]
-    with StageLogging {
+) extends BaseSingleSourceLogic[K, V, Msg](shape) {
 
-  override protected def logSource: Class[_] = classOf[SingleSourceLogic[K, V, Msg]]
+  final override protected def logSource: Class[_] = classOf[ExternalSingleSourceLogic[K, V, Msg]]
 
-  override def executionContext: ExecutionContext = materializer.executionContext
-  override val consumerFuture: Future[ActorRef] = Future.successful(consumerActor)
-  var sourceActor: StageActor = _
-  var tps = Set.empty[TopicPartition]
-  var buffer: Iterator[ConsumerRecord[K, V]] = Iterator.empty
-  var requested = false
-  var requestId = 0
+  final val consumerFuture: Future[ActorRef] = Future.successful(_consumerActor)
 
-  override def preStart(): Unit = {
-    super.preStart()
+  final def createConsumerActor(): ActorRef = _consumerActor
 
-    sourceActor = getStageActor {
-      case (_, msg: KafkaConsumerActor.Internal.Messages[K, V]) =>
-        // might be more than one in flight when we assign/revoke tps
-        if (msg.requestId == requestId)
-          requested = false
-        // do not use simple ++ because of https://issues.scala-lang.org/browse/SI-9766
-        if (buffer.hasNext) {
-          buffer = buffer ++ msg.messages
-        } else {
-          buffer = msg.messages
-        }
-        pump()
-      case (_, Terminated(ref)) if ref == consumerActor =>
-        failStage(new ConsumerFailed())
-    }
-    sourceActor.watch(consumerActor)
+  final def configureSubscription(): Unit =
+    configureManualSubscription(subscription)
 
-    subscription match {
-      case Assignment(topics, _) =>
-        consumerActor.tell(KafkaConsumerActor.Internal.Assign(topics), sourceActor.ref)
-        tps ++= topics
-      case AssignmentWithOffset(topics, _) =>
-        consumerActor.tell(KafkaConsumerActor.Internal.AssignWithOffset(topics), sourceActor.ref)
-        tps ++= topics.keySet
-      case AssignmentOffsetsForTimes(topics, _) =>
-        consumerActor.tell(KafkaConsumerActor.Internal.AssignOffsetsForTimes(topics), sourceActor.ref)
-        tps ++= topics.keySet
-    }
-  }
-
-  @tailrec
-  private def pump(): Unit =
-    if (isAvailable(shape.out)) {
-      if (buffer.hasNext) {
-        val msg = buffer.next()
-        push(shape.out, createMessage(msg))
-        pump()
-      } else if (!requested && tps.nonEmpty) {
-        requestMessages()
-      }
-    }
-
-  private def requestMessages(): Unit = {
-    requested = true
-    requestId += 1
-    log.debug("Requesting messages, requestId: {}, partitions: {}", requestId, tps)
-    consumerActor.tell(KafkaConsumerActor.Internal.RequestMessages(requestId, tps), sourceActor.ref)
-  }
-
-  setHandler(shape.out, new OutHandler {
-    override def onPull(): Unit =
-      pump()
-
-    override def onDownstreamFinish(): Unit =
-      performShutdown()
-  })
-
-  override def postStop(): Unit = {
-    onShutdown()
-    super.postStop()
-  }
-
-  override def performShutdown(): Unit =
+  final def performShutdown(): Unit =
     completeStage()
 
 }

--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -9,66 +9,26 @@ import akka.actor.{ActorRef, ExtendedActorSystem, Terminated}
 import akka.event.Logging
 import akka.kafka.Subscriptions._
 import akka.kafka._
-import akka.stream.stage.GraphStageLogic.StageActor
-import akka.stream.stage.{GraphStageLogic, OutHandler, StageLogging}
 import akka.stream.{ActorMaterializerHelper, SourceShape}
-import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.TopicPartition
 
-import scala.annotation.tailrec
-import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.concurrent.{Future, Promise}
 
 private[kafka] abstract class SingleSourceLogic[K, V, Msg](
-    val shape: SourceShape[Msg],
+    shape: SourceShape[Msg],
     settings: ConsumerSettings[K, V],
     subscription: Subscription
-) extends GraphStageLogic(shape)
-    with PromiseControl
-    with MetricsControl
-    with MessageBuilder[K, V, Msg]
-    with StageLogging {
+) extends BaseSingleSourceLogic[K, V, Msg](shape) {
 
   override protected def logSource: Class[_] = classOf[SingleSourceLogic[K, V, Msg]]
 
-  val consumerPromise = Promise[ActorRef]
+  private val consumerPromise = Promise[ActorRef]
   final val actorNumber = KafkaConsumerActor.Internal.nextNumber()
-  override def executionContext: ExecutionContext = materializer.executionContext
-  override def consumerFuture: Future[ActorRef] = consumerPromise.future
-  var consumerActor: ActorRef = _
-  var sourceActor: StageActor = _
-  var tps = Set.empty[TopicPartition]
-  var buffer: Iterator[ConsumerRecord[K, V]] = Iterator.empty
-  var requested = false
-  var requestId = 0
-  var shutdownStarted = false
-  val partitionLogLevel = if (settings.wakeupDebug) Logging.InfoLevel else Logging.DebugLevel
+  final def consumerFuture: Future[ActorRef] = consumerPromise.future
 
-  override def preStart(): Unit = {
-    super.preStart()
+  private val partitionLogLevel = if (settings.wakeupDebug) Logging.InfoLevel else Logging.DebugLevel
 
-    consumerActor = {
-      val extendedActorSystem = ActorMaterializerHelper.downcast(materializer).system.asInstanceOf[ExtendedActorSystem]
-      extendedActorSystem.systemActorOf(akka.kafka.KafkaConsumerActor.props(settings), s"kafka-consumer-$actorNumber")
-    }
-    consumerPromise.success(consumerActor)
-
-    sourceActor = getStageActor {
-      case (_, msg: KafkaConsumerActor.Internal.Messages[K, V]) =>
-        // might be more than one in flight when we assign/revoke tps
-        if (msg.requestId == requestId)
-          requested = false
-        // do not use simple ++ because of https://issues.scala-lang.org/browse/SI-9766
-        if (buffer.hasNext) {
-          buffer = buffer ++ msg.messages
-        } else {
-          buffer = msg.messages
-        }
-        pump()
-      case (_, Terminated(ref)) if ref == consumerActor =>
-        failStage(new ConsumerFailed())
-    }
-    sourceActor.watch(consumerActor)
-
+  final def configureSubscription(): Unit = {
     val partitionAssignedCB = getAsyncCallback[Set[TopicPartition]] { assignedTps =>
       tps ++= assignedTps
       log.log(partitionLogLevel, "Assigned partitions: {}. All partitions: {}", assignedTps, tps)
@@ -94,52 +54,25 @@ private[kafka] abstract class SingleSourceLogic[K, V, Msg](
         consumerActor.tell(KafkaConsumerActor.Internal.Subscribe(topics, rebalanceListener), sourceActor.ref)
       case TopicSubscriptionPattern(topics, _) =>
         consumerActor.tell(KafkaConsumerActor.Internal.SubscribePattern(topics, rebalanceListener), sourceActor.ref)
-      case Assignment(topics, _) =>
-        consumerActor.tell(KafkaConsumerActor.Internal.Assign(topics), sourceActor.ref)
-        tps ++= topics
-      case AssignmentWithOffset(topics, _) =>
-        consumerActor.tell(KafkaConsumerActor.Internal.AssignWithOffset(topics), sourceActor.ref)
-        tps ++= topics.keySet
-      case AssignmentOffsetsForTimes(topics, _) =>
-        consumerActor.tell(KafkaConsumerActor.Internal.AssignOffsetsForTimes(topics), sourceActor.ref)
-        tps ++= topics.keySet
-    }
-  }
-
-  @tailrec
-  private def pump(): Unit =
-    if (isAvailable(shape.out)) {
-      if (buffer.hasNext) {
-        val msg = buffer.next()
-        push(shape.out, createMessage(msg))
-        pump()
-      } else if (!requested && tps.nonEmpty) {
-        requestMessages()
-      }
+      case s: ManualSubscription => configureManualSubscription(s)
     }
 
-  private def requestMessages(): Unit = {
-    requested = true
-    requestId += 1
-    log.debug("Requesting messages, requestId: {}, partitions: {}", requestId, tps)
-    consumerActor.tell(KafkaConsumerActor.Internal.RequestMessages(requestId, tps), sourceActor.ref)
   }
 
-  setHandler(shape.out, new OutHandler {
-    override def onPull(): Unit =
-      pump()
+  final def createConsumerActor(): ActorRef = {
+    val extendedActorSystem = ActorMaterializerHelper.downcast(materializer).system.asInstanceOf[ExtendedActorSystem]
+    val actor =
+      extendedActorSystem.systemActorOf(akka.kafka.KafkaConsumerActor.props(settings), s"kafka-consumer-$actorNumber")
+    consumerPromise.success(actor)
+    actor
+  }
 
-    override def onDownstreamFinish(): Unit =
-      performShutdown()
-  })
-
-  override def postStop(): Unit = {
+  final override def postStop(): Unit = {
     consumerActor.tell(KafkaConsumerActor.Internal.Stop, sourceActor.ref)
-    onShutdown()
     super.postStop()
   }
 
-  override def performShutdown(): Unit = {
+  final def performShutdown(): Unit = {
     setKeepGoing(true)
     if (!isClosed(shape.out)) {
       complete(shape.out)

--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -104,7 +104,6 @@ private[kafka] abstract class SingleSourceLogic[K, V, Msg](
         consumerActor.tell(KafkaConsumerActor.Internal.AssignOffsetsForTimes(topics), sourceActor.ref)
         tps ++= topics.keySet
     }
-
   }
 
   @tailrec


### PR DESCRIPTION
Make `SingleSourceLogic` and `ExternalSingleSourceLogic` inherit from a new base class so that their shared implementations don't diverge.

The code looked like as if `ExternalSingleSourceLogic` was created as a copy of `SingleSourceLogic` some time ago, it even contained unused callbacks...