### PR TITLE
Exclude change in Metadata.CommitOffset from MiMa

### DIFF
--- a/core/src/main/mima-filters/1.0-M1.backwards.excludes
+++ b/core/src/main/mima-filters/1.0-M1.backwards.excludes
@@ -1,3 +1,9 @@
 # Committer parallelism
 # https://github.com/akka/alpakka-kafka/pull/647
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.CommitterSettings.this")
+
+# Include requested partition in CommittedOffset
+# https://github.com/akka/alpakka-kafka/pull/626
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Metadata#CommittedOffset.*")
+ProblemFilters.exclude[MissingTypesProblem]("akka.kafka.Metadata$CommittedOffset$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Metadata#CommittedOffset.apply")


### PR DESCRIPTION
As it turns out these excludes should have been added with #626, which is already marked as API change.