### PR TITLE
eliminate scala compiler warnings

### DIFF
--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/KafkaConsumerBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/KafkaConsumerBenchmarks.scala
@@ -5,7 +5,9 @@
 
 package akka.kafka.benchmarks
 
+import java.time.Duration
 import java.util
+
 import com.codahale.metrics.Meter
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.kafka.clients.consumer.{OffsetAndMetadata, OffsetCommitCallback}
@@ -15,7 +17,7 @@ import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 
 object KafkaConsumerBenchmarks extends LazyLogging {
-  val pollTimeoutMs = 50L
+  val pollTimeoutMs: Duration = Duration.ofMillis(50L)
 
   /**
    * Reads messages from topic in a loop, then discards immediately. Does not commit.

--- a/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
@@ -36,7 +36,7 @@ private[kafka] trait ProducerStage[K, V, P, IN <: Envelope[K, V, P], OUT <: Resu
  * INTERNAL API
  */
 @InternalApi
-private object ProducerStage {
+private[kafka] object ProducerStage {
 
   trait ProducerCompletionState {
     def onCompletionSuccess(): Unit

--- a/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
@@ -22,7 +22,7 @@ import scala.concurrent.duration._
  * Implemented by [[DefaultProducerStage]] and [[TransactionalProducerStage]].
  */
 @InternalApi
-private[kafka] trait ProducerStage[K, V, P, IN <: Envelope[K, V, P], OUT <: Results[K, V, P]] {
+private[internal] trait ProducerStage[K, V, P, IN <: Envelope[K, V, P], OUT <: Results[K, V, P]] {
   val closeTimeout: FiniteDuration
   val closeProducerOnStop: Boolean
   val producerProvider: () => Producer[K, V]
@@ -36,7 +36,7 @@ private[kafka] trait ProducerStage[K, V, P, IN <: Envelope[K, V, P], OUT <: Resu
  * INTERNAL API
  */
 @InternalApi
-private[kafka] object ProducerStage {
+private[internal] object ProducerStage {
 
   trait ProducerCompletionState {
     def onCompletionSuccess(): Unit


### PR DESCRIPTION
I believe `private[kafka]` was intended instead of just `private` and few deprecations warnings (by kafka-clients poll) were removed.