### PR TITLE
Add factory methods for ProducerMessages

### DIFF
--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaProducerBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaProducerBenchmarks.scala
@@ -6,7 +6,8 @@
 package akka.kafka.benchmarks
 
 import akka.kafka.ConsumerMessage.CommittableMessage
-import akka.kafka.ProducerMessage.{Message, Result, Results}
+import akka.kafka.ProducerMessage
+import akka.kafka.ProducerMessage.{Result, Results}
 import akka.kafka.benchmarks.ReactiveKafkaProducerFixtures.ReactiveKafkaProducerTestFixture
 import akka.stream.Materializer
 import akka.stream.scaladsl.{Sink, Source}
@@ -32,7 +33,10 @@ object ReactiveKafkaProducerBenchmarks extends LazyLogging {
     @volatile var lastPartStart = System.nanoTime()
 
     val future = Source(0 to fixture.msgCount)
-      .map(number => Message(new ProducerRecord[Array[Byte], String](fixture.topic, number.toString), number))
+      .map(
+        number =>
+          ProducerMessage.single(new ProducerRecord[Array[Byte], String](fixture.topic, number.toString), number)
+      )
       .via(fixture.flow)
       .map {
         case msg: Result[Array[Byte], String, Int] =>

--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaTransactionBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaTransactionBenchmarks.scala
@@ -39,8 +39,8 @@ object ReactiveKafkaTransactionBenchmarks extends LazyLogging {
 
     val control = source
       .map { msg =>
-        ProducerMessage.Message(new ProducerRecord[Array[Byte], String](sinkTopic, msg.record.value()),
-                                msg.partitionOffset)
+        ProducerMessage.single(new ProducerRecord[Array[Byte], String](sinkTopic, msg.record.value()),
+                               msg.partitionOffset)
       }
       .via(fixture.flow)
       .toMat(Sink.foreach {

--- a/core/src/main/scala/akka/kafka/ProducerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ProducerMessage.scala
@@ -54,11 +54,24 @@ object ProducerMessage {
       passThrough: PassThrough
   ) extends Envelope[K, V, PassThrough]
 
+  /**
+   * Create a message containing the `record` and a `passThrough`.
+   *
+   * @tparam K the type of keys
+   * @tparam V the type of values
+   * @tparam PassThrough the type of data passed through
+   */
   def single[K, V, PassThrough](
       record: ProducerRecord[K, V],
       passThrough: PassThrough
   ): Envelope[K, V, PassThrough] = Message(record, passThrough)
 
+  /**
+   * Create a message containing the `record`.
+   *
+   * @tparam K the type of keys
+   * @tparam V the type of values
+   */
   def single[K, V](record: ProducerRecord[K, V]): Envelope[K, V, NotUsed] = Message(record, NotUsed)
 
   /**
@@ -88,17 +101,35 @@ object ProducerMessage {
     }
   }
 
+  /**
+   * Create a multi-message containing several `records` and one `passThrough`.
+   *
+   * @tparam K the type of keys
+   * @tparam V the type of values
+   * @tparam PassThrough the type of data passed through
+   */
   def multi[K, V, PassThrough](
       records: immutable.Seq[ProducerRecord[K, V]],
       passThrough: PassThrough
   ): Envelope[K, V, PassThrough] = MultiMessage(records, passThrough)
 
+  /**
+   * Create a multi-message containing several `records`.
+   *
+   * @tparam K the type of keys
+   * @tparam V the type of values
+   */
   def multi[K, V](
       records: immutable.Seq[ProducerRecord[K, V]]
   ): Envelope[K, V, NotUsed] = MultiMessage(records, NotUsed)
 
   /**
-   * Java API
+   * Java API:
+   * Create a multi-message containing several `records` and one `passThrough`.
+   *
+   * @tparam K the type of keys
+   * @tparam V the type of values
+   * @tparam PassThrough the type of data passed through
    */
   def multi[K, V, PassThrough](
       records: java.util.Collection[ProducerRecord[K, V]],
@@ -106,7 +137,11 @@ object ProducerMessage {
   ): Envelope[K, V, PassThrough] = new MultiMessage(records, passThrough)
 
   /**
-   * Java API
+   * Java API:
+   * Create a multi-message containing several `records`.
+   *
+   * @tparam K the type of keys
+   * @tparam V the type of values
    */
   def multi[K, V](
       records: java.util.Collection[ProducerRecord[K, V]]
@@ -126,6 +161,14 @@ object ProducerMessage {
       passThrough: PassThrough
   ) extends Envelope[K, V, PassThrough]
 
+  /**
+   * Create a pass-through message not containing any records.
+   * In some cases the type parameters need to be specified explicitly.
+   *
+   * @tparam K the type of keys
+   * @tparam V the type of values
+   * @tparam PassThrough the type of data passed through
+   */
   def passThrough[K, V, PassThrough](passThrough: PassThrough): Envelope[K, V, PassThrough] =
     PassThroughMessage(passThrough)
 

--- a/tests/src/test/java/docs/javadsl/AtLeastOnceOneToMany.java
+++ b/tests/src/test/java/docs/javadsl/AtLeastOnceOneToMany.java
@@ -10,10 +10,8 @@ import akka.Done;
 import akka.kafka.ConsumerMessage;
 import akka.kafka.ConsumerMessage.CommittableOffset;
 import akka.kafka.ConsumerMessage.CommittableOffsetBatch;
+import akka.kafka.ProducerMessage;
 import akka.kafka.ProducerMessage.Envelope;
-import akka.kafka.ProducerMessage.Message;
-import akka.kafka.ProducerMessage.MultiMessage;
-import akka.kafka.ProducerMessage.PassThroughMessage;
 import akka.kafka.Subscriptions;
 import akka.kafka.javadsl.Consumer;
 import akka.kafka.javadsl.Producer;
@@ -38,7 +36,7 @@ public class AtLeastOnceOneToMany extends ConsumerExample {
             .map(
                 msg -> {
                   Envelope<String, byte[], CommittableOffset> multiMsg =
-                      new MultiMessage<String, byte[], CommittableOffset>(
+                      ProducerMessage.multi(
                           Arrays.asList(
                               new ProducerRecord<>("topic2", msg.record().value()),
                               new ProducerRecord<>("topic3", msg.record().value())),
@@ -80,16 +78,16 @@ class AtLeastOnceOneToConditional extends ConsumerExample {
                   final Envelope<String, byte[], CommittableOffset> produce;
                   if (duplicate(msg.record().value())) {
                     produce =
-                        new MultiMessage<>(
+                        ProducerMessage.multi(
                             Arrays.asList(
                                 new ProducerRecord<>("topic2", msg.record().value()),
                                 new ProducerRecord<>("topic3", msg.record().value())),
                             msg.committableOffset());
                   } else if (ignore(msg.record().value())) {
-                    produce = new PassThroughMessage<>(msg.committableOffset());
+                    produce = ProducerMessage.passThrough(msg.committableOffset());
                   } else {
                     produce =
-                        new Message<>(
+                        ProducerMessage.single(
                             new ProducerRecord<>("topic2", msg.record().value()),
                             msg.committableOffset());
                   }

--- a/tests/src/test/java/docs/javadsl/ConsumerExample.java
+++ b/tests/src/test/java/docs/javadsl/ConsumerExample.java
@@ -279,7 +279,7 @@ class ConsumerToProducerSinkExample extends ConsumerExample {
         Consumer.committableSource(consumerSettings, Subscriptions.topics("topic1", "topic2"))
             .map(
                 msg ->
-                    new ProducerMessage.Message<String, byte[], ConsumerMessage.Committable>(
+                    ProducerMessage.<String, byte[], ConsumerMessage.Committable>single(
                         new ProducerRecord<>(
                             "targetTopic", msg.record().key(), msg.record().value()),
                         msg.committableOffset()))
@@ -301,14 +301,11 @@ class ConsumerToProducerFlowExample extends ConsumerExample {
     Consumer.DrainingControl<Done> control =
         Consumer.committableSource(consumerSettings, Subscriptions.topics("topic1"))
             .map(
-                msg -> {
-                  ProducerMessage.Envelope<String, byte[], ConsumerMessage.Committable> prodMsg =
-                      new ProducerMessage.Message<>(
-                          new ProducerRecord<>("topic2", msg.record().value()),
-                          msg.committableOffset() // the passThrough
-                          );
-                  return prodMsg;
-                })
+                msg ->
+                    ProducerMessage.single(
+                        new ProducerRecord<>("topic2", msg.record().key(), msg.record().value()),
+                        msg.committableOffset() // the passThrough
+                        ))
             .via(Producer.flexiFlow(producerSettings))
             .mapAsync(
                 producerSettings.parallelism(),
@@ -334,14 +331,10 @@ class ConsumerToProducerWithBatchCommitsExample extends ConsumerExample {
     Source<ConsumerMessage.CommittableOffset, Consumer.Control> source =
         Consumer.committableSource(consumerSettings, Subscriptions.topics("topic1"))
             .map(
-                msg -> {
-                  ProducerMessage.Envelope<String, byte[], ConsumerMessage.CommittableOffset>
-                      prodMsg =
-                          new ProducerMessage.Message<>(
-                              new ProducerRecord<>("topic2", msg.record().value()),
-                              msg.committableOffset());
-                  return prodMsg;
-                })
+                msg ->
+                    ProducerMessage.single(
+                        new ProducerRecord<>("topic2", msg.record().key(), msg.record().value()),
+                        msg.committableOffset()))
             .via(Producer.flexiFlow(producerSettings))
             .map(result -> result.passThrough());
 
@@ -366,14 +359,10 @@ class ConsumerToProducerWithBatchCommits2Example extends ConsumerExample {
     Source<ConsumerMessage.CommittableOffset, Consumer.Control> source =
         Consumer.committableSource(consumerSettings, Subscriptions.topics("topic1"))
             .map(
-                msg -> {
-                  ProducerMessage.Envelope<String, byte[], ConsumerMessage.CommittableOffset>
-                      prodMsg =
-                          new ProducerMessage.Message<>(
-                              new ProducerRecord<>("topic2", msg.record().value()),
-                              msg.committableOffset());
-                  return prodMsg;
-                })
+                msg ->
+                    ProducerMessage.single(
+                        new ProducerRecord<>("topic2", msg.record().key(), msg.record().value()),
+                        msg.committableOffset()))
             .via(Producer.flexiFlow(producerSettings))
             .map(result -> result.passThrough());
 

--- a/tests/src/test/java/docs/javadsl/ProducerExample.java
+++ b/tests/src/test/java/docs/javadsl/ProducerExample.java
@@ -105,22 +105,21 @@ class ProducerFlowExample extends ProducerExample {
   }
 
   <KeyType, ValueType, PassThroughType>
-      ProducerMessage.Message<KeyType, ValueType, PassThroughType> createMessage(
+      ProducerMessage.Envelope<KeyType, ValueType, PassThroughType> createMessage(
           KeyType key, ValueType value, PassThroughType passThrough) {
     return
     // #singleMessage
-    new ProducerMessage.Message<KeyType, ValueType, PassThroughType>(
-        new ProducerRecord<>("topicName", key, value), passThrough);
+    ProducerMessage.single(new ProducerRecord<>("topicName", key, value), passThrough);
     // #singleMessage
 
   }
 
   <KeyType, ValueType, PassThroughType>
-      ProducerMessage.MultiMessage<KeyType, ValueType, PassThroughType> createMultiMessage(
+      ProducerMessage.Envelope<KeyType, ValueType, PassThroughType> createMultiMessage(
           KeyType key, ValueType value, PassThroughType passThrough) {
     return
     // #multiMessage
-    new ProducerMessage.MultiMessage<KeyType, ValueType, PassThroughType>(
+    ProducerMessage.multi(
         Arrays.asList(
             new ProducerRecord<>("topicName", key, value),
             new ProducerRecord<>("anotherTopic", key, value)),
@@ -130,12 +129,12 @@ class ProducerFlowExample extends ProducerExample {
   }
 
   <KeyType, ValueType, PassThroughType>
-      ProducerMessage.PassThroughMessage<KeyType, ValueType, PassThroughType>
-          createPassThroughMessage(KeyType key, ValueType value, PassThroughType passThrough) {
+      ProducerMessage.Envelope<KeyType, ValueType, PassThroughType> createPassThroughMessage(
+          KeyType key, ValueType value, PassThroughType passThrough) {
 
-    ProducerMessage.PassThroughMessage<KeyType, ValueType, PassThroughType> ptm =
+    ProducerMessage.Envelope<KeyType, ValueType, PassThroughType> ptm =
         // #passThroughMessage
-        new ProducerMessage.PassThroughMessage<>(passThrough);
+        ProducerMessage.passThrough(passThrough);
     // #passThroughMessage
     return ptm;
   }
@@ -149,7 +148,7 @@ class ProducerFlowExample extends ProducerExample {
                   int partition = 0;
                   String value = String.valueOf(number);
                   ProducerMessage.Envelope<String, String, Integer> msg =
-                      new ProducerMessage.Message<String, String, Integer>(
+                      ProducerMessage.single(
                           new ProducerRecord<>("topic1", partition, "key", value), number);
                   return msg;
                 })

--- a/tests/src/test/java/docs/javadsl/ProducerExample.java
+++ b/tests/src/test/java/docs/javadsl/ProducerExample.java
@@ -107,33 +107,32 @@ class ProducerFlowExample extends ProducerExample {
   <KeyType, ValueType, PassThroughType>
       ProducerMessage.Envelope<KeyType, ValueType, PassThroughType> createMessage(
           KeyType key, ValueType value, PassThroughType passThrough) {
-    return
     // #singleMessage
-    ProducerMessage.single(new ProducerRecord<>("topicName", key, value), passThrough);
+    ProducerMessage.Envelope<KeyType, ValueType, PassThroughType> message =
+        ProducerMessage.single(new ProducerRecord<>("topicName", key, value), passThrough);
     // #singleMessage
-
+    return message;
   }
 
   <KeyType, ValueType, PassThroughType>
       ProducerMessage.Envelope<KeyType, ValueType, PassThroughType> createMultiMessage(
           KeyType key, ValueType value, PassThroughType passThrough) {
-    return
     // #multiMessage
-    ProducerMessage.multi(
-        Arrays.asList(
-            new ProducerRecord<>("topicName", key, value),
-            new ProducerRecord<>("anotherTopic", key, value)),
-        passThrough);
+    ProducerMessage.Envelope<KeyType, ValueType, PassThroughType> multiMessage =
+        ProducerMessage.multi(
+            Arrays.asList(
+                new ProducerRecord<>("topicName", key, value),
+                new ProducerRecord<>("anotherTopic", key, value)),
+            passThrough);
     // #multiMessage
-
+    return multiMessage;
   }
 
   <KeyType, ValueType, PassThroughType>
       ProducerMessage.Envelope<KeyType, ValueType, PassThroughType> createPassThroughMessage(
           KeyType key, ValueType value, PassThroughType passThrough) {
-
+    // #passThroughMessage
     ProducerMessage.Envelope<KeyType, ValueType, PassThroughType> ptm =
-        // #passThroughMessage
         ProducerMessage.passThrough(passThrough);
     // #passThroughMessage
     return ptm;

--- a/tests/src/test/java/docs/javadsl/TransactionsExample.java
+++ b/tests/src/test/java/docs/javadsl/TransactionsExample.java
@@ -31,8 +31,9 @@ class TransactionsSink extends ConsumerExample {
             .via(business())
             .map(
                 msg ->
-                    new ProducerMessage.Message<String, byte[], ConsumerMessage.PartitionOffset>(
-                        new ProducerRecord<>("sink-topic", msg.record().value()),
+                    ProducerMessage.single(
+                        new ProducerRecord<>(
+                            "sink-topic", msg.record().key(), msg.record().value()),
                         msg.partitionOffset()))
             .to(Transactional.sink(producerSettings, "transactional-id"))
             .run(materializer);
@@ -64,9 +65,9 @@ class TransactionsFailureRetryExample extends ConsumerExample {
                         .via(business())
                         .map(
                             msg ->
-                                new ProducerMessage.Message<
-                                    String, byte[], ConsumerMessage.PartitionOffset>(
-                                    new ProducerRecord<>("sink-topic", msg.record().value()),
+                                ProducerMessage.single(
+                                    new ProducerRecord<>(
+                                        "sink-topic", msg.record().key(), msg.record().value()),
                                     msg.partitionOffset()))
                         // side effect out the `Control` materialized value because it can't be
                         // propagated through the `RestartSource`

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -327,7 +327,7 @@ class IntegrationSpec extends SpecBase(kafkaPort = KafkaPorts.IntegrationSpec) w
         val source = Consumer
           .committableSource(consumerDefaults.withGroupId(group1), Subscriptions.topics(topic1))
           .map(msg => {
-            ProducerMessage.Message(
+            ProducerMessage.single(
               // Produce to topic2
               new ProducerRecord[String, String](topic2, msg.record.value),
               msg.committableOffset

--- a/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
@@ -248,8 +248,8 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.ScalaConsumerExamples) {
       Consumer
         .committableSource(consumerSettings, Subscriptions.topics(topic1, topic2))
         .map { msg =>
-          ProducerMessage.Message[String, String, ConsumerMessage.CommittableOffset](
-            new ProducerRecord(targetTopic, msg.record.value),
+          ProducerMessage.single(
+            new ProducerRecord(targetTopic, msg.record.key, msg.record.value),
             msg.committableOffset
           )
         }
@@ -279,8 +279,8 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.ScalaConsumerExamples) {
     val control = Consumer
       .committableSource(consumerSettings, Subscriptions.topics(topic))
       .map { msg =>
-        ProducerMessage.Message[String, String, ConsumerMessage.CommittableOffset](
-          new ProducerRecord(targetTopic, msg.record.value),
+        ProducerMessage.single(
+          new ProducerRecord(targetTopic, msg.record.key, msg.record.value),
           passThrough = msg.committableOffset
         )
       }
@@ -314,8 +314,8 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.ScalaConsumerExamples) {
       .committableSource(consumerSettings, Subscriptions.topics(topic))
       .map(
         msg =>
-          ProducerMessage.Message[String, String, ConsumerMessage.CommittableOffset](
-            new ProducerRecord(targetTopic, msg.record.value),
+          ProducerMessage.single(
+            new ProducerRecord(targetTopic, msg.record.key, msg.record.value),
             msg.committableOffset
         )
       )
@@ -347,8 +347,8 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.ScalaConsumerExamples) {
       .committableSource(consumerSettings, Subscriptions.topics(topic))
       .map(
         msg =>
-          ProducerMessage.Message(
-            new ProducerRecord[String, String](targetTopic, msg.record.value),
+          ProducerMessage.single(
+            new ProducerRecord(targetTopic, msg.record.key, msg.record.value),
             msg.committableOffset
         )
       )

--- a/tests/src/test/scala/docs/scaladsl/ProducerExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/ProducerExample.scala
@@ -97,7 +97,7 @@ class ProducerExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamples)
 
   def createMessage[KeyType, ValueType, PassThroughType](key: KeyType, value: ValueType, passThrough: PassThroughType) =
     // #singleMessage
-    new ProducerMessage.Message[KeyType, ValueType, PassThroughType](
+    ProducerMessage.single(
       new ProducerRecord("topicName", key, value),
       passThrough
     )
@@ -108,7 +108,7 @@ class ProducerExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamples)
                                                               passThrough: PassThroughType) = {
     import scala.collection.immutable
     // #multiMessage
-    new ProducerMessage.MultiMessage[KeyType, ValueType, PassThroughType](
+    ProducerMessage.multi(
       immutable.Seq(
         new ProducerRecord("topicName", key, value),
         new ProducerRecord("anotherTopic", key, value)
@@ -123,7 +123,7 @@ class ProducerExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamples)
                                                                     passThrough: PassThroughType) =
     // format:off
     // #passThroughMessage
-    new ProducerMessage.PassThroughMessage(
+    ProducerMessage.passThrough(
       passThrough
     )
   // #passThroughMessage
@@ -139,7 +139,7 @@ class ProducerExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamples)
       .map { number =>
         val partition = 0
         val value = number.toString
-        ProducerMessage.Message(
+        ProducerMessage.single(
           new ProducerRecord(topic, partition, "key", value),
           number
         )

--- a/tests/src/test/scala/docs/scaladsl/SerializationSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/SerializationSpec.scala
@@ -29,9 +29,9 @@ import net.manub.embeddedkafka.schemaregistry.{
 }
 import org.apache.avro.specific.SpecificRecordBase
 import org.apache.avro.{AvroRuntimeException, Schema}
-// #imports
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerRecord
+// #imports
 import org.apache.kafka.common.serialization._
 // #imports
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
@@ -221,6 +221,53 @@ class SerializationSpec
     control.isShutdown.futureValue should be(Done)
     result.failed.futureValue shouldBe a[org.apache.kafka.common.errors.SerializationException]
   }
+
+  /*
+  it should "signal TBD" in assertAllStagesStopped {
+    val group = createGroupId()
+    val topic = createTopic()
+
+    val specifcRecordSettings: ConsumerSettings[String, SpecificRecord] = specificRecordConsumerSettings(group)
+
+    val byteArraySettings =
+      ConsumerSettings(system, new StringDeserializer, new ByteArrayDeserializer)
+        .withBootstrapServers(bootstrapServers)
+        .withGroupId(group)
+        .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+
+    val producerSettings: ProducerSettings[String, Array[Byte]] =
+      ProducerSettings(system, new StringSerializer, new ByteArraySerializer)
+        .withBootstrapServers(bootstrapServers)
+
+    val samples = immutable.Seq("String1", "String2", "String3")
+    val producerCompletion =
+      Source(samples)
+        .map(n => new ProducerRecord(topic, n, n.getBytes(StandardCharsets.UTF_8)))
+        .runWith(Producer.plainSink(producerSettings))
+    awaitProduce(producerCompletion)
+
+    val (control1, result1) =
+      Consumer
+        .plainSource(specifcRecordSettings, Subscriptions.topics(topic))
+        .take(samples.size.toLong)
+        .toMat(Sink.seq)(Keep.both)
+        .run()
+
+    val (control2, result2) =
+      Consumer
+        .plainSource(byteArraySettings, Subscriptions.topics(topic))
+        .take(samples.size.toLong)
+        .toMat(Sink.seq)(Keep.both)
+        .run()
+
+    sleep(30.seconds, "to see if it fails")
+
+    control1.isShutdown.futureValue should be(Done)
+    control2.isShutdown.futureValue should be(Done)
+    result1.failed.futureValue shouldBe a[org.apache.kafka.common.errors.SerializationException]
+    result2.failed.futureValue shouldBe a[org.apache.kafka.common.errors.SerializationException]
+  }
+   */
 
   it should "signal to all streams of a shared actor in same request, and keep others alive" in assertAllStagesStopped {
     val group = createGroupId()

--- a/tests/src/test/scala/docs/scaladsl/SerializationSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/SerializationSpec.scala
@@ -222,53 +222,6 @@ class SerializationSpec
     result.failed.futureValue shouldBe a[org.apache.kafka.common.errors.SerializationException]
   }
 
-  /*
-  it should "signal TBD" in assertAllStagesStopped {
-    val group = createGroupId()
-    val topic = createTopic()
-
-    val specifcRecordSettings: ConsumerSettings[String, SpecificRecord] = specificRecordConsumerSettings(group)
-
-    val byteArraySettings =
-      ConsumerSettings(system, new StringDeserializer, new ByteArrayDeserializer)
-        .withBootstrapServers(bootstrapServers)
-        .withGroupId(group)
-        .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
-
-    val producerSettings: ProducerSettings[String, Array[Byte]] =
-      ProducerSettings(system, new StringSerializer, new ByteArraySerializer)
-        .withBootstrapServers(bootstrapServers)
-
-    val samples = immutable.Seq("String1", "String2", "String3")
-    val producerCompletion =
-      Source(samples)
-        .map(n => new ProducerRecord(topic, n, n.getBytes(StandardCharsets.UTF_8)))
-        .runWith(Producer.plainSink(producerSettings))
-    awaitProduce(producerCompletion)
-
-    val (control1, result1) =
-      Consumer
-        .plainSource(specifcRecordSettings, Subscriptions.topics(topic))
-        .take(samples.size.toLong)
-        .toMat(Sink.seq)(Keep.both)
-        .run()
-
-    val (control2, result2) =
-      Consumer
-        .plainSource(byteArraySettings, Subscriptions.topics(topic))
-        .take(samples.size.toLong)
-        .toMat(Sink.seq)(Keep.both)
-        .run()
-
-    sleep(30.seconds, "to see if it fails")
-
-    control1.isShutdown.futureValue should be(Done)
-    control2.isShutdown.futureValue should be(Done)
-    result1.failed.futureValue shouldBe a[org.apache.kafka.common.errors.SerializationException]
-    result2.failed.futureValue shouldBe a[org.apache.kafka.common.errors.SerializationException]
-  }
-   */
-
   it should "signal to all streams of a shared actor in same request, and keep others alive" in assertAllStagesStopped {
     val group = createGroupId()
     val topic = createTopic(partitions = 3)

--- a/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
@@ -37,7 +37,7 @@ class TransactionsExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamp
         .source(consumerSettings, Subscriptions.topics(sourceTopic))
         .via(businessFlow)
         .map { msg =>
-          ProducerMessage.Message(new ProducerRecord[String, String](sinkTopic, msg.record.value), msg.partitionOffset)
+          ProducerMessage.single(new ProducerRecord(sinkTopic, msg.record.key, msg.record.value), msg.partitionOffset)
         }
         .to(Transactional.sink(producerSettings, transactionalId))
         .run()
@@ -76,7 +76,7 @@ class TransactionsExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamp
         .source(consumerSettings, Subscriptions.topics(sourceTopic))
         .via(businessFlow)
         .map { msg =>
-          ProducerMessage.Message(new ProducerRecord[String, String](sinkTopic, msg.record.value), msg.partitionOffset)
+          ProducerMessage.single(new ProducerRecord(sinkTopic, msg.record.key, msg.record.value), msg.partitionOffset)
         }
         // side effect out the `Control` materialized value because it can't be propagated through the `RestartSource`
         .mapMaterializedValue(c => innerControl.set(c))


### PR DESCRIPTION
* Add `single`, `multi` and `passThrough` methods for constructing `Envelope` sub-classes
* The factory methods allow for better type-inference
* A few cases still need explicit types