### PR TITLE
Mark Scalatest `provided` in Testkit; sbt 1.2.7; upgrades

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ val coreDependencies = Seq(
 val testkitDependencies = Seq(
   "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion,
   "net.manub" %% "scalatest-embedded-kafka" % "2.0.0" exclude ("log4j", "log4j"),
-  "org.scalatest" %% "scalatest" % scalatestVersion % "provided",
+  "org.scalatest" %% "scalatest" % scalatestVersion % Provided,
   "org.apache.kafka" %% "kafka" % kafkaVersion exclude ("org.slf4j", "slf4j-log4j12")
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ val testDependencies = Seq(
   "org.slf4j" % "log4j-over-slf4j" % slf4jVersion % Test,
   // Schema registry uses Glassfish which uses java.util.logging
   "org.slf4j" % "jul-to-slf4j" % slf4jVersion % Test,
-  "org.mockito" % "mockito-core" % "2.22.0" % Test
+  "org.mockito" % "mockito-core" % "2.23.4" % Test
 )
 
 val integrationTestDependencies = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -18,21 +18,18 @@ val coreDependencies = Seq(
 val testkitDependencies = Seq(
   "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion,
   "net.manub" %% "scalatest-embedded-kafka" % "2.0.0" exclude ("log4j", "log4j"),
-  "org.scalatest" %% "scalatest" % scalatestVersion,
+  "org.scalatest" %% "scalatest" % scalatestVersion % "provided",
   "org.apache.kafka" %% "kafka" % kafkaVersion exclude ("org.slf4j", "slf4j-log4j12")
 )
 
-val confluentAvroSerializerVersion = "5.0.0"
+val confluentAvroSerializerVersion = "5.0.1"
 
 val testDependencies = Seq(
   "io.confluent" % "kafka-avro-serializer" % confluentAvroSerializerVersion % Test,
-  // See https://github.com/sbt/sbt/issues/3618
-  "javax.ws.rs" % "javax.ws.rs-api" % "2.1" artifacts Artifact("javax.ws.rs-api", "jar", "jar"),
   "net.manub" %% "scalatest-embedded-schema-registry" % "2.0.0" % Test exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"),
   "org.scalatest" %% "scalatest" % scalatestVersion % Test,
-  "org.reactivestreams" % "reactive-streams-tck" % "1.0.2" % Test,
-  "io.spray" %% "spray-json" % "1.3.4" % Test,
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.6" % Test, // ApacheV2
+  "io.spray" %% "spray-json" % "1.3.5" % Test,
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.7" % Test, // ApacheV2
   "com.novocode" % "junit-interface" % "0.11" % Test,
   "junit" % "junit" % "4.12" % Test,
   "com.typesafe.akka" %% "akka-slf4j" % akkaVersion % Test,
@@ -229,6 +226,7 @@ lazy val docs = project
       "akka.version" -> akkaVersion,
       "kafka.version" -> kafkaVersion,
       "confluent.version" -> confluentAvroSerializerVersion,
+      "scalatest.version" -> scalatestVersion,
       "extref.akka-docs.base_url" -> s"https://doc.akka.io/docs/akka/$akkaVersion/%s",
       "extref.kafka-docs.base_url" -> s"https://kafka.apache.org/$kafkaVersionForDocs/documentation/%s",
       "extref.java-docs.base_url" -> "https://docs.oracle.com/en/java/javase/11/%s",

--- a/docs/src/main/paradox/testing.md
+++ b/docs/src/main/paradox/testing.md
@@ -60,7 +60,7 @@ The `KafkaSpec` class offers access to
 
 `EmbeddedKafkaLike` extends `KafkaSpec` to add automatic starting and stopping of the embedded Kafka broker.
 
-Most Alpakka Kafka tests implemented in Scala use [Scalatest](http://www.scalatest.org/) with the mix-ins shown below.
+Most Alpakka Kafka tests implemented in Scala use [Scalatest](http://www.scalatest.org/) with the mix-ins shown below. You need to add Scalatest explicitly in your test dependencies (this release of Alpakka Kafka uses Scalatest $scalatest.version$.)
 
 Scala
 : @@snip [snip](/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala) { #testkit }

--- a/project/PackagingTypePlugin.scala
+++ b/project/PackagingTypePlugin.scala
@@ -1,0 +1,10 @@
+import sbt._
+
+// See https://github.com/sbt/sbt/issues/3618#issuecomment-424924293
+// for  "javax.ws.rs" % "javax.ws.rs-api" % "2.1" artifacts Artifact("javax.ws.rs-api", "jar", "jar"),
+object PackagingTypePlugin extends AutoPlugin {
+  override val buildSettings = {
+    sys.props += "packaging.type" -> "jar"
+    Nil
+  }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.2.7


### PR DESCRIPTION
* Testkit should not pull in Scalatest (for Java users)
* sbt 1.2.7
* Better fix for `javax.ws.rs-api` inconsistency
* Removed unused Reactive Streams TCK