### PR TITLE
Use val instead of def for rebalanceListener

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -46,7 +46,7 @@ import scala.concurrent.{Future, Promise}
       log.log(partitionLogLevel, "Revoked partitions: {}. All partitions: {}", revokedTps, tps)
     }
 
-    def rebalanceListener: KafkaConsumerActor.ListenerCallbacks =
+    val rebalanceListener: KafkaConsumerActor.ListenerCallbacks =
       KafkaConsumerActor.ListenerCallbacks(
         assignedTps => {
           subscription.rebalanceListener.foreach {


### PR DESCRIPTION
There is no use of rebalanceListener being a def and a function call happening.