### PR TITLE
Add partitioned transactional source

### DIFF
--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -122,9 +122,14 @@ object ConsumerMessage {
   final case class PartitionOffsetMetadata(key: GroupTopicPartition, offset: Long, metadata: String)
 
   /**
+   * Messages that originate from a transactional partitioned source
+   */
+  trait FromPartitionedSource
+
+  /**
    * Internal Api
    */
-  @InternalApi private[kafka] final case class PartitionOffsetCommittedMarker(
+  @InternalApi private[kafka] case class PartitionOffsetCommittedMarker(
       override val key: GroupTopicPartition,
       override val offset: Long,
       private[kafka] val committedMarker: CommittedMarker

--- a/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
@@ -21,10 +21,10 @@ import scala.concurrent.duration._
  * Implemented by [[DefaultProducerStage]] and [[TransactionalProducerStage]].
  */
 @InternalApi
-private[internal] trait ProducerStage[K, V, P, IN <: Envelope[K, V, P], OUT <: Results[K, V, P]] {
+private[internal] trait ProducerStage[K, V, P, IN <: Envelope[K, V, P], OUT <: Results[K, V, P], S] {
   val closeTimeout: FiniteDuration
   val closeProducerOnStop: Boolean
-  val producerProvider: () => Producer[K, V]
+  val producerProvider: S => Producer[K, V]
 
   val in: Inlet[IN] = Inlet[IN]("messages")
   val out: Outlet[Future[OUT]] = Outlet[Future[OUT]]("result")

--- a/core/src/main/scala/akka/kafka/internal/TransactionalSources.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalSources.scala
@@ -6,16 +6,17 @@
 package akka.kafka.internal
 import java.util.Locale
 
-import akka.Done
+import akka.{Done, NotUsed}
 import akka.actor.{ActorRef, Status, Terminated}
 import akka.actor.Status.Failure
 import akka.annotation.InternalApi
 import akka.kafka.ConsumerMessage.TransactionalMessage
 import akka.kafka.internal.KafkaConsumerActor.Internal.Revoked
 import akka.kafka.scaladsl.Consumer.Control
-import akka.kafka.{ConsumerFailed, ConsumerSettings, Subscription}
+import akka.kafka.{AutoSubscription, ConsumerFailed, ConsumerSettings, Subscription}
 import akka.stream.SourceShape
-import akka.stream.stage.GraphStageLogic
+import akka.stream.scaladsl.Source
+import akka.stream.stage.{AsyncCallback, GraphStageLogic}
 import akka.util.Timeout
 import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord, OffsetAndMetadata}
 import org.apache.kafka.common.TopicPartition
@@ -47,7 +48,9 @@ private[kafka] final class TransactionalSource[K, V](consumerSettings: ConsumerS
   )
 
   override protected def logic(shape: SourceShape[TransactionalMessage[K, V]]): GraphStageLogic with Control =
-    new TransactionalSourceLogic(shape, txConsumerSettings, subscription) with TransactionalMessageBuilder[K, V]
+    new TransactionalSourceLogic(shape, txConsumerSettings, subscription) with TransactionalMessageBuilder[K, V] {
+      override val fromPartitionedSource: Boolean = false
+    }
 
 }
 
@@ -139,9 +142,141 @@ private[internal] abstract class TransactionalSourceLogic[K, V, Msg](shape: Sour
 
 /** Internal API */
 @InternalApi
-private object TransactionalSourceLogic {
-  type Offset = Long
+private[kafka] final class TransactionalSubSource[K, V](
+    consumerSettings: ConsumerSettings[K, V],
+    subscription: AutoSubscription
+) extends KafkaSourceStage[K, V, (TopicPartition, Source[TransactionalMessage[K, V], NotUsed])](
+      s"TransactionalSubSource ${subscription.renderStageAttribute}"
+    ) {
+  import TransactionalSourceLogic._
 
+  require(consumerSettings.properties(ConsumerConfig.GROUP_ID_CONFIG).nonEmpty, "You must define a Consumer group.id.")
+
+  /**
+   * We set the isolation.level config to read_committed to make sure that any consumed messages are from
+   * committed transactions. Note that the consuming partitions may be produced by multiple producers, and these
+   * producers may either use transactional messaging or not at all. So the fetching partitions may have both
+   * transactional and non-transactional messages, and by setting isolation.level config to read_committed consumers
+   * will still consume non-transactional messages.
+   */
+  private val txConsumerSettings = consumerSettings.withProperty(
+    ConsumerConfig.ISOLATION_LEVEL_CONFIG,
+    IsolationLevel.READ_COMMITTED.toString.toLowerCase(Locale.ENGLISH)
+  )
+
+  override protected def logic(
+      shape: SourceShape[(TopicPartition, Source[TransactionalMessage[K, V], NotUsed])]
+  ): GraphStageLogic with Control = {
+    def factory(shape: SourceShape[TransactionalMessage[K, V]],
+                tp: TopicPartition,
+                consumerActor: ActorRef,
+                subSourceStartedCb: AsyncCallback[(TopicPartition, (Control, ActorRef))],
+                subSourceCancelledCb: AsyncCallback[(TopicPartition, Option[ConsumerRecord[K, V]])],
+                actorNumber: Int): MessageSubSourceLogic[K, V, TransactionalMessage[K, V]] =
+      new MessageSubSourceLogic[K, V, TransactionalMessage[K, V]](shape,
+                                                                  tp,
+                                                                  consumerActor,
+                                                                  subSourceStartedCb,
+                                                                  subSourceCancelledCb,
+                                                                  actorNumber) with TransactionalMessageBuilder[K, V] {
+
+        override val fromPartitionedSource: Boolean = true
+        val inFlightRecords = InFlightRecords.empty
+
+        override protected def messageHandling: PartialFunction[(ActorRef, Any), Unit] =
+          super.messageHandling.orElse(drainHandling).orElse {
+            case (_, Revoked(tps)) =>
+              inFlightRecords.revoke(tps.toSet)
+          }
+
+        def shuttingDownReceive: PartialFunction[(ActorRef, Any), Unit] =
+          drainHandling
+            .orElse {
+              case (_, Status.Failure(e)) =>
+                failStage(e)
+              case (_, Terminated(ref)) if ref == consumerActor =>
+                failStage(new ConsumerFailed())
+            }
+
+        override def performShutdown(): Unit = {
+          setKeepGoing(true)
+          if (!isClosed(shape.out)) {
+            complete(shape.out)
+          }
+          subSourceActor.become(shuttingDownReceive)
+          drainAndComplete()
+        }
+
+        def drainAndComplete(): Unit =
+          subSourceActor.ref.tell(Drain(inFlightRecords.assigned(), None, "complete"), subSourceActor.ref)
+
+        def drainHandling: PartialFunction[(ActorRef, Any), Unit] = {
+          case (sender, Committed(offsets)) =>
+            inFlightRecords.committed(offsets.mapValues(_.offset() - 1))
+            sender ! Done
+          case (sender, CommittingFailure) => {
+            log.info("Committing failed, resetting in flight offsets")
+            inFlightRecords.reset()
+          }
+          case (sender, Drain(partitions, ack, msg)) =>
+            if (inFlightRecords.empty(partitions)) {
+              log.debug(s"Partitions drained ${partitions.mkString(",")}")
+              ack.getOrElse(sender) ! msg
+            } else {
+              log.debug(s"Draining partitions {}", partitions)
+              materializer.scheduleOnce(consumerSettings.drainingCheckInterval, new Runnable {
+                override def run(): Unit =
+                  subSourceActor.ref ! Drain(partitions, ack.orElse(Some(sender)), msg)
+              })
+            }
+          case (sender, "complete") =>
+            completeStage()
+        }
+
+        override def groupId: String = txConsumerSettings.properties(ConsumerConfig.GROUP_ID_CONFIG)
+
+        lazy val committedMarker: CommittedMarker = {
+          val ec = materializer.executionContext
+          CommittedMarkerRef(subSourceActor.ref, consumerSettings.commitTimeout)(ec)
+        }
+
+        override def onMessage(rec: ConsumerRecord[K, V]): Unit =
+          inFlightRecords.add(Map(new TopicPartition(rec.topic(), rec.partition()) -> rec.offset()))
+      }
+
+    new SubSourceLogic[K, V, TransactionalMessage[K, V]](shape,
+                                                         txConsumerSettings,
+                                                         subscription,
+                                                         msgSourceLogicFactory = factory) {
+      override protected def blockingRevokedHandler(revokedTps: Set[TopicPartition]): Unit =
+        if (waitForDraining(revokedTps)) {
+          subSources.values.map(_._2).foreach(_ ! Revoked(revokedTps.toList))
+        } else {
+          sourceActor.ref ! Status.Failure(new Error("Timeout while draining"))
+          consumerActor ! KafkaConsumerActor.Internal.Stop
+        }
+
+      def waitForDraining(partitions: Set[TopicPartition]): Boolean = {
+        import akka.pattern.ask
+        implicit val timeout = Timeout(txConsumerSettings.commitTimeout)
+        try {
+          val drainCommandFutures = subSources.values.map(_._2).map(ask(_, Drain(partitions, None, Drained)))
+          implicit val ec = executionContext
+          Await.result(Future.sequence(drainCommandFutures), timeout.duration)
+          true
+        } catch {
+          case t: Throwable =>
+            false
+        }
+      }
+    }
+
+  }
+}
+
+/** Internal API */
+@InternalApi
+private object TransactionalSourceLogic {
   case object Drained
   case class Drain[T](partitions: Set[TopicPartition],
                       drainedConfirmationRef: Option[ActorRef],
@@ -149,8 +284,7 @@ private object TransactionalSourceLogic {
   case class Committed(offsets: Map[TopicPartition, OffsetAndMetadata])
   case object CommittingFailure
 
-  private[TransactionalSourceLogic] final case class CommittedMarkerRef(sourceActor: ActorRef,
-                                                                        commitTimeout: FiniteDuration)(
+  private[internal] final case class CommittedMarkerRef(sourceActor: ActorRef, commitTimeout: FiniteDuration)(
       implicit ec: ExecutionContext
   ) extends CommittedMarker {
     override def committed(offsets: Map[TopicPartition, OffsetAndMetadata]): Future[Done] = {
@@ -164,7 +298,9 @@ private object TransactionalSourceLogic {
       sourceActor ! CommittingFailure
   }
 
-  private[TransactionalSourceLogic] trait InFlightRecords {
+  type Offset = Long
+
+  private[internal] trait InFlightRecords {
     // Assumes that offsets per topic partition are added in the increasing order
     // The assumption is true for Kafka consumer that guarantees that elements are emitted
     // per partition in offset-increasing order.
@@ -177,7 +313,7 @@ private object TransactionalSourceLogic {
     def empty(partitions: Set[TopicPartition]): Boolean
   }
 
-  private[TransactionalSourceLogic] object InFlightRecords {
+  private[internal] object InFlightRecords {
     def empty = new Impl
 
     class Impl extends InFlightRecords {

--- a/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
@@ -163,7 +163,7 @@ object Producer {
         new DefaultProducerStage[K, V, PassThrough, Message[K, V, PassThrough], Result[K, V, PassThrough]](
           settings.closeTimeout,
           closeProducerOnStop = true,
-          () => settings.createKafkaProducer()
+          _ => settings.createKafkaProducer()
         )
       )
       .mapAsync(settings.parallelism)(identity)
@@ -194,7 +194,7 @@ object Producer {
         new DefaultProducerStage[K, V, PassThrough, Envelope[K, V, PassThrough], Results[K, V, PassThrough]](
           settings.closeTimeout,
           closeProducerOnStop = true,
-          () => settings.createKafkaProducer()
+          _ => settings.createKafkaProducer()
         )
       )
       .mapAsync(settings.parallelism)(identity)
@@ -223,7 +223,7 @@ object Producer {
         new DefaultProducerStage[K, V, PassThrough, Message[K, V, PassThrough], Result[K, V, PassThrough]](
           closeTimeout = settings.closeTimeout,
           closeProducerOnStop = false,
-          producerProvider = () => producer
+          producerProvider = _ => producer
         )
       )
       .mapAsync(settings.parallelism)(identity)
@@ -257,7 +257,7 @@ object Producer {
         new DefaultProducerStage[K, V, PassThrough, Envelope[K, V, PassThrough], Results[K, V, PassThrough]](
           closeTimeout = settings.closeTimeout,
           closeProducerOnStop = false,
-          producerProvider = () => producer
+          producerProvider = _ => producer
         )
       )
       .mapAsync(settings.parallelism)(identity)

--- a/docs/src/main/paradox/transactions.md
+++ b/docs/src/main/paradox/transactions.md
@@ -54,6 +54,20 @@ Scala
 Java
 : @@ snip [snip](/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java) { #transactionalFailureRetry }
 
+### Partitioned Example
+
+`Transactional.partitionedSource` 
+(@scala[@scaladoc[Transactional API](akka.kafka.scaladsl.Transactional$)]@java[@scaladoc[Transactional API](akka.kafka.javadsl.Transactional$)])
+ support tracking the automatic partition assignment from Kafka. When a topic-partition is assigned to a consumer, this source will emit a tuple with the assigned topic-partition and a corresponding source. When a topic-partition is revoked, the corresponding source completes.
+ 
+By generating the `transactional.id` from the [[TopicPartition]], multiple instances of your application can run without having to manually assign partitions to each instance.
+
+Scala
+: @@ snip [snip](/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala) { #partitionedTransactionalSink }
+
+Java
+: @@ snip [snip](/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java) { #partitionedTransactionalSink }
+
 ## Caveats
 
 There are several scenarios that this library's implementation of Kafka transactions does not automatically account for.

--- a/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
@@ -94,7 +94,7 @@ class ProducerSpec(_system: ActorSystem)
       .fromGraph(
         new DefaultProducerStage[K, V, P, Message[K, V, P], Result[K, V, P]](settings.closeTimeout,
                                                                              closeOnStop,
-                                                                             () => mock.mock)
+                                                                             _ => mock.mock)
       )
       .mapAsync(1)(identity)
 
@@ -104,7 +104,8 @@ class ProducerSpec(_system: ActorSystem)
       .fromGraph(
         new TransactionalProducerStage[K, V, P](settings.closeTimeout,
                                                 closeOnStop,
-                                                () => mock.mock,
+                                                _ => mock.mock,
+                                                "some-transaction-id",
                                                 settings.eosCommitInterval)
       )
       .mapAsync(1)(identity)

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -299,6 +299,92 @@ class IntegrationSpec extends SpecBase(kafkaPort = KafkaPorts.IntegrationSpec) w
       }
     }
 
+    "partitioned transactional flow rebalances safely" in assertAllStagesStopped {
+      val partitions = 4
+      val totalMessages = 200L
+
+      val topic = createTopic(1, partitions)
+      val outTopic = createTopic(2, partitions)
+      val group = createGroupId(1)
+      val transactionalId = createTransactionalId()
+      val sourceSettings = consumerDefaults
+        .withGroupId(group)
+
+      val topicSubscription = Subscriptions.topics(topic)
+
+      def createAndRunTransactionalFlow(subscription: AutoSubscription) =
+        Transactional
+          .partitionedSource(sourceSettings, subscription)
+          .map {
+            case (tp, source) =>
+              source
+                .map(
+                  msg =>
+                    ProducerMessage.single(new ProducerRecord[String, String](outTopic,
+                                                                              msg.record.partition(),
+                                                                              msg.record.key(),
+                                                                              msg.record.value() + "-out"),
+                                           msg.partitionOffset)
+                )
+                .to(Transactional.sink(producerDefaults, transactionalId))
+                .run()
+          }
+          .toMat(Sink.ignore)(Keep.both)
+          .mapMaterializedValue(DrainingControl.apply)
+          .run()
+
+      def createAndRunProducer(elements: immutable.Iterable[Long]) =
+        Source(elements)
+          .map(n => new ProducerRecord(topic, (n % partitions).toInt, DefaultKey, n.toString))
+          .runWith(Producer.plainSink(producerDefaults, testProducer))
+
+      val control = createAndRunTransactionalFlow(topicSubscription)
+
+      // waits until all partitions are assigned to the single consumer
+      waitUntilConsumerSummary(group) {
+        case singleConsumer :: Nil => singleConsumer.assignment.topicPartitions.size == partitions
+      }
+
+      createAndRunProducer(0L until totalMessages / 2).futureValue
+
+      // create another consumer with the same groupId to trigger re-balancing
+      val control2 = createAndRunTransactionalFlow(topicSubscription)
+
+      // waits until partitions are assigned across both consumers
+      waitUntilConsumerSummary(group) {
+        case consumer1 :: consumer2 :: Nil =>
+          val half = partitions / 2
+          consumer1.assignment.topicPartitions.size == half && consumer2.assignment.topicPartitions.size == half
+      }
+
+      createAndRunProducer(totalMessages / 2 until totalMessages).futureValue
+
+      val checkingGroup = createGroupId(2)
+
+      val (counterQueue, counterCompletion) = Source
+        .queue[String](8, OverflowStrategy.fail)
+        .scan(0L)((c, _) => c + 1)
+        .takeWhile(_ < totalMessages, inclusive = true)
+        .toMat(Sink.last)(Keep.both)
+        .run()
+
+      val streamMessages = Consumer
+        .plainSource[String, String](consumerDefaults
+                                       .withGroupId(checkingGroup)
+                                       .withProperty(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed"),
+                                     Subscriptions.topics(outTopic))
+        .mapAsync(1)(el => counterQueue.offer(el.value()).map(_ => el))
+        .scan(0L)((c, _) => c + 1)
+        .toMat(Sink.last)(Keep.both)
+        .mapMaterializedValue(DrainingControl.apply)
+        .run()
+
+      counterCompletion.futureValue shouldBe totalMessages
+
+      control.drainAndShutdown().futureValue
+      control2.drainAndShutdown().futureValue
+      streamMessages.drainAndShutdown().futureValue shouldBe totalMessages
+    }
   }
 
   "Consumer control" must {


### PR DESCRIPTION
By adding a partitioned transactional source, a new producer will be created per topic-partition when hooked up with the sink or flow. If the `transactional.id` is based on the topic-partition then can get around the restriction of distributing the workload across multiple instances without getting `ProducerFencedException`s.

This was based on reviewing the comments in this thread: https://github.com/akka/alpakka-kafka/pull/420#pullrequestreview-111036369