### PR TITLE
Committer updates

### DIFF
--- a/core/src/main/mima-filters/1.0-M1.backwards.excludes
+++ b/core/src/main/mima-filters/1.0-M1.backwards.excludes
@@ -1,0 +1,3 @@
+# Committer parallelism
+# https://github.com/akka/alpakka-kafka/pull/647
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.CommitterSettings.this")

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -115,6 +115,8 @@ akka.kafka.committer {
   # Maximum interval between commits
   max-interval = 10s
 
+  # Parallelsim for async committing
+  parallelism = 1
 }
 # // #committer-settings
 

--- a/core/src/main/scala/akka/kafka/javadsl/Committer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Committer.scala
@@ -16,14 +16,14 @@ import scala.compat.java8.FutureConverters.FutureOps
 object Committer {
 
   /**
-    * Batches offsets and commits them to Kafka, emits `Done` for every committed batch.
-    */
+   * Batches offsets and commits them to Kafka, emits `Done` for every committed batch.
+   */
   def flow[C <: Committable](settings: CommitterSettings): Flow[C, Done, NotUsed] =
     scaladsl.Committer.flow(settings).asJava
 
   /**
-    * Batches offsets and commits them to Kafka.
-    */
+   * Batches offsets and commits them to Kafka.
+   */
   def sink[C <: Committable](settings: CommitterSettings): Sink[C, CompletionStage[Done]] =
     scaladsl.Committer.sink(settings).mapMaterializedValue(_.toJava).asJava
 

--- a/core/src/main/scala/akka/kafka/javadsl/Committer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Committer.scala
@@ -6,16 +6,25 @@
 package akka.kafka.javadsl
 import java.util.concurrent.CompletionStage
 
-import akka.Done
+import akka.{Done, NotUsed}
 import akka.kafka.ConsumerMessage.Committable
 import akka.kafka.{scaladsl, CommitterSettings}
-import akka.stream.javadsl.Sink
+import akka.stream.javadsl.{Flow, Sink}
 
 import scala.compat.java8.FutureConverters.FutureOps
 
 object Committer {
 
-  def sink(settings: CommitterSettings): Sink[Committable, CompletionStage[Done]] =
+  /**
+    * Batches offsets and commits them to Kafka, emits `Done` for every committed batch.
+    */
+  def flow[C <: Committable](settings: CommitterSettings): Flow[C, Done, NotUsed] =
+    scaladsl.Committer.flow(settings).asJava
+
+  /**
+    * Batches offsets and commits them to Kafka.
+    */
+  def sink[C <: Committable](settings: CommitterSettings): Sink[C, CompletionStage[Done]] =
     scaladsl.Committer.sink(settings).mapMaterializedValue(_.toJava).asJava
 
 }

--- a/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
@@ -25,8 +25,8 @@ object Committer {
       .mapAsync(settings.parallelism)(_.commitScaladsl())
 
   /**
-    * Batches offsets and commits them to Kafka.
-    */
+   * Batches offsets and commits them to Kafka.
+   */
   def sink(settings: CommitterSettings): Sink[Committable, Future[Done]] =
     flow(settings)
       .toMat(Sink.ignore)(Keep.right)

--- a/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
@@ -4,7 +4,8 @@
  */
 
 package akka.kafka.scaladsl
-import akka.Done
+
+import akka.{Done, NotUsed}
 import akka.kafka.CommitterSettings
 import akka.kafka.ConsumerMessage.{Committable, CommittableOffsetBatch}
 import akka.stream.scaladsl.{Flow, Keep, Sink}
@@ -13,12 +14,21 @@ import scala.concurrent.Future
 
 object Committer {
 
-  def sink(settings: CommitterSettings): Sink[Committable, Future[Done]] =
+  /**
+   * Batches offsets and commits them to Kafka, emits `Done` for every committed batch.
+   */
+  def flow(settings: CommitterSettings): Flow[Committable, Done, NotUsed] =
     Flow[Committable]
     // Not very efficient, ideally we should merge offsets instead of grouping them
       .groupedWeightedWithin(settings.maxBatch, settings.maxInterval)(_.batchSize)
       .map(CommittableOffsetBatch.apply)
-      .mapAsync(1)(_.commitScaladsl())
+      .mapAsync(settings.parallelism)(_.commitScaladsl())
+
+  /**
+    * Batches offsets and commits them to Kafka.
+    */
+  def sink(settings: CommitterSettings): Sink[Committable, Future[Done]] =
+    flow(settings)
       .toMat(Sink.ignore)(Keep.right)
 
 }

--- a/tests/src/test/java/docs/javadsl/AtLeastOnceOneToMany.java
+++ b/tests/src/test/java/docs/javadsl/AtLeastOnceOneToMany.java
@@ -13,6 +13,7 @@ import akka.kafka.ConsumerMessage.CommittableOffsetBatch;
 import akka.kafka.ProducerMessage;
 import akka.kafka.ProducerMessage.Envelope;
 import akka.kafka.Subscriptions;
+import akka.kafka.javadsl.Committer;
 import akka.kafka.javadsl.Consumer;
 import akka.kafka.javadsl.Producer;
 import akka.stream.javadsl.Sink;
@@ -45,10 +46,7 @@ public class AtLeastOnceOneToMany extends ConsumerExample {
                 })
             .via(Producer.flexiFlow(producerSettings))
             .map(m -> m.passThrough())
-            .batch(
-                20, ConsumerMessage::createCommittableOffsetBatch, CommittableOffsetBatch::updated)
-            .mapAsync(3, m -> m.commitJavadsl())
-            .runWith(Sink.<Done>ignore(), materializer);
+            .runWith(Committer.sink(committerSettings), materializer);
     // #oneToMany
 
     done.thenAccept(m -> system.terminate());
@@ -95,10 +93,7 @@ class AtLeastOnceOneToConditional extends ConsumerExample {
                 })
             .via(Producer.flexiFlow(producerSettings))
             .map(m -> m.passThrough())
-            .batch(
-                20, ConsumerMessage::createCommittableOffsetBatch, CommittableOffsetBatch::updated)
-            .mapAsync(3, m -> m.commitJavadsl())
-            .runWith(Sink.<Done>ignore(), materializer);
+            .runWith(Committer.sink(committerSettings), materializer);
     // #oneToConditional
 
     done.thenAccept(m -> system.terminate());


### PR DESCRIPTION
* Add `Committer.flow`
* Add setting for parallelism in `Committer`
* Use type-bound instead of strict type in Java API
* Prefer `Committer` over direct committing API
* Prefer `DrainingControl` in all snippets