### PR TITLE
Testkit structure, testing helpers, docs

### DIFF
--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/BenchmarksBase.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/BenchmarksBase.scala
@@ -5,7 +5,7 @@
 package akka.kafka.benchmarks
 
 import akka.kafka.benchmarks.app.RunTestCommand
-import akka.kafka.scaladsl.ScalatestKafkaSpec
+import akka.kafka.testkit.scaladsl.ScalatestKafkaSpec
 import org.scalatest.FlatSpecLike
 
 abstract class BenchmarksBase(name: String) extends ScalatestKafkaSpec(0) with FlatSpecLike {

--- a/build.sbt
+++ b/build.sbt
@@ -215,7 +215,6 @@ lazy val docs = project
   .settings(
     name := "Alpakka Kafka",
     skip in publish := true,
-    paradoxNavigationDepth := 3,
     paradoxGroups := Map("Language" -> Seq("Java", "Scala")),
     paradoxProperties ++= Map(
       "project.url" -> "https://doc.akka.io/docs/akka-stream-kafka/current/",

--- a/core/src/main/scala/akka/kafka/internal/CommittableSources.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommittableSources.scala
@@ -125,7 +125,7 @@ private final case class KafkaAsyncConsumerCommitterRef(consumerActor: ActorRef,
     case b: CommittableOffsetBatchImpl =>
       val futures = b.offsetsAndMetadata.groupBy(_._1.groupId).map {
         case (groupId, offsetsMap) =>
-          val committer = b.stages.getOrElse(
+          val committer = b.committers.getOrElse(
             groupId,
             throw new IllegalStateException(s"Unknown committer, got [$groupId]")
           )

--- a/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
+++ b/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
@@ -165,7 +165,9 @@ private[kafka] final class CommittableOffsetBatchImpl(
                 acc.updated(groupId, committer)
             }
         }
-        new CommittableOffsetBatchImpl(newOffsetsAndMetadata, newCommitters, batchSize + committableOffsetBatch.batchSize)
+        new CommittableOffsetBatchImpl(newOffsetsAndMetadata,
+                                       newCommitters,
+                                       batchSize + committableOffsetBatch.batchSize)
       case _ =>
         throw new IllegalArgumentException(
           s"Unknown CommittableOffsetBatch, got [${committableOffsetBatch.getClass.getName}], " +

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -18,6 +18,7 @@ This **Alpakka Kafka connector** lets you connect [Apache Kafka](https://kafka.a
 * [Transactions](transactions.md)
 * [deser](serialization.md)
 * [debug](debugging.md)
+* [test](testing.md)
 * [Snapshots](snapshots.md)
 
 @@@

--- a/docs/src/main/paradox/testing.md
+++ b/docs/src/main/paradox/testing.md
@@ -1,0 +1,18 @@
+# Testing
+
+To simplify testing of streaming integrations with Alpakka Kafka, it provides the Alpakka Kafka testkit.
+
+@@dependency [Maven,sbt,Gradle] {
+  group=com.typesafe.akka
+  artifact=akka-stream-kafka-testkit_$scala.binary.version$
+  version=$version$
+}
+
+## Mocking the Consumer or Producer
+
+The testkit contains factories to create the messages emitted by Consumer sources in `akka.kafka.testkit.ConsumerResultFactory` and Producer flows in `akka.kafka.testkit.ProducerResultFactory`.
+
+To create the materialized value of Consumer sources, `akka.kafka.testkit.scaladsl.ConsumerControlFactory` offers a wrapped `KillSwitch`.
+
+Scala
+: @@snip [snip](/tests/src/test/scala/docs/scaladsl/TestkitSamplesSpec.scala) { #factories }

--- a/docs/src/main/paradox/testing.md
+++ b/docs/src/main/paradox/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-To simplify testing of streaming integrations with Alpakka Kafka, it provides the Alpakka Kafka testkit.
+To simplify testing of streaming integrations with Alpakka Kafka, it provides the **Alpakka Kafka testkit**.
 
 @@dependency [Maven,sbt,Gradle] {
   group=com.typesafe.akka
@@ -8,14 +8,61 @@ To simplify testing of streaming integrations with Alpakka Kafka, it provides th
   version=$version$
 }
 
+Note that Akka testkits do not promise binary compatibility. The API might be changed even between minor versions.
+
+
 ## Mocking the Consumer or Producer
 
 The testkit contains factories to create the messages emitted by Consumer sources in `akka.kafka.testkit.ConsumerResultFactory` and Producer flows in `akka.kafka.testkit.ProducerResultFactory`.
 
-To create the materialized value of Consumer sources, `akka.kafka.testkit.scaladsl.ConsumerControlFactory` offers a wrapped `KillSwitch`.
+To create the materialized value of Consumer sources, @scala[`akka.kafka.testkit.scaladsl.ConsumerControlFactory`]@java[`akka.kafka.testkit.javadsl.ConsumerControlFactory`] offers a wrapped `KillSwitch`.
 
 Scala
 : @@snip [snip](/tests/src/test/scala/docs/scaladsl/TestkitSamplesSpec.scala) { #factories }
 
 Java
 : @@snip [snip](/tests/src/test/java/docs/javadsl/TestkitSamplesTest.java) { #factories }
+
+
+## Testing with an embedded Kafka server
+
+To test the Alpakka Kafka connector the [Embedded Kafka library](https://github.com/manub/scalatest-embedded-kafka) is an important tool as it helps to easily start and stop Kafka brokers from test cases.
+
+The testkit contains helper classes used by the tests in the Alpakka Kafka connector and may be used for other testing, as well.
+
+
+### Testing from Java code
+
+Test classes may extend `akka.kafka.testkit.javadsl.EmbeddedKafkaTest` to get access to 
+* starting and stopping Kafka brokers (`startEmbeddedKafka(kafkaPort, replicationFactor)` and `stopEmbeddedKafka()`),
+* preconfigured consumer settings (`ConsumerSettings<String, String> consumerDefaults`),
+* preconfigured producer settings (`ProducerSettings<String, String> producerDefaults`), and
+* unique topic creation (`createTopic(int number, int partitions, int replication)`).
+
+The example below shows a skeleton test class for use with JUnit.
+
+Java
+: @@snip [snip](/tests/src/test/java/docs/javadsl/AssignmentTest.java) { #testkit }
+
+
+### Testing from Scala code
+
+The `KafkaSpec` class offers access to 
+* preconfigured consumer settings (`ConsumerSettings<String, String> consumerDefaults`),
+* preconfigured producer settings (`ProducerSettings<String, String> producerDefaults`),
+* unique topic creation (`createTopic(number: Int = 0, partitions: Int = 1, replication: Int = 1)`),
+* an implicit `LoggingAdapter` for use with the `log()` operator, and
+* other goodies.
+
+`EmbeddedKafkaLike` extends `KafkaSpec` to add automatic starting and stopping of the embedded Kafka broker.
+
+Most Alpakka Kafka tests implemented in Scala use [Scalatest](http://www.scalatest.org/) with the mix-ins shown below.
+
+Scala
+: @@snip [snip](/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala) { #testkit }
+
+
+With this `SpecBase` class test classes can extend it to automatically start and stop a Kafka broker to test with.
+
+Scala
+: @@snip [snip](/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala) { #testkit }

--- a/docs/src/main/paradox/testing.md
+++ b/docs/src/main/paradox/testing.md
@@ -16,3 +16,6 @@ To create the materialized value of Consumer sources, `akka.kafka.testkit.scalad
 
 Scala
 : @@snip [snip](/tests/src/test/scala/docs/scaladsl/TestkitSamplesSpec.scala) { #factories }
+
+Java
+: @@snip [snip](/tests/src/test/java/docs/javadsl/TestkitSamplesTest.java) { #factories }

--- a/testkit/src/main/scala/akka/kafka/akka/kafka/testkit/ConsumerResultFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/akka/kafka/testkit/ConsumerResultFactory.scala
@@ -1,0 +1,54 @@
+package akka.kafka.akka.kafka.testkit
+
+import java.util.concurrent.CompletionStage
+
+import akka.Done
+import akka.annotation.ApiMayChange
+import akka.kafka.ConsumerMessage
+import akka.kafka.ConsumerMessage.{CommittableOffset, GroupTopicPartition, PartitionOffset}
+import org.apache.kafka.clients.consumer.ConsumerRecord
+
+import scala.compat.java8.FutureConverters._
+import scala.concurrent.Future
+
+/**
+ * Factory methods to create instances that normally are emitted by [[akka.kafka.scaladsl.Consumer]] and [[akka.kafka.javadsl.Consumer]] flows.
+ */
+@ApiMayChange
+object ConsumerResultFactory {
+
+  def partitionOffset(groupId: String, topic: String, partition: Int, offset: Long): ConsumerMessage.PartitionOffset =
+    ConsumerMessage.PartitionOffset(ConsumerMessage.GroupTopicPartition(groupId, topic, partition), offset)
+
+  def partitionOffset(key: GroupTopicPartition, offset: Long) = ConsumerMessage.PartitionOffset(key, offset)
+
+  def committableOffset(groupId: String,
+                        topic: String,
+                        partition: Int,
+                        offset: Long,
+                        metadata: String): ConsumerMessage.CommittableOffset =
+    committableOffset(partitionOffset(groupId, topic, partition, offset), metadata)
+
+  def committableOffset(partitionOffset: ConsumerMessage.PartitionOffset,
+                        metadata: String): ConsumerMessage.CommittableOffset = {
+    val metadata2 = metadata
+    val partitionOffset2 = partitionOffset
+    new ConsumerMessage.CommittableOffsetMetadata {
+      override val metadata: String = metadata2
+      override val partitionOffset: ConsumerMessage.PartitionOffset = partitionOffset2
+      override def commitScaladsl(): Future[Done] = Future.successful(Done)
+      override def commitJavadsl(): CompletionStage[Done] = commitScaladsl().toJava
+    }
+  }
+
+  def committableMessage[K, V](
+      record: ConsumerRecord[K, V],
+      committableOffset: CommittableOffset
+  ): ConsumerMessage.CommittableMessage[K, V] = ConsumerMessage.CommittableMessage(record, committableOffset)
+
+  def transactionalMessage[K, V](
+      record: ConsumerRecord[K, V],
+      partitionOffset: PartitionOffset
+  ): ConsumerMessage.TransactionalMessage[K, V] = ConsumerMessage.TransactionalMessage(record, partitionOffset)
+
+}

--- a/testkit/src/main/scala/akka/kafka/akka/kafka/testkit/ProducerResultFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/akka/kafka/testkit/ProducerResultFactory.scala
@@ -1,0 +1,36 @@
+package akka.kafka.akka.kafka.testkit
+
+import akka.annotation.ApiMayChange
+import akka.kafka.ProducerMessage
+import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata}
+
+import scala.collection.immutable
+import scala.collection.JavaConverters._
+
+/**
+ * Factory methods to create instances that normally are emitted by [[akka.kafka.scaladsl.Producer]] and [[akka.kafka.javadsl.Producer]] flows.
+ */
+@ApiMayChange
+object ProducerResultFactory {
+
+  def result[K, V, PassThrough](
+      metadata: RecordMetadata,
+      message: ProducerMessage.Message[K, V, PassThrough]
+  ): ProducerMessage.Result[K, V, PassThrough] = ProducerMessage.Result(metadata, message)
+
+  def multiResultPart[K, V](
+      metadata: RecordMetadata,
+      record: ProducerRecord[K, V]
+  ): ProducerMessage.MultiResultPart[K, V] = ProducerMessage.MultiResultPart(metadata, record)
+
+  def multiResult[K, V, PassThrough](
+      parts: immutable.Seq[ProducerMessage.MultiResultPart[K, V]],
+      passThrough: PassThrough
+  ): ProducerMessage.MultiResult[K, V, PassThrough] = ProducerMessage.MultiResult(parts, passThrough)
+
+  /** Java API */
+  def multiResult[K, V, PassThrough](
+      parts: java.util.Collection[ProducerMessage.MultiResultPart[K, V]],
+      passThrough: PassThrough
+  ): ProducerMessage.MultiResult[K, V, PassThrough] = ProducerMessage.MultiResult(parts.asScala.toList, passThrough)
+}

--- a/testkit/src/main/scala/akka/kafka/testkit/ConsumerResultFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/ConsumerResultFactory.scala
@@ -1,4 +1,9 @@
-package akka.kafka.akka.kafka.testkit
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.testkit
 
 import java.util.concurrent.CompletionStage
 
@@ -8,8 +13,8 @@ import akka.kafka.ConsumerMessage
 import akka.kafka.ConsumerMessage.{CommittableOffset, GroupTopicPartition, PartitionOffset}
 import org.apache.kafka.clients.consumer.ConsumerRecord
 
-import scala.compat.java8.FutureConverters._
 import scala.concurrent.Future
+import scala.compat.java8.FutureConverters._
 
 /**
  * Factory methods to create instances that normally are emitted by [[akka.kafka.scaladsl.Consumer]] and [[akka.kafka.javadsl.Consumer]] flows.

--- a/testkit/src/main/scala/akka/kafka/testkit/ConsumerResultFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/ConsumerResultFactory.scala
@@ -13,8 +13,8 @@ import akka.kafka.ConsumerMessage
 import akka.kafka.ConsumerMessage.{CommittableOffset, GroupTopicPartition, PartitionOffset}
 import org.apache.kafka.clients.consumer.ConsumerRecord
 
-import scala.concurrent.Future
 import scala.compat.java8.FutureConverters._
+import scala.concurrent.Future
 
 /**
  * Factory methods to create instances that normally are emitted by [[akka.kafka.scaladsl.Consumer]] and [[akka.kafka.javadsl.Consumer]] flows.

--- a/testkit/src/main/scala/akka/kafka/testkit/ProducerResultFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/ProducerResultFactory.scala
@@ -8,15 +8,26 @@ package akka.kafka.testkit
 import akka.annotation.ApiMayChange
 import akka.kafka.ProducerMessage
 import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata}
+import org.apache.kafka.common.TopicPartition
 
-import scala.collection.immutable
 import scala.collection.JavaConverters._
+import scala.collection.immutable
 
 /**
  * Factory methods to create instances that normally are emitted by [[akka.kafka.scaladsl.Producer]] and [[akka.kafka.javadsl.Producer]] flows.
  */
 @ApiMayChange
 object ProducerResultFactory {
+
+  def recordMetadata(msg: ProducerRecord[_, _]): RecordMetadata =
+    new RecordMetadata(new TopicPartition(msg.topic, msg.partition), -1L, 1L, msg.timestamp(), 233L, 2, 2)
+
+  def recordMetadata(topic: String, partition: Int, offset: Long): RecordMetadata =
+    new RecordMetadata(new TopicPartition(topic, partition), offset, 0L, 12345L, 233L, 2, 2)
+
+  def result[K, V, PassThrough](
+      message: ProducerMessage.Message[K, V, PassThrough]
+  ): ProducerMessage.Result[K, V, PassThrough] = ProducerMessage.Result(recordMetadata(message.record), message)
 
   def result[K, V, PassThrough](
       metadata: RecordMetadata,

--- a/testkit/src/main/scala/akka/kafka/testkit/ProducerResultFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/ProducerResultFactory.scala
@@ -1,4 +1,9 @@
-package akka.kafka.akka.kafka.testkit
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.testkit
 
 import akka.annotation.ApiMayChange
 import akka.kafka.ProducerMessage

--- a/testkit/src/main/scala/akka/kafka/testkit/ProducerResultFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/ProducerResultFactory.scala
@@ -19,8 +19,12 @@ import scala.collection.immutable
 @ApiMayChange
 object ProducerResultFactory {
 
-  def recordMetadata(msg: ProducerRecord[_, _]): RecordMetadata =
-    new RecordMetadata(new TopicPartition(msg.topic, msg.partition), -1L, 1L, msg.timestamp(), 233L, 2, 2)
+  def recordMetadata(msg: ProducerRecord[_, _]): RecordMetadata = {
+    // null checks are required on Scala 2.11
+    val partition = if (msg.partition == null) 0 else msg.partition.toInt
+    val timestamp = if (msg.timestamp == null) 0L else msg.timestamp.toLong
+    new RecordMetadata(new TopicPartition(msg.topic, partition), -1L, 1L, timestamp, 233L, 2, 2)
+  }
 
   def recordMetadata(topic: String, partition: Int, offset: Long): RecordMetadata =
     new RecordMetadata(new TopicPartition(topic, partition), offset, 0L, 12345L, 233L, 2, 2)

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
@@ -30,11 +30,12 @@ trait KafkaTestKit {
     ProducerSettings(system, new StringSerializer, new StringSerializer)
       .withBootstrapServers(bootstrapServers)
 
-  val consumerDefaults: ConsumerSettings[String, String] = ConsumerSettings(system, new StringDeserializer, new StringDeserializer)
-    .withBootstrapServers(bootstrapServers)
-    .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
-    .withWakeupTimeout(10.seconds)
-    .withMaxWakeups(10)
+  val consumerDefaults: ConsumerSettings[String, String] =
+    ConsumerSettings(system, new StringDeserializer, new StringDeserializer)
+      .withBootstrapServers(bootstrapServers)
+      .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+      .withWakeupTimeout(10.seconds)
+      .withMaxWakeups(10)
 
   val committerDefaults = CommitterSettings(system)
 

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
@@ -30,7 +30,7 @@ trait KafkaTestKit {
     ProducerSettings(system, new StringSerializer, new StringSerializer)
       .withBootstrapServers(bootstrapServers)
 
-  val consumerDefaults = ConsumerSettings(system, new StringDeserializer, new StringDeserializer)
+  val consumerDefaults: ConsumerSettings[String, String] = ConsumerSettings(system, new StringDeserializer, new StringDeserializer)
     .withBootstrapServers(bootstrapServers)
     .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
     .withWakeupTimeout(10.seconds)

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
@@ -3,11 +3,12 @@
  * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
  */
 
-package akka.kafka.internal
+package akka.kafka.testkit.internal
+
 import java.util
-import java.util.{Arrays, Properties}
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.{Arrays, Properties}
 
 import akka.actor.ActorSystem
 import akka.kafka.{CommitterSettings, ConsumerSettings, ProducerSettings}
@@ -15,7 +16,7 @@ import kafka.admin.{AdminClient => OldAdminClient}
 import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
-import org.slf4j.{Logger, LoggerFactory}
+import org.slf4j.Logger
 
 import scala.concurrent.duration._
 
@@ -80,7 +81,7 @@ trait KafkaTestKit {
     topicName
   }
 
-  def sleepMillis(ms: Int, msg: String): Unit = {
+  def sleepMillis(ms: Long, msg: String): Unit = {
     log.debug(s"sleeping $ms ms $msg")
     Thread.sleep(ms)
   }

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/TestFrameworkInterface.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/TestFrameworkInterface.scala
@@ -3,7 +3,7 @@
  * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
  */
 
-package akka.kafka.internal
+package akka.kafka.testkit.internal
 
 import org.scalatest.{BeforeAndAfterAll, Suite}
 

--- a/testkit/src/main/scala/akka/kafka/testkit/javadsl/ConsumerControlFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/javadsl/ConsumerControlFactory.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.testkit.javadsl
+
+import java.util.concurrent.{CompletableFuture, CompletionStage, Executor}
+
+import akka.Done
+import akka.annotation.ApiMayChange
+import akka.kafka.javadsl.Consumer
+import akka.stream.javadsl.{Flow, Source}
+import akka.stream.{scaladsl, KillSwitch, KillSwitches}
+import org.apache.kafka.common.{Metric, MetricName}
+
+/**
+ * Helper factory to create [[akka.kafka.javadsl.Consumer.Control]] instances when
+ * testing without a Kafka broker.
+ */
+@ApiMayChange
+object ConsumerControlFactory {
+
+  def attachControl[A, B](source: Source[A, B]): Source[A, Consumer.Control] =
+    source
+      .viaMat(controlFlow(), (a: B, b: Consumer.Control) => b)
+
+  def controlFlow[A](): Flow[A, A, Consumer.Control] =
+    scaladsl
+      .Flow[A]
+      .viaMat(KillSwitches.single[A])(scaladsl.Keep.right)
+      .mapMaterializedValue(killSwitch => control(killSwitch))
+      .asJava
+
+  def control(killSwitch: KillSwitch): Consumer.Control = new FakeControl(killSwitch)
+
+  class FakeControl(val killSwitch: KillSwitch) extends Consumer.Control {
+
+    val shutdownPromise: CompletableFuture[Done] = new CompletableFuture[Done]()
+
+    override def stop(): CompletionStage[Done] = {
+      killSwitch.shutdown()
+      shutdownPromise.complete(Done)
+      shutdownPromise
+    }
+
+    override def shutdown(): CompletionStage[Done] = stop()
+
+    override def isShutdown: CompletionStage[Done] = shutdownPromise
+
+    override def getMetrics: CompletionStage[java.util.Map[MetricName, Metric]] = ???
+
+    override def drainAndShutdown[T](
+        streamCompletion: CompletionStage[T],
+        ec: Executor
+    ): CompletionStage[T] = stop().thenCompose(_ => streamCompletion)
+
+  }
+
+}

--- a/testkit/src/main/scala/akka/kafka/testkit/javadsl/EmbeddedKafkaTest.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/javadsl/EmbeddedKafkaTest.scala
@@ -3,7 +3,7 @@
  * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
  */
 
-package akka.kafka.javadsl
+package akka.kafka.testkit.javadsl
 
 import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 

--- a/testkit/src/main/scala/akka/kafka/testkit/javadsl/KafkaTest.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/javadsl/KafkaTest.scala
@@ -3,9 +3,9 @@
  * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
  */
 
-package akka.kafka.javadsl
+package akka.kafka.testkit.javadsl
 
-import akka.kafka.internal.KafkaTestKit
+import akka.kafka.testkit.internal.KafkaTestKit
 import org.slf4j.{Logger, LoggerFactory}
 
 abstract class KafkaTest extends KafkaTestKit {

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/ConsumerControlFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/ConsumerControlFactory.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
 package akka.kafka.testkit.scaladsl
 
 import akka.Done

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/ConsumerControlFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/ConsumerControlFactory.scala
@@ -1,0 +1,51 @@
+package akka.kafka.testkit.scaladsl
+
+import akka.Done
+import akka.annotation.ApiMayChange
+import akka.kafka.scaladsl.Consumer
+import akka.stream.scaladsl.{Flow, Keep, Source}
+import akka.stream.{KillSwitch, KillSwitches}
+import org.apache.kafka.common.{Metric, MetricName}
+
+import scala.concurrent.{Future, Promise}
+
+/**
+ * Helper factory to create [[akka.kafka.scaladsl.Consumer.Control]] instances when
+ * testing without a Kafka broker.
+ */
+@ApiMayChange
+object ConsumerControlFactory {
+
+  def attachControl[A, B](source: Source[A, B]): Source[A, Consumer.Control] =
+    source
+      .viaMat(controlFlow())(Keep.right)
+
+  def controlFlow[A](): Flow[A, A, Consumer.Control] =
+    Flow[A]
+      .viaMat(KillSwitches.single[A])(Keep.right)
+      .mapMaterializedValue(killSwitch => control(killSwitch))
+
+  def control(killSwitch: KillSwitch): Consumer.Control = new FakeControl(killSwitch)
+
+  class FakeControl(val killSwitch: KillSwitch) extends Consumer.Control {
+
+    val shutdownPromise = Promise[Done]
+
+    override def stop(): Future[Done] = {
+      killSwitch.shutdown()
+      shutdownPromise.trySuccess(Done)
+      shutdownPromise.future
+    }
+
+    override def shutdown(): Future[Done] = {
+      killSwitch.shutdown()
+      shutdownPromise.trySuccess(Done)
+      shutdownPromise.future
+    }
+
+    override def isShutdown: Future[Done] = shutdownPromise.future
+
+    override def metrics: Future[Map[MetricName, Metric]] = ???
+  }
+
+}

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
@@ -3,7 +3,7 @@
  * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
  */
 
-package akka.kafka.scaladsl
+package akka.kafka.testkit.scaladsl
 
 import java.util
 import java.util.concurrent.TimeUnit
@@ -12,8 +12,9 @@ import akka.Done
 import akka.actor.ActorSystem
 import akka.event.LoggingAdapter
 import akka.kafka._
-import akka.kafka.internal.KafkaTestKit
 import akka.kafka.scaladsl.Consumer.Control
+import akka.kafka.scaladsl.{Consumer, Producer}
+import akka.kafka.testkit.internal.KafkaTestKit
 import akka.stream.scaladsl.{Keep, Source}
 import akka.stream.testkit.TestSubscriber
 import akka.stream.testkit.scaladsl.TestSink
@@ -25,8 +26,8 @@ import org.apache.kafka.clients.producer.{Producer => KProducer, ProducerRecord}
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.annotation.tailrec
-import scala.collection.immutable
 import scala.collection.JavaConverters._
+import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/ScalatestKafkaSpec.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/ScalatestKafkaSpec.scala
@@ -3,9 +3,9 @@
  * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
  */
 
-package akka.kafka.scaladsl
+package akka.kafka.testkit.scaladsl
 
-import akka.kafka.internal.TestFrameworkInterface
+import akka.kafka.testkit.internal.TestFrameworkInterface
 import org.scalatest.Suite
 
 abstract class ScalatestKafkaSpec(override val kafkaPort: Int)

--- a/tests/src/it/scala/akka/kafka/PartitionedSourceFailoverSpec.scala
+++ b/tests/src/it/scala/akka/kafka/PartitionedSourceFailoverSpec.scala
@@ -2,7 +2,8 @@ package akka.kafka
 
 import akka.Done
 import akka.kafka.scaladsl.Consumer.DrainingControl
-import akka.kafka.scaladsl.{Consumer, Producer, ScalatestKafkaSpec}
+import akka.kafka.scaladsl.{Consumer, Producer}
+import akka.kafka.testkit.scaladsl.ScalatestKafkaSpec
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import com.spotify.docker.client.DefaultDockerClient

--- a/tests/src/it/scala/akka/kafka/PlainSourceFailoverSpec.scala
+++ b/tests/src/it/scala/akka/kafka/PlainSourceFailoverSpec.scala
@@ -1,6 +1,7 @@
 package akka.kafka
 
-import akka.kafka.scaladsl.{Consumer, Producer, ScalatestKafkaSpec}
+import akka.kafka.scaladsl.{Consumer, Producer}
+import akka.kafka.testkit.scaladsl.ScalatestKafkaSpec
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import com.spotify.docker.client.DefaultDockerClient

--- a/tests/src/test/java/docs/javadsl/AssignmentTest.java
+++ b/tests/src/test/java/docs/javadsl/AssignmentTest.java
@@ -12,13 +12,17 @@ import akka.kafka.KafkaPorts;
 import akka.kafka.ManualSubscription;
 import akka.kafka.Subscriptions;
 import akka.kafka.javadsl.Consumer;
+// #testkit
 import akka.kafka.testkit.javadsl.EmbeddedKafkaTest;
+// #testkit
 import akka.kafka.javadsl.Producer;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
+// #testkit
 import akka.stream.testkit.javadsl.StreamTestKit;
+// #testkit
 import akka.testkit.javadsl.TestKit;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -37,10 +41,13 @@ import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertEquals;
 
+// #testkit
+
 public class AssignmentTest extends EmbeddedKafkaTest {
 
   private static final ActorSystem sys = ActorSystem.create("AssignmentTest");
   private static final Materializer mat = ActorMaterializer.create(sys);
+  private static final int kafkaPort = KafkaPorts.AssignmentTest();
 
   @Override
   public ActorSystem system() {
@@ -49,13 +56,15 @@ public class AssignmentTest extends EmbeddedKafkaTest {
 
   @Override
   public String bootstrapServers() {
-    return "localhost:" + KafkaPorts.AssignmentTest();
+    return "localhost:" + kafkaPort;
   }
 
   @BeforeClass
   public static void beforeClass() {
-    startEmbeddedKafka(KafkaPorts.AssignmentTest(), 1);
+    startEmbeddedKafka(kafkaPort, 1);
   }
+
+  // #testkit
 
   @Test
   public void mustConsumeFromTheSpecifiedSingleTopic()
@@ -229,6 +238,7 @@ public class AssignmentTest extends EmbeddedKafkaTest {
     assertEquals(0, oldMessages);
   }
 
+  // #testkit
   @After
   public void after() {
     StreamTestKit.assertAllStagesStopped(mat);
@@ -240,3 +250,4 @@ public class AssignmentTest extends EmbeddedKafkaTest {
     TestKit.shutdownActorSystem(sys);
   }
 }
+// #testkit

--- a/tests/src/test/java/docs/javadsl/AssignmentTest.java
+++ b/tests/src/test/java/docs/javadsl/AssignmentTest.java
@@ -12,7 +12,7 @@ import akka.kafka.KafkaPorts;
 import akka.kafka.ManualSubscription;
 import akka.kafka.Subscriptions;
 import akka.kafka.javadsl.Consumer;
-import akka.kafka.javadsl.EmbeddedKafkaTest;
+import akka.kafka.testkit.javadsl.EmbeddedKafkaTest;
 import akka.kafka.javadsl.Producer;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;

--- a/tests/src/test/java/docs/javadsl/TestkitSamplesTest.java
+++ b/tests/src/test/java/docs/javadsl/TestkitSamplesTest.java
@@ -81,7 +81,8 @@ public class TestkitSamplesTest {
     // create a source imitating the Consumer.committableSource
     Source<ConsumerMessage.CommittableMessage<String, String>, Consumer.Control>
         mockedKafkaConsumerSource =
-            Source.from(elements).viaMat(ConsumerControlFactory.controlFlow(), Keep.right());
+            Source.cycle(elements::iterator)
+                .viaMat(ConsumerControlFactory.controlFlow(), Keep.right());
 
     // create a source imitating the Producer.flexiFlow
     Flow<
@@ -126,7 +127,10 @@ public class TestkitSamplesTest {
             .run(mat);
     // #factories
 
-    stream.first().shutdown();
+    Thread.sleep(1 * 1000L);
+    assertThat(
+        stream.first().shutdown().toCompletableFuture().get(2, TimeUnit.SECONDS),
+        is(Done.getInstance()));
     assertThat(
         stream.second().toCompletableFuture().get(2, TimeUnit.SECONDS), is(Done.getInstance()));
   }

--- a/tests/src/test/java/docs/javadsl/TestkitSamplesTest.java
+++ b/tests/src/test/java/docs/javadsl/TestkitSamplesTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package docs.javadsl;
+
+import akka.Done;
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.japi.Pair;
+import akka.kafka.ConsumerMessage;
+import akka.kafka.ProducerMessage;
+import akka.kafka.javadsl.Consumer;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.Keep;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.stream.testkit.javadsl.StreamTestKit;
+import akka.testkit.javadsl.TestKit;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.*;
+
+// #factories
+import akka.kafka.testkit.ConsumerResultFactory;
+import akka.kafka.testkit.ProducerResultFactory;
+import akka.kafka.testkit.javadsl.ConsumerControlFactory;
+// #factories
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+public class TestkitSamplesTest {
+
+  private static final ActorSystem sys = ActorSystem.create("TestkitTest");
+  private static final Materializer mat = ActorMaterializer.create(sys);
+
+  @AfterClass
+  public static void afterClass() {
+    TestKit.shutdownActorSystem(sys);
+  }
+
+  @After
+  public void after() {
+    StreamTestKit.assertAllStagesStopped(mat);
+  }
+
+  @Test
+  public void withoutBrokerTesting() throws Exception {
+    String topic = "topic";
+    String targetTopic = "target-topic";
+    String groupId = "group1";
+    long startOffset = 100L;
+    int partition = 0;
+
+    // #factories
+
+    // create elements emitted by the mocked Consumer
+    List<ConsumerMessage.CommittableMessage<String, String>> elements =
+        Arrays.asList(
+            ConsumerResultFactory.committableMessage(
+                new ConsumerRecord<>(topic, partition, startOffset, "key", "value 1"),
+                ConsumerResultFactory.committableOffset(
+                    groupId, topic, partition, startOffset, "metadata")),
+            ConsumerResultFactory.committableMessage(
+                new ConsumerRecord<>(topic, partition, startOffset + 1, "key", "value 2"),
+                ConsumerResultFactory.committableOffset(
+                    groupId, topic, partition, startOffset + 1, "metadata 2")));
+
+    // create a source imitating the Consumer.committableSource
+    Source<ConsumerMessage.CommittableMessage<String, String>, Consumer.Control>
+        mockedKafkaConsumerSource =
+            Source.from(elements).viaMat(ConsumerControlFactory.controlFlow(), Keep.right());
+
+    // create a source imitating the Producer.flexiFlow
+    Flow<
+            ProducerMessage.Envelope<String, String, ConsumerMessage.CommittableOffset>,
+            ProducerMessage.Results<String, String, ConsumerMessage.CommittableOffset>,
+            NotUsed>
+        mockedKafkaProducerFlow =
+            Flow
+                .<ProducerMessage.Envelope<String, String, ConsumerMessage.CommittableOffset>>
+                    create()
+                .map(
+                    msg -> {
+                      if (msg instanceof ProducerMessage.Message) {
+                        ProducerMessage.Message<String, String, ConsumerMessage.CommittableOffset>
+                            msg2 =
+                                (ProducerMessage.Message<
+                                        String, String, ConsumerMessage.CommittableOffset>)
+                                    msg;
+                        return ProducerResultFactory.result(msg2);
+                      } else throw new RuntimeException("unexpected element: " + msg);
+                    });
+
+    // run the flow as if it was connected to a Kafka broker
+    Pair<Consumer.Control, CompletionStage<Done>> stream =
+        mockedKafkaConsumerSource
+            .map(
+                msg -> {
+                  ProducerMessage.Envelope<String, String, ConsumerMessage.CommittableOffset>
+                      message =
+                          new ProducerMessage.Message<>(
+                              new ProducerRecord<>(
+                                  targetTopic, msg.record().key(), msg.record().value()),
+                              msg.committableOffset());
+                  return message;
+                })
+            .via(mockedKafkaProducerFlow)
+            .map(ProducerMessage.Results::passThrough)
+            .groupedWithin(10, Duration.ofSeconds(5))
+            .map(ConsumerMessage::createCommittableOffsetBatch)
+            .mapAsync(3, ConsumerMessage.Committable::commitJavadsl)
+            .toMat(Sink.ignore(), Keep.both())
+            .run(mat);
+    // #factories
+
+    stream.first().shutdown();
+    assertThat(
+        stream.second().toCompletableFuture().get(2, TimeUnit.SECONDS), is(Done.getInstance()));
+  }
+}

--- a/tests/src/test/scala/akka/kafka/javadsl/EmbeddedKafkaWithSchemaRegistryTest.scala
+++ b/tests/src/test/scala/akka/kafka/javadsl/EmbeddedKafkaWithSchemaRegistryTest.scala
@@ -4,7 +4,7 @@
  */
 
 package akka.kafka.javadsl
-
+import akka.kafka.testkit.javadsl.KafkaTest
 import net.manub.embeddedkafka.schemaregistry.{
   EmbeddedKafkaConfigWithSchemaRegistryImpl,
   EmbeddedKafkaWithSchemaRegistry

--- a/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
@@ -5,6 +5,7 @@
 
 package akka.kafka.scaladsl
 
+// #testkit
 import akka.kafka.testkit.scaladsl.{EmbeddedKafkaLike, ScalatestKafkaSpec}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{Matchers, WordSpecLike}
@@ -16,3 +17,4 @@ abstract class SpecBase(kafkaPort: Int)
     with Matchers
     with ScalaFutures
     with Eventually
+// #testkit

--- a/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
@@ -5,6 +5,7 @@
 
 package akka.kafka.scaladsl
 
+import akka.kafka.testkit.scaladsl.{EmbeddedKafkaLike, ScalatestKafkaSpec}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{Matchers, WordSpecLike}
 

--- a/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala
@@ -8,13 +8,17 @@ package docs.scaladsl
 import akka.kafka.scaladsl.{Consumer, Producer, SpecBase}
 import akka.kafka.{KafkaPorts, Subscriptions}
 import akka.stream.scaladsl.{Sink, Source}
+// #testkit
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import net.manub.embeddedkafka.EmbeddedKafkaConfig
+// #testkit
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 
 import scala.collection.immutable
 import scala.concurrent.duration._
+
+// #testkit
 
 class AssignmentSpec extends SpecBase(kafkaPort = KafkaPorts.AssignmentSpec) {
 
@@ -26,6 +30,7 @@ class AssignmentSpec extends SpecBase(kafkaPort = KafkaPorts.AssignmentSpec) {
                         Map(
                           "offsets.topic.replication.factor" -> "1"
                         ))
+  // #testkit
 
   "subscription with partition assignment" must {
 
@@ -148,5 +153,7 @@ class AssignmentSpec extends SpecBase(kafkaPort = KafkaPorts.AssignmentSpec) {
       messages.futureValue.map(_ - now).count(_ > 5000) shouldBe 0
     }
   }
+  // #testkit
 
 }
+// #testkit

--- a/tests/src/test/scala/docs/scaladsl/DocsSpecBase.scala
+++ b/tests/src/test/scala/docs/scaladsl/DocsSpecBase.scala
@@ -6,8 +6,8 @@
 package docs.scaladsl
 
 import akka.NotUsed
-import akka.kafka.internal.TestFrameworkInterface
-import akka.kafka.scaladsl.{EmbeddedKafkaLike, KafkaSpec}
+import akka.kafka.testkit.scaladsl.{EmbeddedKafkaLike, KafkaSpec}
+import akka.kafka.testkit.internal.TestFrameworkInterface
 import akka.stream.scaladsl.Flow
 import org.scalatest.{FlatSpecLike, Matchers, Suite}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}

--- a/tests/src/test/scala/docs/scaladsl/SerializationSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/SerializationSpec.scala
@@ -9,9 +9,10 @@ import java.nio.charset.StandardCharsets
 
 import akka.Done
 import akka.kafka._
-import akka.kafka.internal.TestFrameworkInterface
+import akka.kafka.testkit.internal.TestFrameworkInterface
 import akka.kafka.scaladsl.Consumer.DrainingControl
 import akka.kafka.scaladsl._
+import akka.kafka.testkit.scaladsl.KafkaSpec
 import akka.stream.{ActorAttributes, Supervision}
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped

--- a/tests/src/test/scala/docs/scaladsl/TestkitSamplesSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/TestkitSamplesSpec.scala
@@ -1,0 +1,89 @@
+package docs.scaladsl
+
+import akka.actor.ActorSystem
+import akka.kafka.ConsumerMessage.{CommittableOffset, CommittableOffsetBatch}
+import akka.kafka.scaladsl.Consumer
+import akka.kafka.{ConsumerMessage, ProducerMessage}
+import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import akka.stream.{ActorMaterializer, Materializer}
+import akka.testkit.TestKit
+import akka.{Done, NotUsed}
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+
+import scala.collection.immutable
+import scala.concurrent.duration._
+
+class TestkitSamplesSpec
+    extends TestKit(ActorSystem("example"))
+    with FlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with ScalaFutures {
+  implicit val mat: Materializer = ActorMaterializer()
+
+  override protected def afterAll(): Unit = TestKit.shutdownActorSystem(system)
+
+  "Without broker testing" should "be possible" in {
+    val topic = "topic"
+    val targetTopic = "target-topic"
+    val groupId = "group1"
+    val startOffset = 100L
+    val partition = 0
+
+    // #factories
+    import akka.kafka.testkit.ConsumerResultFactory
+    import akka.kafka.testkit.ProducerResultFactory
+    import akka.kafka.testkit.scaladsl.ConsumerControlFactory
+
+    // create elements emitted by the mocked Consumer
+    val elements = immutable.Seq(
+      ConsumerResultFactory.committableMessage(
+        new ConsumerRecord(topic, partition, startOffset, "key", "value 1"),
+        ConsumerResultFactory.committableOffset(groupId, topic, partition, startOffset, "metadata")
+      ),
+      ConsumerResultFactory.committableMessage(
+        new ConsumerRecord(topic, partition, startOffset + 1, "key", "value 2"),
+        ConsumerResultFactory.committableOffset(groupId, topic, partition, startOffset + 1, "metadata 2")
+      )
+    )
+
+    // create a source imitating the Consumer.committableSource
+    val mockedKafkaConsumerSource: Source[ConsumerMessage.CommittableMessage[String, String], Consumer.Control] =
+      Source(elements)
+        .viaMat(ConsumerControlFactory.controlFlow())(Keep.right)
+
+    // create a source imitating the Producer.flexiFlow
+    val mockedKafkaProducerFlow: Flow[ProducerMessage.Envelope[String, String, CommittableOffset],
+                                      ProducerMessage.Results[String, String, CommittableOffset],
+                                      NotUsed] =
+      Flow[ProducerMessage.Envelope[String, String, CommittableOffset]]
+        .map {
+          case msg: ProducerMessage.Message[String, String, CommittableOffset] =>
+            ProducerResultFactory.result(msg)
+        }
+
+    // run the flow as if it was connected to a Kafka broker
+    val (control, streamCompletion) = mockedKafkaConsumerSource
+      .map(
+        msg =>
+          ProducerMessage.Message(
+            new ProducerRecord[String, String](targetTopic, msg.record.value),
+            msg.committableOffset
+        )
+      )
+      .via(mockedKafkaProducerFlow)
+      .map(_.passThrough)
+      .groupedWithin(10, 5.seconds)
+      .map(CommittableOffsetBatch(_))
+      .mapAsync(3)(_.commitScaladsl())
+      .toMat(Sink.ignore)(Keep.both)
+      .run()
+    // #factories
+
+    control.shutdown()
+    streamCompletion.futureValue should be (Done)
+  }
+}

--- a/tests/src/test/scala/docs/scaladsl/TestkitSamplesSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/TestkitSamplesSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
 package docs.scaladsl
 
 import akka.actor.ActorSystem
@@ -84,6 +89,6 @@ class TestkitSamplesSpec
     // #factories
 
     control.shutdown()
-    streamCompletion.futureValue should be (Done)
+    streamCompletion.futureValue should be(Done)
   }
 }

--- a/tests/src/test/scala/docs/scaladsl/TestkitSamplesSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/TestkitSamplesSpec.scala
@@ -20,6 +20,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 
 import scala.collection.immutable
+import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class TestkitSamplesSpec
@@ -84,13 +85,14 @@ class TestkitSamplesSpec
       )
       .via(mockedKafkaProducerFlow)
       .map(_.passThrough)
-      .groupedWithin(10, 5.seconds)
+      .groupedWithin(10, 500.millis)
       .map(CommittableOffsetBatch(_))
       .mapAsync(3)(_.commitScaladsl())
       .toMat(Sink.ignore)(Keep.both)
       .run()
     // #factories
 
+    Await.result(streamCompletion, 2.seconds)
     streamCompletion.futureValue should be(Done)
   }
 }

--- a/tests/src/test/scala/docs/scaladsl/TestkitSamplesSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/TestkitSamplesSpec.scala
@@ -20,7 +20,6 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 
 import scala.collection.immutable
-import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class TestkitSamplesSpec
@@ -43,8 +42,8 @@ class TestkitSamplesSpec
     val partition = 0
 
     // #factories
-    import akka.kafka.testkit.{ConsumerResultFactory, ProducerResultFactory}
     import akka.kafka.testkit.scaladsl.ConsumerControlFactory
+    import akka.kafka.testkit.{ConsumerResultFactory, ProducerResultFactory}
 
     // create elements emitted by the mocked Consumer
     val elements = immutable.Seq(
@@ -92,7 +91,6 @@ class TestkitSamplesSpec
       .run()
     // #factories
 
-    Await.result(streamCompletion, 2.seconds)
     streamCompletion.futureValue should be(Done)
   }
 }

--- a/tests/src/test/scala/docs/scaladsl/TestkitSamplesSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/TestkitSamplesSpec.scala
@@ -59,7 +59,8 @@ class TestkitSamplesSpec
 
     // create a source imitating the Consumer.committableSource
     val mockedKafkaConsumerSource: Source[ConsumerMessage.CommittableMessage[String, String], Consumer.Control] =
-      Source(elements)
+      Source
+        .cycle(() => elements.iterator)
         .viaMat(ConsumerControlFactory.controlFlow())(Keep.right)
 
     // create a source imitating the Producer.flexiFlow
@@ -91,6 +92,8 @@ class TestkitSamplesSpec
       .run()
     // #factories
 
+    Thread.sleep(1 * 1000L)
+    control.shutdown().futureValue should be(Done)
     streamCompletion.futureValue should be(Done)
   }
 }


### PR DESCRIPTION
* Move all testkit code under `akka.kafka.testkit`
* Add factories that create instances emitted by Consumers and Producers
* Add testkit documentation with sample code