### PR TITLE
Use sbt-paradox-dependencies plugin

### DIFF
--- a/docs/src/main/paradox/home.md
+++ b/docs/src/main/paradox/home.md
@@ -38,11 +38,14 @@ If you want to try out a connector that has not yet been released, give @ref[sna
 @@dependency [Maven,sbt,Gradle] {
   group=com.typesafe.akka
   artifact=akka-stream-kafka_$scala.binary.version$
-  version=$version$
+  version=$project.version$
 }
 
 This connector depends on Akka 2.5.x and note that it is important that all `akka-*` dependencies are in the same version, so it is recommended to depend on them explicitly to avoid problems with transient dependencies causing an unlucky mix of versions.
 
+The table below shows Alpakka Kafka's direct dependencies and the second tab shows all libraries it depends on transitively.
+
+@@dependencies { module="core" }
 
 ## Scala and Java APIs
 

--- a/docs/src/main/paradox/testing.md
+++ b/docs/src/main/paradox/testing.md
@@ -5,10 +5,14 @@ To simplify testing of streaming integrations with Alpakka Kafka, it provides th
 @@dependency [Maven,sbt,Gradle] {
   group=com.typesafe.akka
   artifact=akka-stream-kafka-testkit_$scala.binary.version$
-  version=$version$
+  version=$project.version$
 }
 
 Note that Akka testkits do not promise binary compatibility. The API might be changed even between minor versions.
+
+The table below shows Alpakka Kafka testkits's direct dependencies and the second tab shows all libraries it depends on transitively.
+
+@@dependencies { module="testkit" }
 
 
 ## Mocking the Consumer or Producer

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,6 +5,8 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.7")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0")
 addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.4.2")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-dependencies" % "26-c0c675cf")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2+10-148ba0ff") // pre-release in 2m repository
 addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.14")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.13")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")


### PR DESCRIPTION
To show the direct dependencies and the transitive dependencies in the documentation.