### PR TITLE
Fix the name of the docs project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -202,7 +202,7 @@ lazy val docs = project
   .enablePlugins(AkkaParadoxPlugin)
   .settings(commonSettings)
   .settings(
-    name := "akka-stream-kafka-docs",
+    name := "Alpakka Kafka",
     skip in publish := true,
     paradoxNavigationDepth := 3,
     paradoxGroups := Map("Language" -> Seq("Java", "Scala")),


### PR DESCRIPTION
It appears at the bottom of the generated paradox documentation.