### PR TITLE
Committer sink

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -103,6 +103,21 @@ akka.kafka.consumer {
 }
 # // #consumer-settings
 
+# // #committer-settings
+# Properties for akka.kafka.CommitterSettings can be
+# defined in this section or a configuration section with
+# the same layout.
+akka.kafka.committer {
+
+  # Maximum number of messages in a single commit batch
+  max-batch = 1000
+
+  # Maximum interval between commits
+  max-interval = 1m
+
+}
+# // #committer-settings
+
 # The dispatcher that will be used by default by consumer and
 # producer stages.
 akka.kafka.default-dispatcher {

--- a/core/src/main/scala/akka/kafka/CommitterSettings.scala
+++ b/core/src/main/scala/akka/kafka/CommitterSettings.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka
+import java.util.concurrent.TimeUnit
+
+import akka.actor.ActorSystem
+import akka.util.JavaDurationConverters._
+import com.typesafe.config.Config
+
+import scala.concurrent.duration._
+
+object CommitterSettings {
+
+  /**
+   * Create settings from the default configuration
+   * `akka.kafka.committer`.
+   */
+  def apply(actorSystem: ActorSystem): CommitterSettings =
+    apply(actorSystem.settings.config.getConfig("akka.kafka.committer"))
+
+  /**
+   * Create settings from a configuration with the same layout as
+   * the default configuration `akka.kafka.committer`.
+   */
+  def apply(config: Config): CommitterSettings = {
+    val maxBatch = config.getLong("max-batch")
+    val maxInterval = config.getDuration("max-interval", TimeUnit.MILLISECONDS).millis
+    new CommitterSettings(maxBatch, maxInterval)
+  }
+
+  /**
+   * Java API: Create settings from the default configuration
+   * `akka.kafka.committer`.
+   */
+  def create(actorSystem: ActorSystem): CommitterSettings =
+    apply(actorSystem)
+
+  /**
+   * Java API: Create settings from a configuration with the same layout as
+   * the default configuration `akka.kafka.committer`.
+   */
+  def create(config: Config): CommitterSettings =
+    apply(config)
+
+}
+
+/**
+ * Settings for committer. See `akka.kafka.committer` section in
+ * reference.conf. Note that the [[CommitterSettings companion]] object provides
+ * `apply` and `create` functions for convenient construction of the settings, together with
+ * the `with` methods.
+ */
+class CommitterSettings private (
+    val maxBatch: Long,
+    val maxInterval: FiniteDuration
+) {
+
+  def withMaxBatch(maxBatch: Long): CommitterSettings =
+    copy(maxBatch = maxBatch)
+
+  def withMaxInterval(maxInterval: FiniteDuration): CommitterSettings =
+    copy(maxInterval = maxInterval)
+
+  def withMaxInterval(maxInterval: java.time.Duration): CommitterSettings =
+    copy(maxInterval = maxInterval.asScala)
+
+  private def copy(maxBatch: Long = maxBatch, maxInterval: FiniteDuration = maxInterval): CommitterSettings =
+    new CommitterSettings(maxBatch, maxInterval)
+
+  override def toString: String =
+    "akka.kafka.CommitterSettings(" +
+    s"maxBatch=$maxBatch," +
+    s"maxInterval=${maxInterval.toCoarsest}" +
+    ")"
+
+}

--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -140,14 +140,9 @@ object ConsumerMessage {
   trait CommittableOffsetBatch extends Committable {
 
     /**
-     * Add/overwrite an offset position for the given groupId, topic, partition.
+     * Add/overwrite an offset position from another committable.
      */
-    def updated(offset: CommittableOffset): CommittableOffsetBatch
-
-    /**
-     * Add/overwrite offset positions from another batch.
-     */
-    def updated(offset: CommittableOffsetBatch): CommittableOffsetBatch
+    def updated(offset: Committable): CommittableOffsetBatch
 
     /**
      * Scala API: Get current offset positions

--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -109,7 +109,7 @@ object ConsumerMessage {
      * Scala API:
      * Create an offset batch out of a list of offsets.
      */
-    def apply(offsets: Seq[CommittableOffset]): CommittableOffsetBatch =
+    def apply(offsets: Seq[Committable]): CommittableOffsetBatch =
       offsets.foldLeft(CommittableOffsetBatch.empty) { (batch, elem) =>
         batch.updated(elem)
       }

--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -48,6 +48,11 @@ object ConsumerMessage {
   trait Committable {
     def commitScaladsl(): Future[Done]
     def commitJavadsl(): CompletionStage[Done]
+
+    /**
+     * Get a number of processed messages this committable contains
+     */
+    def batchSize: Long
   }
 
   /**
@@ -92,7 +97,7 @@ object ConsumerMessage {
   )
 
   object CommittableOffsetBatch {
-    val empty: CommittableOffsetBatch = new CommittableOffsetBatchImpl(Map.empty, Map.empty)
+    val empty: CommittableOffsetBatch = new CommittableOffsetBatchImpl(Map.empty, Map.empty, 0)
 
     /**
      * Scala API:
@@ -153,6 +158,7 @@ object ConsumerMessage {
      * Java API: Get current offset positions
      */
     def getOffsets(): JMap[GroupTopicPartition, Long]
+
   }
 
 }

--- a/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
+++ b/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
@@ -102,7 +102,12 @@ private[kafka] final class CommittableOffsetBatchImpl(
 ) extends CommittableOffsetBatch {
   def offsets = offsetsAndMetadata.mapValues(_.offset())
 
-  def updated(committableOffset: CommittableOffset): CommittableOffsetBatch = {
+  def updated(committable: Committable): CommittableOffsetBatch = committable match {
+    case offset: CommittableOffset => updatedWithOffset(offset)
+    case batch: CommittableOffsetBatch => updatedWithBatch(batch)
+  }
+
+  private def updatedWithOffset(committableOffset: CommittableOffset): CommittableOffsetBatch = {
     val partitionOffset = committableOffset.partitionOffset
     val key = partitionOffset.key
     val metadata = committableOffset match {
@@ -137,7 +142,7 @@ private[kafka] final class CommittableOffsetBatchImpl(
     new CommittableOffsetBatchImpl(newOffsets, newStages, size + 1)
   }
 
-  def updated(committableOffsetBatch: CommittableOffsetBatch): CommittableOffsetBatch =
+  private def updatedWithBatch(committableOffsetBatch: CommittableOffsetBatch): CommittableOffsetBatch =
     committableOffsetBatch match {
       case c: CommittableOffsetBatchImpl =>
         val newOffsetsAndMetadata = offsetsAndMetadata ++ c.offsetsAndMetadata

--- a/core/src/main/scala/akka/kafka/javadsl/Committer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Committer.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.javadsl
+import java.util.concurrent.CompletionStage
+
+import akka.Done
+import akka.kafka.ConsumerMessage.Committable
+import akka.kafka.{scaladsl, CommitterSettings}
+import akka.stream.javadsl.Sink
+
+import scala.compat.java8.FutureConverters.FutureOps
+
+object Committer {
+
+  def sink(settings: CommitterSettings): Sink[Committable, CompletionStage[Done]] =
+    scaladsl.Committer.sink(settings).mapMaterializedValue(_.toJava).asJava
+
+}

--- a/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2018 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.scaladsl
+import akka.Done
+import akka.kafka.CommitterSettings
+import akka.kafka.ConsumerMessage.{Committable, CommittableOffsetBatch}
+import akka.stream.scaladsl.{Flow, Keep, Sink}
+
+import scala.concurrent.Future
+
+object Committer {
+
+  def sink(settings: CommitterSettings): Sink[Committable, Future[Done]] =
+    Flow[Committable]
+    // Not very efficient, ideally we should merge offsets instead of grouping them
+      .groupedWeightedWithin(settings.maxBatch, settings.maxInterval)(_.batchSize)
+      .map(CommittableOffsetBatch.apply)
+      .mapAsync(1)(_.commitScaladsl())
+      .toMat(Sink.ignore)(Keep.right)
+
+}

--- a/docs/src/main/paradox/consumer.md
+++ b/docs/src/main/paradox/consumer.md
@@ -88,7 +88,22 @@ The above example uses separate `mapAsync` stages for processing and committing.
 
 Committing the offset for each message as illustrated above is rather slow. It is recommended to batch the commits for better throughput, with the trade-off that more messages may be re-delivered in case of failures.
 
-You can use the Akka Stream `batch` combinator to perform the batching. Note that it will only aggregate elements into batches if the downstream consumer is slower than the upstream producer.
+You can use a pre-defined `Committer.sink` to perform commits in batches:
+
+Scala
+: @@ snip [snip](/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala) { #committerSink }
+
+Java
+: @@ snip [snip](/tests/src/test/java/docs/javadsl/ConsumerExample.java) { #committerSink }
+ 
+When creating a `Committer.sink` you need to pass in `CommitterSettings` (@scaladoc[API](akka.kafka.CommitterSettings)) that defines:
+
+* `max-batch` — maximum number of messages to commit at once,
+* `max-interval` — maximum interval between commits.
+
+The bigger the values are, the less load you put on Kafka and the smaller are chances that committing offsets will become a bottleneck. However, increasing these values also means that in case of a failure you will have to re-process more messages. 
+
+You can also make a manual batching using the Akka Stream `batch` combinator to perform the batching. Note that it will only aggregate elements into batches if the downstream consumer is slower than the upstream producer.
 
 Scala
 : @@ snip [snip](/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala) { #atLeastOnceBatch }

--- a/testkit/src/main/scala/akka/kafka/internal/KafkaTestKit.scala
+++ b/testkit/src/main/scala/akka/kafka/internal/KafkaTestKit.scala
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
 import akka.actor.ActorSystem
-import akka.kafka.{ConsumerSettings, ProducerSettings}
+import akka.kafka.{CommitterSettings, ConsumerSettings, ProducerSettings}
 import kafka.admin.{AdminClient => OldAdminClient}
 import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
 import org.apache.kafka.clients.consumer.ConsumerConfig
@@ -34,6 +34,8 @@ trait KafkaTestKit {
     .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
     .withWakeupTimeout(10.seconds)
     .withMaxWakeups(10)
+
+  val committerDefaults = CommitterSettings(system)
 
   def nextNumber(): Int = KafkaTestKit.topicCounter.incrementAndGet()
 


### PR DESCRIPTION
Design considerations:
 * committer is a `Sink` as in my experience it is usually the last step of the flow
 * committer settings `max-batch` and `max-interval` define the amount of work we can afford to lose, in terms of messages or time

Implements #619