### PR TITLE
Atomically update topic partitions in the Consumer Dummy

### DIFF
--- a/tests/src/test/java/docs/javadsl/ConsumerExample.java
+++ b/tests/src/test/java/docs/javadsl/ConsumerExample.java
@@ -341,7 +341,8 @@ class ConsumerWithIndependentFlowsPerPartition extends ConsumerExample {
     // #committablePartitionedSource-stream-per-partition
     Consumer.DrainingControl<Done> control =
         Consumer.committablePartitionedSource(consumerSettings, Subscriptions.topics("topic1"))
-            .mapAsyncUnordered(maxPartitions,
+            .mapAsyncUnordered(
+                maxPartitions,
                 pair -> {
                   Source<ConsumerMessage.CommittableMessage<String, byte[]>, NotUsed> source =
                       pair.second();

--- a/tests/src/test/scala/docs/scaladsl/TestkitSamplesSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/TestkitSamplesSpec.scala
@@ -6,10 +6,10 @@
 package docs.scaladsl
 
 import akka.actor.ActorSystem
-import akka.kafka.ConsumerMessage.{CommittableOffset, CommittableOffsetBatch}
+import akka.kafka.ConsumerMessage.{CommittableOffset}
 import akka.kafka.scaladsl.{Committer, Consumer}
 import akka.kafka.{CommitterSettings, ConsumerMessage, ProducerMessage}
-import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import akka.stream.scaladsl.{Flow, Keep, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.testkit.TestKit


### PR DESCRIPTION
This is required as `tps` can be concurrently updated from the test case and from the thread that is running `KafkaConsumerActor`.