### PR TITLE
Remove rebalance listener for manual subscriptions

### DIFF
--- a/core/src/main/mima-filters/1.0-M1.backwards.excludes
+++ b/core/src/main/mima-filters/1.0-M1.backwards.excludes
@@ -9,3 +9,23 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.CommitterSettings
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Metadata#CommittedOffset.*")
 ProblemFilters.exclude[MissingTypesProblem]("akka.kafka.Metadata$CommittedOffset$")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Metadata#CommittedOffset.apply")
+
+# Remove rebalance listener for manual subscriptions
+# https://github.com/akka/alpakka-kafka/pull/639
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#Assignment.copy$default$2")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#Assignment.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#Assignment.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#Assignment.apply")
+ProblemFilters.exclude[MissingTypesProblem]("akka.kafka.Subscriptions$Assignment$")
+
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#AssignmentWithOffset.copy$default$2")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#AssignmentWithOffset.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#AssignmentWithOffset.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#AssignmentWithOffset.apply")
+ProblemFilters.exclude[MissingTypesProblem]("akka.kafka.Subscriptions$AssignmentWithOffset$")
+
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#AssignmentOffsetsForTimes.copy$default$2")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#AssignmentOffsetsForTimes.copy")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#AssignmentOffsetsForTimes.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#AssignmentOffsetsForTimes.apply")
+ProblemFilters.exclude[MissingTypesProblem]("akka.kafka.Subscriptions$AssignmentOffsetsForTimes$")

--- a/core/src/main/mima-filters/1.0-M1.backwards.excludes
+++ b/core/src/main/mima-filters/1.0-M1.backwards.excludes
@@ -10,20 +10,18 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Metadata#Committe
 ProblemFilters.exclude[MissingTypesProblem]("akka.kafka.Metadata$CommittedOffset$")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Metadata#CommittedOffset.apply")
 
-# Remove rebalance listener for manual subscriptions
+# PR #639 Remove rebalance listener for manual subscriptions
 # https://github.com/akka/alpakka-kafka/pull/639
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#Assignment.copy$default$2")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#Assignment.copy")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#Assignment.this")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#Assignment.apply")
 ProblemFilters.exclude[MissingTypesProblem]("akka.kafka.Subscriptions$Assignment$")
-
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#AssignmentWithOffset.copy$default$2")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#AssignmentWithOffset.copy")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#AssignmentWithOffset.this")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#AssignmentWithOffset.apply")
 ProblemFilters.exclude[MissingTypesProblem]("akka.kafka.Subscriptions$AssignmentWithOffset$")
-
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#AssignmentOffsetsForTimes.copy$default$2")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#AssignmentOffsetsForTimes.copy")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Subscriptions#AssignmentOffsetsForTimes.this")

--- a/core/src/main/scala/akka/kafka/internal/BaseSingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/BaseSingleSourceLogic.scala
@@ -71,13 +71,13 @@ import scala.concurrent.{ExecutionContext, Future}
   protected def configureSubscription(): Unit
 
   protected def configureManualSubscription(subscription: ManualSubscription): Unit = subscription match {
-    case Assignment(topics, _) =>
+    case Assignment(topics) =>
       consumerActor.tell(KafkaConsumerActor.Internal.Assign(topics), sourceActor.ref)
       tps ++= topics
-    case AssignmentWithOffset(topics, _) =>
+    case AssignmentWithOffset(topics) =>
       consumerActor.tell(KafkaConsumerActor.Internal.AssignWithOffset(topics), sourceActor.ref)
       tps ++= topics.keySet
-    case AssignmentOffsetsForTimes(topics, _) =>
+    case AssignmentOffsetsForTimes(topics) =>
       consumerActor.tell(KafkaConsumerActor.Internal.AssignOffsetsForTimes(topics), sourceActor.ref)
       tps ++= topics.keySet
   }

--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -36,7 +36,7 @@ import scala.concurrent.{Future, Promise}
 
   final def configureSubscription(): Unit = {
 
-    def rebalanceListener: KafkaConsumerActor.ListenerCallbacks = {
+    def rebalanceListener(autoSubscription: AutoSubscription): KafkaConsumerActor.ListenerCallbacks = {
       val partitionAssignedCB = getAsyncCallback[Set[TopicPartition]] { assignedTps =>
         tps ++= assignedTps
         log.log(partitionLogLevel, "Assigned partitions: {}. All partitions: {}", assignedTps, tps)
@@ -48,7 +48,6 @@ import scala.concurrent.{Future, Promise}
         log.log(partitionLogLevel, "Revoked partitions: {}. All partitions: {}", revokedTps, tps)
       }
 
-    def rebalanceListener(autoSubscription: AutoSubscription): KafkaConsumerActor.ListenerCallbacks =
       KafkaConsumerActor.ListenerCallbacks(
         assignedTps => {
           autoSubscription.rebalanceListener.foreach {


### PR DESCRIPTION
While digging around for #539 I noticed that the manual subscription case classes allow setting the actor to receive rebalance notifications. Manual subscriptions do never rebalance, so I deprecated those methods and made them no-ops for now.