### PR TITLE
Testcase to illustrate duplicated transactional messages when rebalancing

### DIFF
--- a/tests/src/test/resources/logback-test.xml
+++ b/tests/src/test/resources/logback-test.xml
@@ -38,7 +38,7 @@
     <logger name="io.confluent" level="WARN"/>
 
     <root level="DEBUG">
-        <!--appender-ref ref="STDOUT" /-->
+        <appender-ref ref="STDOUT" />
         <appender-ref ref="FILE" />
     </root>
 

--- a/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
@@ -27,7 +27,8 @@ class TransactionsSpec extends SpecBase(kafkaPort = KafkaPorts.TransactionsSpec)
                         zooKeeperPort,
                         Map(
                           "offsets.topic.replication.factor" -> "1",
-                          "max.partition.fetch.bytes" -> "2048"
+                          "max.partition.fetch.bytes" -> "2048",
+                          "num.partitions" -> "4"
                         ))
 
   "A consume-transform-produce cycle" must {
@@ -253,7 +254,7 @@ class TransactionsSpec extends SpecBase(kafkaPort = KafkaPorts.TransactionsSpec)
       Await.result(innerControl.shutdown(), remainingOrDefault)
     }
 
-    "provide consistency when partitions rebalanced" in {
+    "provide consistency when partitions are rebalanced" in {
       val sourceTopic = createTopicName(1)
       val sinkTopic = createTopicName(2)
       val group = createGroupId(1)
@@ -302,7 +303,7 @@ class TransactionsSpec extends SpecBase(kafkaPort = KafkaPorts.TransactionsSpec)
 
       probeConsumer
         .request(elements)
-        .expectNextN((1 to elements).map(_.toString))
+        .expectNextUnorderedN((1 to elements).map(_.toString))
 
       probeConsumer.cancel()
 


### PR DESCRIPTION
In the test below I'm creating many transactional streams that process copy elements from input to output.

The test fails because some elements are copied multiple times.
