### PR TITLE
Fixed copy/paste error in CommitterSettings

### DIFF
--- a/core/src/main/scala/akka/kafka/CommitterSettings.scala
+++ b/core/src/main/scala/akka/kafka/CommitterSettings.scala
@@ -71,7 +71,7 @@ class CommitterSettings private (
   def withMaxInterval(maxInterval: java.time.Duration): CommitterSettings =
     copy(maxInterval = maxInterval.asScala)
 
-  def withParallelism(value: Int): CommitterSettings =
+  def withParallelism(parallelism: Int): CommitterSettings =
     copy(parallelism = parallelism)
 
   private def copy(maxBatch: Long = maxBatch,


### PR DESCRIPTION
The method CommitterSettings.withParallelism used the wrong property to set the value of the object, making it impossible to update the parallelism value.

## References

Issue #717 
