### PR TITLE
Use some 2.0 features (timeouts)

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -88,6 +88,11 @@ akka.kafka.consumer {
 
   # Time to wait for pending requests when a partition is closed
   wait-close-partition = 500ms
+
+  # Timeout for akka.kafka.Metadata requests
+  # This value is used instead of Kafka's default from `default.api.timeout.ms`
+  # which is 1 minute.
+  metadata-request-timeout = 5s
 }
 # // #consumer-settings
 

--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -185,8 +185,43 @@ class ConsumerSettings[K, V] @deprecated("use the factory methods `ConsumerSetti
     val commitTimeWarning: FiniteDuration = 1.second,
     val wakeupDebug: Boolean = true,
     val waitClosePartition: FiniteDuration,
-    val metadataRequestTimeout: FiniteDuration = 5.seconds
+    val metadataRequestTimeout: FiniteDuration
 ) {
+
+  @deprecated("use the factory methods `ConsumerSettings.apply` and `create` instead", "1.0-M1")
+  def this(properties: Map[String, String],
+           keyDeserializer: Option[Deserializer[K]],
+           valueDeserializer: Option[Deserializer[V]],
+           pollInterval: FiniteDuration,
+           pollTimeout: FiniteDuration,
+           stopTimeout: FiniteDuration,
+           closeTimeout: FiniteDuration,
+           commitTimeout: FiniteDuration,
+           wakeupTimeout: FiniteDuration,
+           maxWakeups: Int,
+           commitRefreshInterval: Duration,
+           dispatcher: String,
+           commitTimeWarning: FiniteDuration,
+           wakeupDebug: Boolean,
+           waitClosePartition: FiniteDuration,
+  ) = this(
+    properties,
+    keyDeserializer,
+    valueDeserializer,
+    pollInterval,
+    pollTimeout,
+    stopTimeout,
+    closeTimeout,
+    commitTimeout,
+    wakeupTimeout,
+    maxWakeups,
+    commitRefreshInterval,
+    dispatcher,
+    commitTimeWarning,
+    wakeupDebug,
+    waitClosePartition,
+    metadataRequestTimeout = 5.seconds
+  )
 
   def withBootstrapServers(bootstrapServers: String): ConsumerSettings[K, V] =
     withProperty(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -5,7 +5,6 @@
 
 package akka.kafka.internal
 
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.LockSupport
 import java.util.regex.Pattern
@@ -32,6 +31,8 @@ import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 import scala.util.Try
 import scala.util.control.{NoStackTrace, NonFatal}
+
+import akka.util.JavaDurationConverters._
 
 object KafkaConsumerActor {
 
@@ -300,7 +301,7 @@ class KafkaConsumerActor[K, V](settings: ConsumerSettings[K, V]) extends Actor w
       case (ref, req) =>
         ref ! Messages(req.requestId, Iterator.empty)
     }
-    consumer.close(settings.closeTimeout.toMillis, TimeUnit.MILLISECONDS)
+    consumer.close(settings.closeTimeout.asJava)
     super.postStop()
   }
 

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -33,8 +33,6 @@ import scala.concurrent.duration._
 import scala.util.Try
 import scala.util.control.{NoStackTrace, NonFatal}
 
-import akka.util.JavaDurationConverters._
-
 object KafkaConsumerActor {
 
   object Internal {

--- a/docs/src/main/paradox/consumer-metadata.md
+++ b/docs/src/main/paradox/consumer-metadata.md
@@ -16,12 +16,16 @@ The supported metadata are
 | GetEndOffsets | EndOffsets |
 | GetOffsetsForTimes | OffsetsForTimes |
 | GetCommittedOffset | CommittedOffset |
+
+These requests are blocking within the Kafka client library up to a timeout configured by `metadata-request-timeout` or `ConsumerSettings.withMetadataRequestTimeout` respectively.
    
 @@@ warning
 
-Processing of these requests blocks the actor loop. The KafkaConsumerActor is configured to run on its own dispatcher, so just as the other remote calls to Kafka, the blocking happens within a designated thread pool.
+Processing of these requests blocks the actor loop. The `KafkaConsumerActor` is configured to run on its own dispatcher, so just as the other remote calls to Kafka, the blocking happens within a designated thread pool.
 
 However, calling these during consuming might affect performance and even cause timeouts in extreme cases.
+
+Please consider to use a dedicated `KafkaConsumerActor` to run metadata requests against.
 
 @@@   
 

--- a/tests/src/test/java/docs/javadsl/FetchMetadata.java
+++ b/tests/src/test/java/docs/javadsl/FetchMetadata.java
@@ -7,6 +7,7 @@ package docs.javadsl;
 
 // #metadata
 import akka.actor.ActorRef;
+import akka.kafka.ConsumerSettings;
 import akka.kafka.KafkaConsumerActor;
 import akka.kafka.Metadata;
 import akka.pattern.PatternsCS;
@@ -24,12 +25,11 @@ public class FetchMetadata extends ConsumerExample {
 
   void demo() {
     // #metadata
-    // Create kafka consumer actor to be used with Consumer.plainExternalSource or
-    // committableExternalSource
-    ActorRef consumer = system.actorOf((KafkaConsumerActor.props(consumerSettings)));
-
-    // ... create source ...
     Duration timeout = Duration.ofSeconds(2);
+    ConsumerSettings<String, byte[]> settings =
+        consumerSettings.withMetadataRequestTimeout(timeout);
+
+    ActorRef consumer = system.actorOf((KafkaConsumerActor.props(settings)));
 
     CompletionStage<Metadata.Topics> topicsStage =
         PatternsCS.ask(consumer, Metadata.createListTopics(), timeout)


### PR DESCRIPTION
* use a configurable timeout on all Metadata requests
* deprecate `ConsumerSettings` constructors
* use a *for now* hardcoded timeout for `position`
* use a *for now* hardcoded timeout for `offsetForTimes`

This PR does the easy part of #608.