### PR TITLE
Always use latest JDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,12 @@ before_install:
   # fetch full history for correct current and previous version detection
   - git fetch --unshallow
   # using jabba for custom jdk management
-  - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.11.0/install.sh | bash && . ~/.jabba/jabba.sh
-  - jabba install adopt@1.8.192-12
-  - jabba install adopt@1.11.0-1
+  - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.11.2/install.sh | bash && . ~/.jabba/jabba.sh
+  - jabba install adopt@~1.8.202-08
+  - jabba install adopt@~1.11.0-2
 
 script:
-  - jabba use ${JDK:=adopt@1.8.192-12}
+  - jabba use ${JDK:=adopt@~1.8.202-08}
   - java -version
   - sbt -jvm-opts .jvmopts-travis "$CMD"
 
@@ -37,7 +37,7 @@ jobs:
       env: CMD="+test"
 
     - env:
-      - JDK="adopt@1.11.0-1"
+      - JDK="adopt@~1.11.0-2"
       - CMD="+test"
 
     - env: CMD="mimaReportBinaryIssues"


### PR DESCRIPTION
## Purpose

The `~` in the latest jabba allows to use the latest version, if there is one, than specified.