### PR TITLE
Update matching Akka version to 2.5.x for release 0.18 on home.md

### DIFF
--- a/docs/src/main/paradox/home.md
+++ b/docs/src/main/paradox/home.md
@@ -17,7 +17,7 @@ This **Alpakka Kafka connector** lets you connect [Apache Kafka](https://kafka.a
 |1.1.x  | 2.5.x        | [release 0.20+](https://github.com/akka/reactive-kafka/releases)
 |1.0.x  | 2.5.x        | [release 0.20+](https://github.com/akka/reactive-kafka/releases)
 |0.11.x | 2.5.x        | [release 0.19](https://github.com/akka/reactive-kafka/milestone/19?closed=1)
-|0.11.x | 2.4.x        | [release 0.18](https://github.com/akka/reactive-kafka/milestone/18?closed=1)
+|0.11.x | 2.5.x        | [release 0.18](https://github.com/akka/reactive-kafka/milestone/18?closed=1)
 
 
 ## Dependencies


### PR DESCRIPTION
Fixes the docs to include Akka 2.5.x as a matching version of 0.18 release, instead of 2.4.x

From 0.18 README.md

> Please note that the library depends on Akka 2.5.x. It can't be used with Akka 2.4.x. Version 0.17 and earlier can be used with Akka 2.4.x

[0.18 README.md](https://github.com/akka/alpakka-kafka/blob/v0.18/README.md)
