### PR TITLE
Add Scaladoc flags

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import com.lightbend.paradox.markdown.GitHubResolver
 import sbt.Resolver
 enablePlugins(AutomateHeaderPlugin)
 
@@ -66,8 +67,6 @@ val kafkaScale = settingKey[Int]("Number of kafka docker containers")
 
 resolvers in ThisBuild ++= Seq(Resolver.bintrayRepo("manub", "maven"))
 
-// TODO read version or master
-val githubTree = "master"
 val commonSettings = Seq(
   organization := "com.typesafe.akka",
   organizationName := "Lightbend Inc.",
@@ -104,8 +103,10 @@ val commonSettings = Seq(
     version.value,
     "-sourcepath",
     (baseDirectory in ThisBuild).value.toString,
-    "-doc-source-url",
-    s"https://github.com/akka/alpakka-kafka/tree/${githubTree}€{FILE_PATH}.scala",
+    "-doc-source-url", {
+      val branch = if (isSnapshot.value) "master" else s"v$version"
+      s"https://github.com/akka/alpakka-kafka/tree/${branch}€{FILE_PATH}.scala#L1"
+    },
     "-skip-packages",
     "akka.pattern" // for some reason Scaladoc creates this
   ),

--- a/build.sbt
+++ b/build.sbt
@@ -66,6 +66,8 @@ val kafkaScale = settingKey[Int]("Number of kafka docker containers")
 
 resolvers in ThisBuild ++= Seq(Resolver.bintrayRepo("manub", "maven"))
 
+// TODO read version or master
+val githubTree = "master"
 val commonSettings = Seq(
   organization := "com.typesafe.akka",
   organizationName := "Lightbend Inc.",
@@ -94,6 +96,18 @@ val commonSettings = Seq(
     "-Ywarn-dead-code",
     "-Ywarn-numeric-widen",
     "-Xfuture"
+  ),
+  scalacOptions in (Compile, doc) := scalacOptions.value ++ Seq(
+    "-doc-title",
+    "Alpakka Kafka",
+    "-doc-version",
+    version.value,
+    "-sourcepath",
+    (baseDirectory in ThisBuild).value.toString,
+    "-doc-source-url",
+    s"https://github.com/akka/alpakka-kafka/tree/${githubTree}€{FILE_PATH}.scala",
+    "-skip-packages",
+    "akka.pattern" // for some reason Scaladoc creates this
   ),
   // show full stack traces and test case durations
   testOptions += Tests.Argument("-oDF"),

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import com.lightbend.paradox.markdown.GitHubResolver
 import sbt.Resolver
 enablePlugins(AutomateHeaderPlugin)
 

--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -180,7 +180,7 @@ object ConsumerSettings {
 
 /**
  * Settings for consumers. See `akka.kafka.consumer` section in
- * `reference.conf`. Note that the [[akka.kafka.ConsumerSetting$ companion]] object provides
+ * `reference.conf`. Note that the [[akka.kafka.ConsumerSettings$ companion]] object provides
  * `apply` and `create` functions for convenient construction of the settings, together with
  * the `with` methods.
  *


### PR DESCRIPTION
* Add linking to sources from Scaladoc
* Set title and version in Scaladoc
* Exclude the mysterious `akka.pattern` package

TODO: select the correct tree for the Github link