### PR TITLE
Testdummy: Don't pause partitions that are not assigned anymore

### DIFF
--- a/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
@@ -596,7 +596,7 @@ object PartitionedSourceSpec {
       super.pause(partitions)
       val ps = partitions.asScala
       log.debug(s"pausing ${ps.mkString("(", ", ", ")")}")
-      tps = tps ++ ps.map(_ -> Paused)
+      tps = tps ++ ps.filter(tp => tps.contains(tp)).map(_ -> Paused)
     }
     override def resume(partitions: java.util.Collection[TopicPartition]): Unit = {
       val ps = partitions.asScala


### PR DESCRIPTION
As it turns out, the timing sometimes could set a partition as paused that is not considered assigned anymore.

Fixes #601 (hopefully)