### PR TITLE
Do not explicitly add dependency lib

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,6 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0")
 addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.4.2")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-dependencies" % "26-c0c675cf")
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2+10-148ba0ff") // pre-release in 2m repository
 addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.14")
 addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.13")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")


### PR DESCRIPTION
It comes automatically from `sbt-paradox-dependencies` as a transitive depenendency. From https://dl.bintray.com/sbt/sbt-plugin-releases/com.lightbend.paradox/sbt-paradox-dependencies/scala_2.12/sbt_1.0/26-c0c675cf/ivys/ivy.xml :

```
...
<dependency org="net.virtual-void" name="sbt-dependency-graph" rev="0.9.2+10-148ba0ff" conf="compile->default(compile)" e:sbtVersion="1.0" e:scalaVersion="2.12"/>
...
```