### PR TITLE
Transactions: Add offsets to be committed directly after `producer.send`

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/DefaultProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/DefaultProducerStage.scala
@@ -15,7 +15,7 @@ import akka.stream.ActorAttributes.SupervisionStrategy
 import akka.stream.Supervision.Decider
 import akka.stream.{Attributes, FlowShape, Supervision}
 import akka.stream.stage._
-import org.apache.kafka.clients.producer.{Callback, Producer, ProducerRecord, RecordMetadata}
+import org.apache.kafka.clients.producer.{Callback, Producer, RecordMetadata}
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.concurrent.duration.FiniteDuration

--- a/core/src/main/scala/akka/kafka/internal/DefaultProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/DefaultProducerStage.scala
@@ -134,7 +134,8 @@ private class DefaultProducerStageLogic[K, V, P, IN <: Envelope[K, V, P], OUT <:
         val future = res.asInstanceOf[Future[OUT]]
         push(stage.out, future)
 
-      case _: PassThroughMessage[K, V, P] =>
+      case passthrough: PassThroughMessage[K, V, P] =>
+        postSend(passthrough)
         val future = Future.successful(PassThroughResult[K, V, P](in.passThrough)).asInstanceOf[Future[OUT]]
         push(stage.out, future)
 

--- a/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
@@ -45,6 +45,5 @@ private[internal] object ProducerStage {
 
   trait MessageCallback[K, V, P] {
     protected def awaitingConfirmation: AtomicInteger
-    def onMessageAckCb: AsyncCallback[Envelope[K, V, P]]
   }
 }

--- a/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
@@ -187,7 +187,6 @@ private final class TransactionalProducerStageLogic[K, V, P](stage: Transactiona
   }
 
   private def abortTransaction(): Unit = {
-    println("aborting transaction")
     log.debug("Aborting transaction")
     producer.abortTransaction()
   }

--- a/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
@@ -118,13 +118,10 @@ private final class TransactionalProducerStageLogic[K, V, P](stage: Transactiona
   }
 
   private def suspendDemand(): Unit =
-    setHandler(
-      stage.out,
-      new OutHandler {
-        // suspend demand while a commit is in process so we can drain any outstanding message acknowledgements
-        override def onPull(): Unit = ()
-      }
-    )
+    setHandler(stage.out, new OutHandler {
+      // suspend demand while a commit is in process so we can drain any outstanding message acknowledgements
+      override def onPull(): Unit = ()
+    })
 
   override protected def onTimer(timerKey: Any): Unit =
     if (timerKey == commitSchedulerKey) {
@@ -188,6 +185,7 @@ private final class TransactionalProducerStageLogic[K, V, P](stage: Transactiona
   }
 
   private def abortTransaction(): Unit = {
+    println("aborting transaction")
     log.debug("Aborting transaction")
     producer.abortTransaction()
   }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.7
+sbt.version=1.2.8

--- a/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
@@ -161,7 +161,7 @@ class CommittingSpec extends SpecBase(kafkaPort = KafkaPorts.CommittingSpec) wit
             }
           }
       )
-      eventualStrings.futureValue shouldBe NumbersPartition0 ++ NumbersPartition1
+      eventualStrings.futureValue should contain theSameElementsAs NumbersPartition0 ++ NumbersPartition1
 
       probe1.cancel()
       probe2.cancel()

--- a/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
@@ -271,7 +271,7 @@ class TransactionsSpec extends SpecBase(kafkaPort = KafkaPorts.TransactionsSpec)
       val sinkTopic = createTopic(2, destinationPartitions)
       val group = createGroupId(1)
 
-      val elements = 900 * 1000
+      val elements = 600 * 1000
       val restartAfter = 10 * 1000
 
       val partitionSize = elements / sourcePartitions

--- a/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
@@ -271,7 +271,7 @@ class TransactionsSpec extends SpecBase(kafkaPort = KafkaPorts.TransactionsSpec)
       val sinkTopic = createTopic(2, destinationPartitions)
       val group = createGroupId(1)
 
-      val elements = 600 * 1000
+      val elements = 300 * 1000
       val restartAfter = 10 * 1000
 
       val partitionSize = elements / sourcePartitions

--- a/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
@@ -279,7 +279,7 @@ class TransactionsSpec extends SpecBase(kafkaPort = KafkaPorts.TransactionsSpec)
         (0 until sourcePartitions).map(
           part => produce(sourceTopic, ((part * partitionSize) + 1) to (partitionSize * (part + 1)), part)
         )
-      Await.result(Future.sequence(producers), 30.seconds)
+      Await.result(Future.sequence(producers), 1.minute)
 
       val consumerSettings = consumerDefaults.withGroupId(group)
 

--- a/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
@@ -271,9 +271,6 @@ class TransactionsSpec extends SpecBase(kafkaPort = KafkaPorts.TransactionsSpec)
       val sinkTopic = createTopic(2, destinationPartitions)
       val group = createGroupId(1)
 
-      givenInitializedTopic(sourceTopic)
-      givenInitializedTopic(sinkTopic)
-
       val elements = 900 * 1000
       val restartAfter = 10 * 1000
 

--- a/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
@@ -282,7 +282,7 @@ class TransactionsSpec extends SpecBase(kafkaPort = KafkaPorts.TransactionsSpec)
         (0 until sourcePartitions).map(
           part => produce(sourceTopic, ((part * partitionSize) + 1) to (partitionSize * (part + 1)), part)
         )
-      Await.result(Future.sequence(producers), remainingOrDefault)
+      Await.result(Future.sequence(producers), 30.seconds)
 
       val consumerSettings = consumerDefaults.withGroupId(group)
 


### PR DESCRIPTION
## Purpose

The transaction flow could produce duplicates (as the test cases showed). By adding the offsets to be committed directly after `producers.send` instead of in the call-back this is solved.

## Background context

The included test-case where multiple transactional source-sink flows are being restarted while moving messages from one topic to another. This test-case showed produced duplicates before the change.