### PR TITLE
Include requested partition in CommittedOffset

### DIFF
--- a/core/src/main/scala/akka/kafka/Metadata.scala
+++ b/core/src/main/scala/akka/kafka/Metadata.scala
@@ -170,7 +170,7 @@ object Metadata {
    * [[org.apache.kafka.clients.consumer.KafkaConsumer#committed()]]
    */
   final case class GetCommittedOffset(partition: TopicPartition) extends Request with NoSerializationVerificationNeeded
-  final case class CommittedOffset(response: Try[OffsetAndMetadata])
+  final case class CommittedOffset(response: Try[OffsetAndMetadata], requestedPartition: TopicPartition)
       extends Response
       with NoSerializationVerificationNeeded {
 

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -641,8 +641,9 @@ import scala.util.control.{NoStackTrace, NonFatal}
       })
 
     case Metadata.GetCommittedOffset(partition) =>
-      Metadata.CommittedOffset(Try {
-        consumer.committed(partition, settings.getMetadataRequestTimeout)
-      })
+      Metadata.CommittedOffset(
+        Try { consumer.committed(partition, settings.getMetadataRequestTimeout) },
+        partition
+      )
   }
 }

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -477,7 +477,7 @@ class IntegrationSpec extends SpecBase(kafkaPort = KafkaPorts.IntegrationSpec) w
 
         // GetCommittedOffset
         inside(Await.result(consumer ? GetCommittedOffset(partition0), 10.seconds)) {
-          case CommittedOffset(Success(offsetMeta)) =>
+          case CommittedOffset(Success(offsetMeta), _) =>
             assert(offsetMeta == null, "Wrong offset in GetCommittedOffset")
         }
 


### PR DESCRIPTION
Provides context when receiving the response so that you can use the
tell pattern without losing important context about what information you
requested