### PR TITLE
Run integration tests with oldest Kafka possible

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - "2181:2181"
   kafka:
     scale: ${KAFKA_SCALE:-1}
-    image: wurstmeister/kafka:1.1.0
+    image: wurstmeister/kafka:2.11-0.11.0.3
     ports:
       - "9094"
     environment:


### PR DESCRIPTION
wurstmeister now [publishes Kafka docker images for many different Kafka versions](https://hub.docker.com/r/wurstmeister/kafka/tags/). All of the images contain the latest wurstmeister scripts. So substitutions now work for every image. More info on their image versioning scheme [here](https://github.com/wurstmeister/kafka-docker#tags-and-releases).

Integration tests timed-out when running with `2.11-0.11.0.3`. They passed with `2.11-1.0.1` so this is what we should be running integration tests against.

