### PR TITLE
Rename Committer to InternalCommitter to reduce confusion

### DIFF
--- a/core/src/main/mima-filters/1.0-M1.backwards.excludes
+++ b/core/src/main/mima-filters/1.0-M1.backwards.excludes
@@ -1,3 +1,5 @@
+ProblemFilters.exclude[Problem]("akka.kafka.internal.*")
+
 # Committer parallelism
 # https://github.com/akka/alpakka-kafka/pull/647
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.CommitterSettings.this")

--- a/core/src/main/scala/akka/kafka/internal/CommittableSources.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommittableSources.scala
@@ -39,7 +39,7 @@ private[kafka] final class CommittableSource[K, V](settings: ConsumerSettings[K,
     with CommittableMessageBuilder[K, V] {
       override def metadataFromRecord(record: ConsumerRecord[K, V]): String = _metadataFromRecord(record)
       override def groupId: String = settings.properties(ConsumerConfig.GROUP_ID_CONFIG)
-      lazy val committer: Committer = {
+      lazy val committer: InternalCommitter = {
         val ec = materializer.executionContext
         KafkaAsyncConsumerCommitterRef(consumerActor, settings.commitTimeout)(ec)
       }
@@ -60,7 +60,7 @@ private[kafka] final class ExternalCommittableSource[K, V](consumer: ActorRef,
     with CommittableMessageBuilder[K, V] {
       override def metadataFromRecord(record: ConsumerRecord[K, V]): String = OffsetFetchResponse.NO_METADATA
       override def groupId: String = _groupId
-      lazy val committer: Committer = {
+      lazy val committer: InternalCommitter = {
         val ec = materializer.executionContext
         KafkaAsyncConsumerCommitterRef(consumerActor, commitTimeout)(ec)
       }
@@ -83,7 +83,7 @@ private[kafka] final class CommittableSubSource[K, V](settings: ConsumerSettings
     with CommittableMessageBuilder[K, V] with MetricsControl {
       override def metadataFromRecord(record: ConsumerRecord[K, V]): String = _metadataFromRecord(record)
       override def groupId: String = settings.properties(ConsumerConfig.GROUP_ID_CONFIG)
-      lazy val committer: Committer = {
+      lazy val committer: InternalCommitter = {
         val ec = materializer.executionContext
         KafkaAsyncConsumerCommitterRef(consumerActor, settings.commitTimeout)(ec)
       }
@@ -93,7 +93,7 @@ private[kafka] final class CommittableSubSource[K, V](settings: ConsumerSettings
 /**
  * Internal API.
  *
- * [[Committer]] implementation for committable sources.
+ * [[InternalCommitter]] implementation for committable sources.
  *
  * Sends [[akka.kafka.internal.KafkaConsumerActor.Internal.Commit Commit]] messages to the consumer actor.
  *
@@ -101,7 +101,7 @@ private[kafka] final class CommittableSubSource[K, V](settings: ConsumerSettings
  */
 private final case class KafkaAsyncConsumerCommitterRef(consumerActor: ActorRef, commitTimeout: FiniteDuration)(
     implicit ec: ExecutionContext
-) extends Committer {
+) extends InternalCommitter {
   import akka.pattern.ask
   import scala.collection.breakOut
 

--- a/testkit/src/main/scala/akka/kafka/testkit/ConsumerResultFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/ConsumerResultFactory.scala
@@ -9,7 +9,7 @@ import akka.Done
 import akka.annotation.ApiMayChange
 import akka.kafka.ConsumerMessage
 import akka.kafka.ConsumerMessage.{CommittableOffset, GroupTopicPartition, PartitionOffset}
-import akka.kafka.internal.{CommittableOffsetImpl, Committer}
+import akka.kafka.internal.{CommittableOffsetImpl, InternalCommitter}
 import org.apache.kafka.clients.consumer.ConsumerRecord
 
 import scala.collection.immutable
@@ -21,7 +21,7 @@ import scala.concurrent.Future
 @ApiMayChange
 object ConsumerResultFactory {
 
-  val fakeCommitter = new Committer {
+  val fakeCommitter = new InternalCommitter {
     override def commit(
         offsets: immutable.Seq[ConsumerMessage.PartitionOffsetMetadata]
     ): Future[Done] = Future.successful(Done)


### PR DESCRIPTION
...with the newish user API `Committer` (The internal class will show in completion for Java users as it is `private[kafka]`).