### PR TITLE
Expose consumer creation failures

### DIFF
--- a/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
@@ -5,7 +5,7 @@
 
 package akka.kafka
 
-import akka.actor.{NoSerializationVerificationNeeded, Props}
+import akka.actor.{ActorRef, NoSerializationVerificationNeeded, Props}
 import akka.kafka.internal.{KafkaConsumerActor => InternalKafkaConsumerActor}
 
 object KafkaConsumerActor {
@@ -23,7 +23,17 @@ object KafkaConsumerActor {
 
   case class StoppingException() extends RuntimeException("Kafka consumer is stopping")
 
+  /**
+   * Creates Props for the Kafka Consumer Actor.
+   */
   def props[K, V](settings: ConsumerSettings[K, V]): Props =
-    Props(new InternalKafkaConsumerActor(settings)).withDispatcher(settings.dispatcher)
+    Props(new InternalKafkaConsumerActor(None, settings)).withDispatcher(settings.dispatcher)
 
+  /**
+   * Creates Props for the Kafka Consumer Actor with a reference back to the owner of it
+   * which will be signalled with [[akka.actor.Status.Failure(exception)]], in case the
+   * Kafka client instance can't be created.
+   */
+  def props[K, V](owner: ActorRef, settings: ConsumerSettings[K, V]): Props =
+    Props(new InternalKafkaConsumerActor(Some(owner), settings)).withDispatcher(settings.dispatcher)
 }

--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -73,7 +73,8 @@ private[kafka] abstract class SingleSourceLogic[K, V, Msg](
   final def createConsumerActor(): ActorRef = {
     val extendedActorSystem = ActorMaterializerHelper.downcast(materializer).system.asInstanceOf[ExtendedActorSystem]
     val actor =
-      extendedActorSystem.systemActorOf(akka.kafka.KafkaConsumerActor.props(settings), s"kafka-consumer-$actorNumber")
+      extendedActorSystem.systemActorOf(akka.kafka.KafkaConsumerActor.props(sourceActor.ref, settings),
+                                        s"kafka-consumer-$actorNumber")
     consumerPromise.success(actor)
     actor
   }

--- a/tests/src/test/scala/akka/kafka/scaladsl/MisconfiguredConsumerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/MisconfiguredConsumerSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.scaladsl
+
+import akka.actor.ActorSystem
+import akka.kafka.{ConsumerSettings, Subscriptions}
+import akka.stream.scaladsl.Sink
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
+import akka.stream.{ActorMaterializer, Materializer}
+import akka.testkit.TestKit
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.{Matchers, WordSpecLike}
+
+import scala.concurrent.duration._
+
+class MisconfiguredConsumerSpec
+    extends TestKit(ActorSystem())
+    with WordSpecLike
+    with Matchers
+    with ScalaFutures
+    with Eventually {
+
+  implicit val materializer: Materializer = ActorMaterializer()
+  implicit val patience = PatienceConfig(2.seconds, 20.millis)
+
+  def bootstrapServers = "nowhere:6666"
+
+  "Failing consumer construction" must {
+    "be signalled to the stream by single sources" in assertAllStagesStopped {
+      val consumerSettings =
+        ConsumerSettings(system, new StringDeserializer, new StringDeserializer).withGroupId("group")
+      val result = Consumer
+        .plainSource(consumerSettings, Subscriptions.topics("topic"))
+        .runWith(Sink.head)
+
+      result.failed.futureValue shouldBe a[org.apache.kafka.common.KafkaException]
+    }
+
+    "be signalled to the stream by partitioned sources" in assertAllStagesStopped {
+      val consumerSettings =
+        ConsumerSettings(system, new StringDeserializer, new StringDeserializer).withGroupId("group")
+      val result = Consumer
+        .plainPartitionedSource(consumerSettings, Subscriptions.topics("topic"))
+        .runWith(Sink.head)
+
+      result.failed.futureValue shouldBe a[org.apache.kafka.common.KafkaException]
+    }
+  }
+}


### PR DESCRIPTION
Catch exceptions in the actor and send them as `Status.Failure` to known stage actors so that the stream can fail with the appropriate error.

* Pass creating stage's ActorRef to consumer actor (owner)
* Catch Kafka Consumer creation exceptions and pass to owner
* Catch exceptions in poll's outer catch clause

Fixes #612 