### PR TITLE
Changes for running benchmarks on Jenkins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ jobs:
 
     - stage: integration
       env: CMD="dockerComposeTestAll"
-    - env: CMD="benchmarks/dockerComposeTest it:test"
+    - env: CMD="benchmarks/It/compile"
 
     - stage: whitesource
       env: CMD=";whitesourceCheckPolicies ;whitesourceUpdate"

--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/BenchmarksBase.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/BenchmarksBase.scala
@@ -20,11 +20,11 @@ abstract class BenchmarksBase(name: String) extends ScalatestKafkaSpec(0) with F
 }
 
 class ApacheKafkaConsumerNokafka extends BenchmarksBase("ApacheKafkaConsumerNokafka") {
-  it should "bench" in Benchmarks.run(RunTestCommand("apache-kafka-consumer-nokafka", bootstrapServers, 2000000))
+  it should "bench" in Benchmarks.run(RunTestCommand("apache-kafka-plain-consumer-nokafka", bootstrapServers, 2000000))
 }
 
 class AlpakkaKafkaConsumerNokafka extends BenchmarksBase("AlpakkaKafkaConsumerNokafka") {
-  it should "bench" in Benchmarks.run(RunTestCommand("alpakka-kafka-consumer-nokafka", bootstrapServers, 2000000))
+  it should "bench" in Benchmarks.run(RunTestCommand("alpakka-kafka-plain-consumer-nokafka", bootstrapServers, 2000000))
 }
 
 class ApacheKafkaPlainConsumer extends BenchmarksBase("ApacheKafkaPlainConsumer") {

--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ val coreDependencies = Seq(
 )
 
 val testkitDependencies = Seq(
+  "com.typesafe.akka" %% "akka-testkit" % akkaVersion,
   "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion,
   "net.manub" %% "scalatest-embedded-kafka" % "2.0.0" exclude ("log4j", "log4j"),
   "org.apache.commons" % "commons-compress" % "1.18", // embedded Kafka pulls in Avro which pulls in commons-compress 1.8.1


### PR DESCRIPTION
This PR changes Travis configuration to only compile benchmark source files.

Benchmarks are now being run nightly twice on the Akka Jenkins cluster: https://jenkins.akka.io:8498/job/alpakka-kafka-perf-master/plot/ Last 40 runs are stored and plotted.

Fixes #688