### PR TITLE
Prefer committable over commitable

### DIFF
--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/Benchmarks.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/Benchmarks.scala
@@ -32,13 +32,13 @@ object Benchmarks {
                     KafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
       case "alpakka-kafka-batched-consumer" =>
         runPerfTest(cmd,
-                    ReactiveKafkaConsumerFixtures.commitableSources(cmd),
+                    ReactiveKafkaConsumerFixtures.committableSources(cmd),
                     ReactiveKafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
       case "apache-kafka-at-most-once-consumer" =>
         runPerfTest(cmd, KafkaConsumerFixtures.filledTopics(cmd), KafkaConsumerBenchmarks.consumeCommitAtMostOnce)
       case "alpakka-kafka-at-most-once-consumer" =>
         runPerfTest(cmd,
-                    ReactiveKafkaConsumerFixtures.commitableSources(cmd),
+                    ReactiveKafkaConsumerFixtures.committableSources(cmd),
                     ReactiveKafkaConsumerBenchmarks.consumeCommitAtMostOnce)
       case "apache-kafka-plain-producer" =>
         runPerfTest(cmd, KafkaProducerFixtures.initializedProducer(cmd), KafkaProducerBenchmarks.plainFlow)

--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaConsumerBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaConsumerBenchmarks.scala
@@ -20,13 +20,13 @@ import scala.util.Success
 
 object ReactiveKafkaConsumerBenchmarks extends LazyLogging {
   val streamingTimeout = 30 minutes
-  type NonCommitableFixture = ReactiveKafkaConsumerTestFixture[ConsumerRecord[Array[Byte], String]]
-  type CommitableFixture = ReactiveKafkaConsumerTestFixture[CommittableMessage[Array[Byte], String]]
+  type NonCommittableFixture = ReactiveKafkaConsumerTestFixture[ConsumerRecord[Array[Byte], String]]
+  type CommittableFixture = ReactiveKafkaConsumerTestFixture[CommittableMessage[Array[Byte], String]]
 
   /**
    * Creates a predefined stream, reads N elements, discarding them into a Sink.ignore. Does not commit.
    */
-  def consumePlainNoKafka(fixture: NonCommitableFixture, meter: Meter)(implicit mat: Materializer): Unit = {
+  def consumePlainNoKafka(fixture: NonCommittableFixture, meter: Meter)(implicit mat: Materializer): Unit = {
     logger.debug("Creating and starting a stream")
     meter.mark()
     val future = Source
@@ -43,7 +43,7 @@ object ReactiveKafkaConsumerBenchmarks extends LazyLogging {
   /**
    * Creates a stream and reads N elements, discarding them into a Sink.ignore. Does not commit.
    */
-  def consumePlain(fixture: NonCommitableFixture, meter: Meter)(implicit mat: Materializer): Unit = {
+  def consumePlain(fixture: NonCommittableFixture, meter: Meter)(implicit mat: Materializer): Unit = {
     logger.debug("Creating and starting a stream")
     val future = fixture.source
       .take(fixture.msgCount.toLong)
@@ -59,7 +59,7 @@ object ReactiveKafkaConsumerBenchmarks extends LazyLogging {
    * Reads elements from Kafka source and commits a batch as soon as it's possible. Backpressures when batch max of
    * size is accumulated.
    */
-  def consumerAtLeastOnceBatched(batchSize: Int)(fixture: CommitableFixture,
+  def consumerAtLeastOnceBatched(batchSize: Int)(fixture: CommittableFixture,
                                                  meter: Meter)(implicit mat: Materializer): Unit = {
     logger.debug("Creating and starting a stream")
     val promise = Promise[Unit]
@@ -89,7 +89,7 @@ object ReactiveKafkaConsumerBenchmarks extends LazyLogging {
   /**
    * Reads elements from Kafka source and commits each one immediately after read.
    */
-  def consumeCommitAtMostOnce(fixture: CommitableFixture, meter: Meter)(implicit mat: Materializer): Unit = {
+  def consumeCommitAtMostOnce(fixture: CommittableFixture, meter: Meter)(implicit mat: Materializer): Unit = {
     logger.debug("Creating and starting a stream")
     val promise = Promise[Unit]
     val control = fixture.source

--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaConsumerFixtures.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaConsumerFixtures.scala
@@ -37,7 +37,7 @@ object ReactiveKafkaConsumerFixtures extends PerfFixtureHelpers {
       }
     )
 
-  def commitableSources(c: RunTestCommand)(implicit actorSystem: ActorSystem) =
+  def committableSources(c: RunTestCommand)(implicit actorSystem: ActorSystem) =
     FixtureGen[ReactiveKafkaConsumerTestFixture[CommittableMessage[Array[Byte], String]]](
       c,
       msgCount => {

--- a/core/src/main/scala/akka/kafka/ProducerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ProducerMessage.scala
@@ -18,7 +18,7 @@ import scala.collection.JavaConverters._
 object ProducerMessage {
 
   /**
-   * Type accepted by `Producer.commitableSink` and `Producer.flexiFlow` with implementations
+   * Type accepted by `Producer.committableSink` and `Producer.flexiFlow` with implementations
    *
    * - [[Message]] publishes a single message to its topic, and continues in the stream as [[Result]]
    *

--- a/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
@@ -11,7 +11,7 @@ import akka.kafka.{ConsumerMessage, ProducerSettings}
 import akka.stream.ActorAttributes
 import akka.stream.scaladsl.{Flow, Keep, Sink}
 import akka.{Done, NotUsed}
-import org.apache.kafka.clients.producer.{ProducerRecord, Producer => KProducer}
+import org.apache.kafka.clients.producer.ProducerRecord
 
 import scala.concurrent.Future
 
@@ -42,7 +42,7 @@ object Producer {
    */
   def plainSink[K, V](
       settings: ProducerSettings[K, V],
-      producer: KProducer[K, V]
+      producer: org.apache.kafka.clients.producer.Producer[K, V]
   ): Sink[ProducerRecord[K, V], Future[Done]] =
     Flow[ProducerRecord[K, V]]
       .map(Message(_, NotUsed))
@@ -65,10 +65,58 @@ object Producer {
    * Note that there is a risk that something fails after publishing but before
    * committing, so it is "at-least once delivery" semantics.
    */
-  def commitableSink[K, V](
+  def committableSink[K, V](
       settings: ProducerSettings[K, V]
   ): Sink[Envelope[K, V, ConsumerMessage.Committable], Future[Done]] =
     flexiFlow[K, V, ConsumerMessage.Committable](settings)
+      .mapAsync(settings.parallelism)(_.passThrough.commitScaladsl())
+      .toMat(Sink.ignore)(Keep.right)
+
+  /**
+   * Create a sink that is aware of the [[ConsumerMessage.CommittableOffset committable offset]]
+   * from a [[Consumer.committableSource]]. It will commit the consumer offset when the message has
+   * been published successfully to the topic.
+   *
+   * It publishes records to Kafka topics conditionally:
+   *
+   * - [[akka.kafka.ProducerMessage.Message Message]] publishes a single message to its topic, and commits the offset
+   *
+   * - [[akka.kafka.ProducerMessage.MultiMessage MultiMessage]] publishes all messages in its `records` field, and commits the offset
+   *
+   * - [[akka.kafka.ProducerMessage.PassThroughMessage PassThroughMessage]] does not publish anything, but commits the offset
+   *
+   * Note that there is a risk that something fails after publishing but before
+   * committing, so it is "at-least once delivery" semantics.
+   */
+  @deprecated("use committableSink instead", "1.0-M2")
+  def commitableSink[K, V](
+      settings: ProducerSettings[K, V]
+  ): Sink[Envelope[K, V, ConsumerMessage.Committable], Future[Done]] = committableSink(settings)
+
+  /**
+   * Create a sink that is aware of the [[ConsumerMessage.CommittableOffset committable offset]]
+   * from a [[Consumer.committableSource]]. It will commit the consumer offset when the message has
+   * been published successfully to the topic.
+   *
+   * It publishes records to Kafka topics conditionally:
+   *
+   * - [[akka.kafka.ProducerMessage.Message Message]] publishes a single message to its topic, and commits the offset
+   *
+   * - [[akka.kafka.ProducerMessage.MultiMessage MultiMessage]] publishes all messages in its `records` field, and commits the offset
+   *
+   * - [[akka.kafka.ProducerMessage.PassThroughMessage PassThroughMessage]] does not publish anything, but commits the offset
+   *
+   *
+   * Note that there is always a risk that something fails after publishing but before
+   * committing, so it is "at-least once delivery" semantics.
+   *
+   * Supports sharing a Kafka Producer instance.
+   */
+  def committableSink[K, V](
+      settings: ProducerSettings[K, V],
+      producer: org.apache.kafka.clients.producer.Producer[K, V]
+  ): Sink[Envelope[K, V, ConsumerMessage.Committable], Future[Done]] =
+    flexiFlow[K, V, ConsumerMessage.Committable](settings, producer)
       .mapAsync(settings.parallelism)(_.passThrough.commitScaladsl())
       .toMat(Sink.ignore)(Keep.right)
 
@@ -93,11 +141,8 @@ object Producer {
    */
   def commitableSink[K, V](
       settings: ProducerSettings[K, V],
-      producer: KProducer[K, V]
-  ): Sink[Envelope[K, V, ConsumerMessage.Committable], Future[Done]] =
-    flexiFlow[K, V, ConsumerMessage.Committable](settings, producer)
-      .mapAsync(settings.parallelism)(_.passThrough.commitScaladsl())
-      .toMat(Sink.ignore)(Keep.right)
+      producer: org.apache.kafka.clients.producer.Producer[K, V]
+  ): Sink[Envelope[K, V, ConsumerMessage.Committable], Future[Done]] = committableSink(settings, producer)
 
   /**
    * Create a flow to publish records to Kafka topics and then pass it on.
@@ -170,7 +215,7 @@ object Producer {
   @deprecated("prefer flexiFlow over this flow implementation", "0.21")
   def flow[K, V, PassThrough](
       settings: ProducerSettings[K, V],
-      producer: KProducer[K, V]
+      producer: org.apache.kafka.clients.producer.Producer[K, V]
   ): Flow[Message[K, V, PassThrough], Result[K, V, PassThrough], NotUsed] = {
     val flow = Flow
       .fromGraph(
@@ -204,7 +249,7 @@ object Producer {
    */
   def flexiFlow[K, V, PassThrough](
       settings: ProducerSettings[K, V],
-      producer: KProducer[K, V]
+      producer: org.apache.kafka.clients.producer.Producer[K, V]
   ): Flow[Envelope[K, V, PassThrough], Results[K, V, PassThrough], NotUsed] = {
     val flow = Flow
       .fromGraph(

--- a/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
@@ -139,6 +139,7 @@ object Producer {
    *
    * Supports sharing a Kafka Producer instance.
    */
+  @deprecated("use committableSink instead", "1.0-M2")
   def commitableSink[K, V](
       settings: ProducerSettings[K, V],
       producer: org.apache.kafka.clients.producer.Producer[K, V]

--- a/docs/src/main/paradox/atleastonce.md
+++ b/docs/src/main/paradox/atleastonce.md
@@ -24,9 +24,9 @@ Java
 
 ### Batches
 
-If committable messages are processed in batches (using `batch` or `grouped`), it is also important to commit the resulting `CommitableOffsetBatch` only after all messages in the batch are fully processed.
+If committable messages are processed in batches (using `batch` or `grouped`), it is also important to commit the resulting `CommittableOffsetBatch` only after all messages in the batch are fully processed.
 
-Should the batch need to be split up again, using mapConcat, care should be taken to associate the `CommitableOffsetBatch` only with the last message. This scenario could occur if we created batches to more efficiently update a database and then needed to split up the batches to send individual messages to a Kafka producer flow.
+Should the batch need to be split up again, using mapConcat, care should be taken to associate the `CommittableOffsetBatch` only with the last message. This scenario could occur if we created batches to more efficiently update a database and then needed to split up the batches to send individual messages to a Kafka producer flow.
 
 ### Multiple Destinations
 

--- a/docs/src/main/paradox/consumer.md
+++ b/docs/src/main/paradox/consumer.md
@@ -139,11 +139,11 @@ Maintaining at-least-once delivery semantics requires care, many risks and solut
 
 ## Connecting Producer and Consumer
 
-For cases when you need to read messages from one topic, transform or enrich them, and then write to another topic you can use `Consumer.committableSource` and connect it to a `Producer.commitableSink`. The `commitableSink` will commit the offset back to the consumer when it has successfully published the message.
+For cases when you need to read messages from one topic, transform or enrich them, and then write to another topic you can use `Consumer.committableSource` and connect it to a `Producer.committableSink`. The `committableSink` will commit the offset back to the consumer when it has successfully published the message.
 
 The `committableSink` accepts implementations `ProducerMessage.Envelope` (@scaladoc[API](akka.kafka.ProducerMessage$$Envelope)) that contain the offset to commit the consumption of the originating message (of type `ConsumerMessage.Committable` (@scaladoc[API](akka.kafka.ConsumerMessage$$Committable))). See @ref[Producing messages](producer.md#producing-messages) about different implementations of `Envelope` supported.
 
-Note that there is a risk that something fails after publishing but before committing, so `commitableSink` has "at-least-once" delivery semantics. 
+Note that there is a risk that something fails after publishing but before committing, so `committableSink` has "at-least-once" delivery semantics. 
 
 Scala
 : @@ snip [snip](/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala) { #consumerToProducerSink }
@@ -161,7 +161,7 @@ Java
 
 @@@note 
 
-There is a risk that something fails after publishing, but before committing, so `commitableSink` has "at-least-once" delivery semantics.
+There is a risk that something fails after publishing, but before committing, so `committableSink` has "at-least-once" delivery semantics.
 
 To get delivery guarantees, please read about @ref[transactions](transactions.md).
 
@@ -263,10 +263,10 @@ To manage this shutdown process, use the `Consumer.DrainingControl`
 by combining the `Consumer.Control` with the sink's materialized completion future in `mapMaterializedValue'. That control offers the method `drainAndShutdown` which implements the process descibed above. It is recommended to use the same shutdown mechanism also when not using batching to avoid potential race conditions, depending on the exact layout of the stream.
 
 Scala
-: @@ snip [snip](/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala) { #shutdownCommitableSource }
+: @@ snip [snip](/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala) { #shutdownCommittableSource }
 
 Java
-: @@ snip [snip](/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java) { #shutdownCommitableSource }
+: @@ snip [snip](/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java) { #shutdownCommittableSource }
 
 
 @@@ index

--- a/docs/src/main/paradox/transactions.md
+++ b/docs/src/main/paradox/transactions.md
@@ -16,7 +16,7 @@ Only use this source if you have the intention to connect it to `Transactional.f
 
 ## Transactional Sink and Flow
 
-The `Transactional.sink` is similar to the `Consumer.commitableSink` in that messages will be automatically committed as part of a transaction.  The `Transactional.sink` or `Transactional.flow` are required when connecting a consumer to a producer to achieve a transactional workflow.
+The `Transactional.sink` is similar to the `Producer.committableSink` in that messages will be automatically committed as part of a transaction.  The `Transactional.sink` or `Transactional.flow` are required when connecting a consumer to a producer to achieve a transactional workflow.
 
 They override producer properties `enable.idempotence` to `true` and `max.in.flight.requests.per.connection` to `1` as required by the Kafka producer to enable transactions.
 

--- a/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java
@@ -278,7 +278,7 @@ public class ConsumerExampleTest extends EmbeddedKafkaTest {
                     ProducerMessage.<String, String, ConsumerMessage.Committable>single(
                         new ProducerRecord<>(targetTopic, msg.record().key(), msg.record().value()),
                         msg.committableOffset()))
-            .toMat(Producer.commitableSink(producerSettings), Keep.both())
+            .toMat(Producer.committableSink(producerSettings), Keep.both())
             .mapMaterializedValue(Consumer::createDrainingControl)
             .run(materializer);
     // #consumerToProducerSink
@@ -556,7 +556,7 @@ public class ConsumerExampleTest extends EmbeddedKafkaTest {
     CommitterSettings committerSettings = committerDefaults();
     // TODO there is a problem with combining `take` and committing.
     int messageCount = 1;
-    // #shutdownCommitableSource
+    // #shutdownCommittableSource
     final Executor ec = Executors.newCachedThreadPool();
 
     Consumer.DrainingControl<Done> control =
@@ -573,12 +573,12 @@ public class ConsumerExampleTest extends EmbeddedKafkaTest {
             .mapMaterializedValue(Consumer::createDrainingControl)
             .run(materializer);
 
-    // #shutdownCommitableSource
+    // #shutdownCommittableSource
     assertDone(produceString(topic, messageCount, partition0()));
     assertDone(control.isShutdown());
     assertEquals(Done.done(), resultOf(control.drainAndShutdown(ec), 20));
-    // #shutdownCommitableSource
+    // #shutdownCommittableSource
     control.drainAndShutdown(ec);
-    // #shutdownCommitableSource
+    // #shutdownCommittableSource
   }
 }

--- a/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java
@@ -566,9 +566,9 @@ public class ConsumerExampleTest extends EmbeddedKafkaTest {
                 msg ->
                     business(msg.record().key(), msg.record().value())
                         .thenApply(done -> msg.committableOffset()))
-            // #shutdownCommitableSource
+            // #shutdownCommittableSource
             .take(messageCount)
-            // #shutdownCommitableSource
+            // #shutdownCommittableSource
             .toMat(Committer.sink(committerSettings.withMaxBatch(1)), Keep.both())
             .mapMaterializedValue(Consumer::createDrainingControl)
             .run(materializer);

--- a/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
@@ -225,7 +225,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.ScalaConsumerExamples) {
             msg.committableOffset
           )
         }
-        .toMat(Producer.commitableSink(producerSettings))(Keep.both)
+        .toMat(Producer.committableSink(producerSettings))(Keep.both)
         .mapMaterializedValue(DrainingControl.apply)
         .run()
     // #consumerToProducerSink
@@ -388,7 +388,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.ScalaConsumerExamples) {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val topic = createTopic()
     val committerSettings = committerDefaults
-    // #shutdownCommitableSource
+    // #shutdownCommittableSource
     val drainingControl =
       Consumer
         .committableSource(consumerSettings, Subscriptions.topics(topic))
@@ -400,7 +400,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.ScalaConsumerExamples) {
         .run()
 
     val streamComplete = drainingControl.drainAndShutdown()
-    // #shutdownCommitableSource
+    // #shutdownCommittableSource
     Await.result(streamComplete, 5.seconds) should be(Done)
   }
 


### PR DESCRIPTION
I noticed `Producer.commitableSink` used single-t spelling opposed to all other things in Alpakka Kafka. 
Added `Producer.committableSink` variants and deprecated the existing.