### PR TITLE
Add assertAllStagesStopped; upgrade to JUnit 5 interface 0.8.1

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -21,5 +21,5 @@ addSbtPlugin("com.github.ehsanyou" % "sbt-docker-compose" % "67284e73-envvars-2m
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2+10-148ba0ff")
 resolvers += Resolver.bintrayIvyRepo("2m", "sbt-plugins")
 
-addSbtPlugin("net.aichler" % "sbt-jupiter-interface" % "0.8.0")
+addSbtPlugin("net.aichler" % "sbt-jupiter-interface" % "0.8.1")
 resolvers += Resolver.jcenterRepo

--- a/tests/src/test/scala/docs/scaladsl/AtLeastOnce.scala
+++ b/tests/src/test/scala/docs/scaladsl/AtLeastOnce.scala
@@ -13,6 +13,7 @@ import akka.kafka.scaladsl.Consumer.DrainingControl
 import akka.kafka.{KafkaPorts, ProducerMessage, Subscriptions}
 import akka.kafka.scaladsl.{Committer, Consumer, Producer}
 import akka.stream.scaladsl.{Keep, Sink}
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import net.manub.embeddedkafka.EmbeddedKafkaConfig
 import org.apache.kafka.clients.producer.ProducerRecord
 
@@ -29,7 +30,7 @@ class AtLeastOnce extends DocsSpecBase(KafkaPorts.ScalaAtLeastOnceExamples) {
 
   override def sleepAfterProduce: FiniteDuration = 10.seconds
 
-  "Connect a Consumer to Producer" should "map messages one-to-many, and commit in batches" in {
+  "Connect a Consumer to Producer" should "map messages one-to-many, and commit in batches" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val immutable.Seq(topic1, topic2, topic3) = createTopics(1, 2, 3)
     val producerSettings = producerDefaults
@@ -65,7 +66,7 @@ class AtLeastOnce extends DocsSpecBase(KafkaPorts.ScalaAtLeastOnceExamples) {
     result.futureValue should have size (20)
   }
 
-  "At-Least-Once One To Conditional" should "work" in {
+  "At-Least-Once One To Conditional" should "work" in assertAllStagesStopped {
 
     def duplicate(value: String): Boolean = "1" == value
     def ignore(value: String): Boolean = "2" == value

--- a/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
@@ -14,6 +14,7 @@ import akka.kafka.scaladsl.Consumer.DrainingControl
 import akka.kafka.scaladsl._
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.stream.scaladsl.{Flow, Keep, RestartSource, Sink, Source}
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.{Done, NotUsed}
 import net.manub.embeddedkafka.EmbeddedKafkaConfig
 import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord}
@@ -39,7 +40,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.ScalaConsumerExamples) {
   override def sleepAfterProduce: FiniteDuration = 4.seconds
   private def waitBeforeValidation(): Unit = sleep(4.seconds)
 
-  "ExternalOffsetStorage" should "work" in {
+  "ExternalOffsetStorage" should "work" in assertAllStagesStopped {
     val topic = createTopic()
     val consumerSettings = consumerDefaults.withClientId("externalOffsetStorage")
     // format: off
@@ -112,7 +113,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.ScalaConsumerExamples) {
     consumerSettingsWithAutoCommit
   }
 
-  "Consume messages at-most-once" should "work" in {
+  "Consume messages at-most-once" should "work" in assertAllStagesStopped {
     val consumerSettings = createSettings().withGroupId(createGroupId())
     val topic = createTopic()
     val totalMessages = 10
@@ -146,7 +147,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.ScalaConsumerExamples) {
 
   def business(rec: ConsumerRecord[String, String]): Future[Done] = Future.successful(Done)
 
-  "Consume messages at-least-once" should "work" in {
+  "Consume messages at-least-once" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val topic = createTopic()
     // #atLeastOnce
@@ -173,7 +174,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.ScalaConsumerExamples) {
     Future.successful(Done)
   // format: on
 
-  "Consume messages at-least-once, and commit in batches" should "work" in {
+  "Consume messages at-least-once, and commit in batches" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val topic = createTopic()
     // #commitWithMetadata
@@ -195,7 +196,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.ScalaConsumerExamples) {
     control.drainAndShutdown().futureValue should be(Done)
   }
 
-  "Consume messages at-least-once, and commit with a committer sink" should "work" in {
+  "Consume messages at-least-once, and commit with a committer sink" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val topic = createTopic()
     // #committerSink
@@ -216,7 +217,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.ScalaConsumerExamples) {
     Await.result(control.drainAndShutdown(), 5.seconds)
   }
 
-  "Connect a Consumer to Producer" should "work" in {
+  "Connect a Consumer to Producer" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val immutable.Seq(topic1, topic2, targetTopic) = createTopics(1, 2, 3)
     val producerSettings = producerDefaults
@@ -249,7 +250,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.ScalaConsumerExamples) {
 
   }
 
-  "Connect a Consumer to Producer" should "support flows" in {
+  "Connect a Consumer to Producer" should "support flows" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val immutable.Seq(topic, targetTopic) = createTopics(1, 2)
     val producerSettings = producerDefaults
@@ -281,7 +282,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.ScalaConsumerExamples) {
     Await.result(receiveControl.drainAndShutdown(), 5.seconds) should have size (10)
   }
 
-  "Backpressure per partition with batch commit" should "work" in {
+  "Backpressure per partition with batch commit" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId()).withStopTimeout(10.millis)
     val topic = createTopic()
     val maxPartitions = 100
@@ -299,7 +300,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.ScalaConsumerExamples) {
     control.drainAndShutdown().futureValue should be(Done)
   }
 
-  "Flow per partition" should "Process each assigned partition separately" in {
+  "Flow per partition" should "Process each assigned partition separately" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId()).withStopTimeout(10.millis)
     val comitterSettings = committerDefaults
     val topic = createTopic()
@@ -322,7 +323,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.ScalaConsumerExamples) {
     control.drainAndShutdown().futureValue should be(Done)
   }
 
-  "Rebalance Listener" should "get messages" in {
+  "Rebalance Listener" should "get messages" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val topic = createTopic()
     val assignedPromise = Promise[Done]
@@ -370,7 +371,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.ScalaConsumerExamples) {
     revokedPromise.future.futureValue should be(Done)
   }
 
-  "Shutdown via Consumer.Control" should "work" in {
+  "Shutdown via Consumer.Control" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val topic = createTopic()
     val offset = 123456L
@@ -390,7 +391,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.ScalaConsumerExamples) {
     Await.result(consumerControl.shutdown(), 5.seconds) should be(Done)
   }
 
-  "Shutdown when batching commits" should "work" in {
+  "Shutdown when batching commits" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val topic = createTopic()
     val committerSettings = committerDefaults
@@ -410,7 +411,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.ScalaConsumerExamples) {
     Await.result(streamComplete, 5.seconds) should be(Done)
   }
 
-  "Restarting Stream" should "work" in {
+  "Restarting Stream" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val topic = createTopic()
     //#restartSource
@@ -439,7 +440,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.ScalaConsumerExamples) {
     Await.result(result, 5.seconds) should have size 10
   }
 
-  it should "work with committable source" in {
+  it should "work with committable source" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val committerSettings = committerDefaults
     val topic = createTopic()

--- a/tests/src/test/scala/docs/scaladsl/PartitionExamples.scala
+++ b/tests/src/test/scala/docs/scaladsl/PartitionExamples.scala
@@ -9,6 +9,7 @@ import akka.actor.ActorRef
 import akka.kafka.scaladsl.Consumer
 import akka.kafka.{KafkaConsumerActor, KafkaPorts, Subscriptions}
 import akka.stream.scaladsl.{Keep, Sink}
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import net.manub.embeddedkafka.EmbeddedKafkaConfig
 import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
 
@@ -27,7 +28,7 @@ class PartitionExamples extends DocsSpecBase(KafkaPorts.ScalaPartitionExamples) 
                           "offsets.topic.num.partitions" -> "3"
                         ))
 
-  "Externally controlled kafka consumer" should "work" in {
+  "Externally controlled kafka consumer" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val topic = createTopic(partitions = 3)
     val partition1 = 1
@@ -77,7 +78,7 @@ class PartitionExamples extends DocsSpecBase(KafkaPorts.ScalaPartitionExamples) 
     result2.futureValue should have size 10
   }
 
-  "Consumer Metrics" should "work" in {
+  "Consumer Metrics" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val topic = createTopic(partitions = 3)
     val partition = 1

--- a/tests/src/test/scala/docs/scaladsl/ProducerExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/ProducerExample.scala
@@ -8,6 +8,7 @@ package docs.scaladsl
 import akka.kafka.{KafkaPorts, ProducerMessage, ProducerSettings, Subscriptions}
 import akka.kafka.scaladsl.{Consumer, Producer}
 import akka.stream.scaladsl.{Keep, Sink, Source}
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.StringSerializer
 
@@ -26,7 +27,7 @@ class ProducerExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamples)
   override def sleepAfterProduce: FiniteDuration = 4.seconds
   private def waitBeforeValidation(): Unit = sleep(6.seconds)
 
-  "PlainSink" should "work" in {
+  "PlainSink" should "work" in assertAllStagesStopped {
     // #settings
     val config = system.settings.config.getConfig("akka.kafka.producer")
     val producerSettings =
@@ -52,7 +53,7 @@ class ProducerExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamples)
     result.futureValue should have size (100)
   }
 
-  "PlainSink with shared producer" should "work" in {
+  "PlainSink with shared producer" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val producerSettings = producerDefaults
     val kafkaProducer = producerSettings.createKafkaProducer()
@@ -74,7 +75,7 @@ class ProducerExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamples)
     kafkaProducer.close()
   }
 
-  "Metrics" should "be observed" in {
+  "Metrics" should "be observed" in assertAllStagesStopped {
     // #producer
     val config = system.settings.config.getConfig("akka.kafka.producer")
     val producerSettings =
@@ -143,7 +144,7 @@ class ProducerExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamples)
     ptm
   }
 
-  "flexiFlow" should "work" in {
+  "flexiFlow" should "work" in assertAllStagesStopped {
     val producerSettings = producerDefaults
     val topic = createTopic()
     def println(s: String): Unit = {}

--- a/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
@@ -12,6 +12,7 @@ import akka.kafka.scaladsl.Consumer.{Control, DrainingControl}
 import akka.kafka.scaladsl.{Consumer, Transactional}
 import akka.kafka.{KafkaPorts, ProducerMessage, Subscriptions}
 import akka.stream.scaladsl.{Keep, RestartSource, Sink}
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import net.manub.embeddedkafka.EmbeddedKafkaConfig
 import org.apache.kafka.clients.producer.ProducerRecord
 
@@ -26,7 +27,7 @@ class TransactionsExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamp
 
   override def sleepAfterProduce: FiniteDuration = 10.seconds
 
-  "Transactional sink" should "work" in {
+  "Transactional sink" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val producerSettings = producerDefaults
     val immutable.Seq(sourceTopic, sinkTopic) = createTopics(1, 2)
@@ -60,7 +61,7 @@ class TransactionsExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamp
     result.futureValue should have size (10)
   }
 
-  "TransactionsFailureRetryExample" should "work" in {
+  "TransactionsFailureRetryExample" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val producerSettings = producerDefaults
     val immutable.Seq(sourceTopic, sinkTopic) = createTopics(1, 2)


### PR DESCRIPTION
## Purpose

* Use `assertAllStagesStopped` for more tests.
* Use sbt-jupiter-interface 0.8.1 as it fixes formatting of JUnit 4 test names
