### PR TITLE
Fix transactional producer resume demand

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
@@ -107,7 +107,7 @@ private final class TransactionalProducerStageLogic[K, V, P](stage: Transactiona
       override def onPull(): Unit = tryPull(stage.in)
     })
     // kick off demand for more messages if we're resuming demand
-    if (tryToPull && !hasBeenPulled(stage.in)) {
+    if (tryToPull && isAvailable(stage.out) && !hasBeenPulled(stage.in)) {
       tryPull(stage.in)
     }
   }


### PR DESCRIPTION
Check if the outlet is available before resuming demand in transactional producer stage to fix #484 