### PR TITLE
Resume only currently assigned partitions

### DIFF
--- a/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
@@ -589,7 +589,7 @@ object PartitionedSourceSpec {
     override def resume(partitions: java.util.Collection[TopicPartition]): Unit = {
       val ps = partitions.asScala
       log.debug(s"resuming ${ps.mkString("(", ", ", ")")}")
-      tps = tps ++ ps.map(_ -> Resumed)
+      tps = tps ++ ps.filter(tp => tps.contains(tp)).map(_ -> Resumed)
     }
   }
 

--- a/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
@@ -72,15 +72,17 @@ class PartitionedSourceSpec(_system: ActorSystem)
     dummy.setNextPollData(tp1 -> singleRecord)
     sink.requestNext().record.value() should be("value")
 
-    dummy.tpsResumed should contain allOf (tp0, tp1)
-    dummy.tpsPaused should be('empty)
+    eventually {
+      dummy.tpsResumed should contain allOf (tp0, tp1)
+      dummy.tpsPaused should be('empty)
+    }
+
     dummy.assignWithCallback(tp0)
 
     eventually {
       dummy.tpsResumed should contain only tp0
+      dummy.tpsPaused should be('empty)
     }
-
-    dummy.tpsPaused should be('empty)
 
     sink.cancel()
   }


### PR DESCRIPTION
Otherwise partitions that are no longer assigned come back to dummy consumer.

This testcase was failing when dummy consumer topic partition assignments were changed in between getting the assignments in consumer actor [here](https://github.com/akka/alpakka-kafka/blob/e5743e13b978c2c00ec22530f4662cf89ee852c9/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala#L379) and then using that value in the resume call [here](https://github.com/akka/alpakka-kafka/blob/e5743e13b978c2c00ec22530f4662cf89ee852c9/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala#L459).

Fixes #611 
