### PR TITLE
Use takeWhile in integration tests

### DIFF
--- a/tests/src/it/scala/akka/kafka/PlainSourceFailoverSpec.scala
+++ b/tests/src/it/scala/akka/kafka/PlainSourceFailoverSpec.scala
@@ -46,16 +46,13 @@ class PlainSourceFailoverSpec extends ScalatestKafkaSpec(PlainSourceFailoverSpec
         .withProperty(ConsumerConfig.METADATA_MAX_AGE_CONFIG, "100") // default was 5 * 60 * 1000 (five minutes)
 
       val consumer = Consumer.plainSource(consumerConfig, Subscriptions.topics(topic))
+        .takeWhile(_.value().toInt < totalMessages, inclusive = true)
         .scan(0)((c, _) => c + 1)
         .map { i =>
           if (i % 1000 == 0) log.info(s"Received [$i] messages so far.")
           i
         }
-        .map(Some.apply)
-        .keepAlive(maxIdle = 10.seconds, () => None)
-        .takeWhile(_.isDefined)
         .runWith(Sink.last)
-        .map(_.get)
 
       waitUntilConsumerSummary(groupId, timeout = 5.seconds) {
         case singleConsumer :: Nil => singleConsumer.assignment.size == partitions


### PR DESCRIPTION
Using keepAlive had problem when the stream was slow to start. keepAlive
would inject an element and the consumer source would be cancelled
without starting to produce elements.

Using takeWhile might miss duplicates of the last message. But it makes
consumer source completion more robust and fast.