### PR TITLE
Implement draining logic for transactional flow

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -2,14 +2,14 @@
 # // #producer-settings
 # Properties for akka.kafka.ProducerSettings can be
 # defined in this section or a configuration section with
-# the same layout. 
+# the same layout.
 akka.kafka.producer {
   # Tuning parameter of how many sends that can run in parallel.
   parallelism = 100
 
   # Duration to wait for `KafkaConsumer.close` to finish.
   close-timeout = 60s
-  
+
   # Fully qualified config path which holds the dispatcher configuration
   # to be used by the producer stages. Some blocking may occur.
   # When this value is empty, the dispatcher configured for the stream
@@ -17,6 +17,7 @@ akka.kafka.producer {
   use-dispatcher = "akka.kafka.default-dispatcher"
 
   # The time interval to commit a transaction when using the `Transactional.sink` or `Transactional.flow`
+  # for exactly-once-semantics processing.
   eos-commit-interval = 100ms
 
   # Properties defined by org.apache.kafka.clients.producer.ProducerConfig
@@ -29,27 +30,29 @@ akka.kafka.producer {
 # // #consumer-settings
 # Properties for akka.kafka.ConsumerSettings can be
 # defined in this section or a configuration section with
-# the same layout. 
+# the same layout.
 akka.kafka.consumer {
   # Tuning property of scheduled polls.
   # Controls the interval from one scheduled poll to the next.
   poll-interval = 50ms
-  
+
   # Tuning property of the `KafkaConsumer.poll` parameter.
   # Note that non-zero value means that the thread that
   # is executing the stage will be blocked. See also the `wakup-timeout` setting below.
   poll-timeout = 50ms
-  
+
   # The stage will delay stopping the internal actor to allow processing of
   # messages already in the stream (required for successful committing).
   # Prefer use of `DrainingControl` over a large stop-timeout.
   stop-timeout = 30s
-  
+
   # Duration to wait for `KafkaConsumer.close` to finish.
   close-timeout = 20s
-  
+
   # If offset commit requests are not completed within this timeout
   # the returned Future is completed `CommitTimeoutException`.
+  # The `Transactional.source` waits this ammount of time for the producer to mark messages as not
+  # being in flight anymore as well as waiting for messages to drain, when rebalance is triggered.
   commit-timeout = 15s
 
   # If commits take longer than this time a warning is logged
@@ -67,7 +70,7 @@ akka.kafka.consumer {
 
   # Not used anymore (since 1.0-RC1)
   # wakeup-debug = true
-  
+
   # Fully qualified config path which holds the dispatcher configuration
   # to be used by the KafkaConsumerActor. Some blocking may occur.
   use-dispatcher = "akka.kafka.default-dispatcher"
@@ -93,6 +96,10 @@ akka.kafka.consumer {
   # This value is used instead of Kafka's default from `default.api.timeout.ms`
   # which is 1 minute.
   metadata-request-timeout = 5s
+
+  # Interval for checking that transaction was completed before closing the consumer.
+  # Used in the transactional flow for exactly-once-semantics processing.
+  eos-draining-check-interval = 30ms
 }
 # // #consumer-settings
 

--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -70,6 +70,7 @@ object ConsumerSettings {
     val positionTimeout = config.getDuration("position-timeout").asScala
     val offsetForTimesTimeout = config.getDuration("offset-for-times-timeout").asScala
     val metadataRequestTimeout = config.getDuration("metadata-request-timeout").asScala
+    val drainingCheckInterval = config.getDuration("eos-draining-check-interval").asScala
     new ConsumerSettings[K, V](
       properties,
       keyDeserializer,
@@ -86,6 +87,7 @@ object ConsumerSettings {
       positionTimeout,
       offsetForTimesTimeout,
       metadataRequestTimeout,
+      drainingCheckInterval,
       ConsumerSettings.createKafkaConsumer
     )
   }
@@ -196,6 +198,7 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
     val positionTimeout: FiniteDuration,
     val offsetForTimesTimeout: FiniteDuration,
     val metadataRequestTimeout: FiniteDuration,
+    val drainingCheckInterval: FiniteDuration,
     val consumerFactory: ConsumerSettings[K, V] => Consumer[K, V]
 ) {
 
@@ -230,6 +233,7 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
     positionTimeout = 5.seconds,
     offsetForTimesTimeout = 5.seconds,
     metadataRequestTimeout = 5.seconds,
+    drainingCheckInterval = 30.millis,
     consumerFactory = ConsumerSettings.createKafkaConsumer
   )
 
@@ -466,6 +470,14 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
   def withMetadataRequestTimeout(metadataRequestTimeout: java.time.Duration): ConsumerSettings[K, V] =
     copy(metadataRequestTimeout = metadataRequestTimeout.asScala)
 
+  /** Scala API: Check interval for TransactionalProducer when finishing transaction before shutting down consumer */
+  def withDrainingCheckInterval(drainingCheckInterval: FiniteDuration): ConsumerSettings[K, V] =
+    copy(drainingCheckInterval = drainingCheckInterval)
+
+  /** Java API: Check interval for TransactionalProducer when finishing transaction before shutting down consumer */
+  def withDrainingCheckInterval(drainingCheckInterval: java.time.Duration): ConsumerSettings[K, V] =
+    copy(drainingCheckInterval = drainingCheckInterval.asScala)
+
   /**
    * Replaces the default Kafka consumer creation logic.
    */
@@ -499,6 +511,7 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
       positionTimeout: FiniteDuration = positionTimeout,
       offsetForTimesTimeout: FiniteDuration = offsetForTimesTimeout,
       metadataRequestTimeout: FiniteDuration = metadataRequestTimeout,
+      drainingCheckInterval: FiniteDuration = drainingCheckInterval,
       consumerFactory: ConsumerSettings[K, V] => Consumer[K, V] = consumerFactory
   ): ConsumerSettings[K, V] =
     new ConsumerSettings[K, V](
@@ -517,6 +530,7 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
       positionTimeout,
       offsetForTimesTimeout,
       metadataRequestTimeout,
+      drainingCheckInterval,
       consumerFactory
     )
 
@@ -539,6 +553,7 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
     s"dispatcher=$dispatcher," +
     s"commitTimeWarning=${commitTimeWarning.toCoarsest}," +
     s"waitClosePartition=${waitClosePartition.toCoarsest}," +
-    s"metadataRequestTimeout=${metadataRequestTimeout.toCoarsest}" +
+    s"metadataRequestTimeout=${metadataRequestTimeout.toCoarsest}," +
+    s"drainingCheckInterval=${drainingCheckInterval.toCoarsest}" +
     ")"
 }

--- a/core/src/main/scala/akka/kafka/internal/TransactionalSource.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalSource.scala
@@ -6,14 +6,24 @@
 package akka.kafka.internal
 import java.util.Locale
 
+import akka.Done
+import akka.actor.{ActorRef, Status, Terminated}
+import akka.actor.Status.Failure
 import akka.annotation.InternalApi
 import akka.kafka.ConsumerMessage.TransactionalMessage
+import akka.kafka.internal.KafkaConsumerActor.Internal.Revoked
 import akka.kafka.scaladsl.Consumer.Control
-import akka.kafka.{ConsumerSettings, Subscription}
+import akka.kafka.{ConsumerFailed, ConsumerMessage, ConsumerSettings, Subscription}
 import akka.stream.SourceShape
 import akka.stream.stage.GraphStageLogic
-import org.apache.kafka.clients.consumer.ConsumerConfig
+import akka.util.Timeout
+import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord, OffsetAndMetadata}
+import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.requests.IsolationLevel
+
+import scala.collection.immutable.Iterable
+import scala.concurrent.duration.{FiniteDuration, _}
+import scala.concurrent.{Await, ExecutionContext, Future}
 
 /** Internal API */
 @InternalApi
@@ -23,6 +33,46 @@ private[kafka] final class TransactionalSource[K, V](consumerSettings: ConsumerS
       s"TransactionalSource ${subscription.renderStageAttribute}"
     ) {
   require(consumerSettings.properties(ConsumerConfig.GROUP_ID_CONFIG).nonEmpty, "You must define a Consumer group.id.")
+
+  type Offset = Long
+
+  private trait InFlightRecords {
+    // Assumes that offsets per topic partition are added in the increasing order
+    // The assumption is true for Kafka consumer that guarantees that elements are emitted
+    // per partition in offset-increasing order.
+    def add(offsets: Map[TopicPartition, Offset]): Unit
+    def committed(offsets: Map[TopicPartition, Offset]): Unit
+    def revoke(revokedTps: Set[TopicPartition]): Unit
+    def reset(): Unit
+
+    def empty(): Boolean
+  }
+
+  private object InFlightRecords {
+    def empty = new Impl
+
+    class Impl extends InFlightRecords {
+      private var inFlightRecords: Map[TopicPartition, Offset] = Map.empty
+
+      override def add(offsets: Map[TopicPartition, Offset]): Unit =
+        inFlightRecords = inFlightRecords ++ offsets
+
+      override def committed(committed: Map[TopicPartition, Offset]): Unit =
+        inFlightRecords = inFlightRecords.flatMap {
+          case (tp, offset) if committed.get(tp).contains(offset) => None
+          case x => Some(x)
+        }
+
+      override def revoke(revokedTps: Set[TopicPartition]): Unit =
+        inFlightRecords = inFlightRecords -- revokedTps
+
+      override def reset(): Unit = inFlightRecords = Map.empty
+
+      override def empty(): Boolean = inFlightRecords.isEmpty
+
+      override def toString: String = inFlightRecords.toString()
+    }
+  }
 
   /**
    * We set the isolation.level config to read_committed to make sure that any consumed messages are from
@@ -36,9 +86,99 @@ private[kafka] final class TransactionalSource[K, V](consumerSettings: ConsumerS
     IsolationLevel.READ_COMMITTED.toString.toLowerCase(Locale.ENGLISH)
   )
 
+  case object Drained
+  case class Drain[T](drainedConfirmationRef: Option[ActorRef], drainedConfirmationMsg: T)
+  case class Committed(offsets: Map[TopicPartition, OffsetAndMetadata])
+  case object CommitingFailure
+
   override protected def logic(shape: SourceShape[TransactionalMessage[K, V]]): GraphStageLogic with Control =
     new SingleSourceLogic[K, V, TransactionalMessage[K, V]](shape, txConsumerSettings, subscription)
     with TransactionalMessageBuilder[K, V] {
+      var inFlightRecords = InFlightRecords.empty
+
+      override def messageHandling = super.messageHandling.orElse(drainHandling).orElse {
+        case (_, Revoked(tps)) =>
+          inFlightRecords.revoke(tps.toSet)
+      }
+
+      override def shuttingDownReceive =
+        super.shuttingDownReceive
+          .orElse(drainHandling)
+          .orElse {
+            case (_, Status.Failure(e)) =>
+              failStage(e)
+            case (_, Terminated(ref)) if ref == consumerActor =>
+              failStage(new ConsumerFailed())
+          }
+
+      def drainHandling: PartialFunction[(ActorRef, Any), Unit] = {
+        case (sender, Committed(offsets)) =>
+          inFlightRecords.committed(offsets.mapValues(_.offset() - 1))
+          sender ! Done
+        case (sender, CommitingFailure) => {
+          log.info("Committing failed, resetting in flight offsets")
+          inFlightRecords.reset()
+        }
+        case (sender, Drain(ack, msg)) =>
+          if (inFlightRecords.empty()) {
+            log.debug("Source drained")
+            ack.getOrElse(sender) ! msg
+          } else {
+            log.debug(s"Draining partitions {}", inFlightRecords)
+            materializer.scheduleOnce(consumerSettings.drainingCheckInterval, new Runnable {
+              override def run(): Unit =
+                sourceActor.ref ! Drain(ack.orElse(Some(sender)), msg)
+            })
+          }
+      }
+
       override def groupId: String = txConsumerSettings.properties(ConsumerConfig.GROUP_ID_CONFIG)
+      lazy val committedMarker: CommittedMarker = {
+        val ec = materializer.executionContext
+        CommittedMarkerRef(sourceActor.ref)(ec)
+      }
+
+      override def onMessage(rec: ConsumerRecord[K, V]): Unit =
+        inFlightRecords.add(Map(new TopicPartition(rec.topic(), rec.partition()) -> rec.offset()))
+
+      override protected def stopConsumerActor(): Unit =
+        sourceActor.ref.tell(Drain(Some(consumerActor), KafkaConsumerActor.Internal.Stop), sourceActor.ref)
+
+      // This is invoked in the KafkaConsumerActor thread when doing poll.
+      override def partitionRevokedHandler(revokedTps: Set[TopicPartition]): Unit = {
+        if (waitForDraining()) {
+          sourceActor.ref ! Revoked(revokedTps.toList)
+        } else {
+          sourceActor.ref ! Failure(new Error("Timeout while draining"))
+          consumerActor ! KafkaConsumerActor.Internal.Stop
+        }
+        super.partitionRevokedHandler(revokedTps)
+      }
+
+      def waitForDraining(): Boolean = {
+        import akka.pattern.ask
+        implicit val timeout = Timeout(consumerSettings.commitTimeout)
+        try {
+          Await.result(ask(stageActor.ref, Drain(None, Drained)), timeout.duration)
+          true
+        } catch {
+          case t: Throwable =>
+            false
+        }
+      }
     }
+
+  private[kafka] final case class CommittedMarkerRef(sourceActor: ActorRef)(
+      implicit ec: ExecutionContext
+  ) extends CommittedMarker {
+    override def committed(offsets: Map[TopicPartition, OffsetAndMetadata]): Future[Done] = {
+      import akka.pattern.ask
+      sourceActor
+        .ask(Committed(offsets))(Timeout(consumerSettings.commitTimeout))
+        .map(_ => Done)
+    }
+
+    override def failed(): Unit =
+      sourceActor ! CommitingFailure
+  }
 }

--- a/testkit/src/main/scala/akka/kafka/testkit/ConsumerResultFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/ConsumerResultFactory.scala
@@ -8,7 +8,7 @@ package akka.kafka.testkit
 import akka.Done
 import akka.annotation.ApiMayChange
 import akka.kafka.ConsumerMessage
-import akka.kafka.ConsumerMessage.{CommittableOffset, GroupTopicPartition, PartitionOffset}
+import akka.kafka.ConsumerMessage.{CommittableOffset, GroupTopicPartition, PartitionOffsetCommittedMarker}
 import akka.kafka.internal.{CommittableOffsetImpl, InternalCommitter}
 import org.apache.kafka.clients.consumer.ConsumerRecord
 
@@ -29,7 +29,7 @@ object ConsumerResultFactory {
   }
 
   def partitionOffset(groupId: String, topic: String, partition: Int, offset: Long): ConsumerMessage.PartitionOffset =
-    ConsumerMessage.PartitionOffset(ConsumerMessage.GroupTopicPartition(groupId, topic, partition), offset)
+    new ConsumerMessage.PartitionOffset(ConsumerMessage.GroupTopicPartition(groupId, topic, partition), offset)
 
   def partitionOffset(key: GroupTopicPartition, offset: Long) = ConsumerMessage.PartitionOffset(key, offset)
 
@@ -51,7 +51,7 @@ object ConsumerResultFactory {
 
   def transactionalMessage[K, V](
       record: ConsumerRecord[K, V],
-      partitionOffset: PartitionOffset
+      partitionOffset: PartitionOffsetCommittedMarker
   ): ConsumerMessage.TransactionalMessage[K, V] = ConsumerMessage.TransactionalMessage(record, partitionOffset)
 
 }

--- a/tests/src/test/resources/logback-test.xml
+++ b/tests/src/test/resources/logback-test.xml
@@ -38,7 +38,7 @@
     <logger name="io.confluent" level="WARN"/>
 
     <root level="DEBUG">
-        <!--appender-ref ref="STDOUT" /-->
+        <!--<appender-ref ref="STDOUT" /-->
         <appender-ref ref="FILE" />
     </root>
 


### PR DESCRIPTION
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](https://github.com/akka/alpakka-kafka/tree/master/CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?

## Fixes

Duplications in a transactional flow that occur, when either closing the stream or partitions are revoked by Kafka.

## Purpose

This PR introduces draining logic for `TransactionalSource`. Specifically, for each partition managed by the source, we keep track of the message offsets emitted by the source.
When closing the stage or revoking partitions, we make sure that all the offsets are committed back to the Kafka by the producer.
To know that an offset was committed by the producer we attach `CommittedMarker` to each message produced by the stream. `TransactionalProducerStage` uses this marker to tell the source that an offset was committed.

## Background Context

In a transactional stream processing partition `P`, we need to wait for all commits to be acknowledged by Kafka before closing the consumer.
If we don't, it's possible that another consumer is assigned `P`, which triggers fetching offset that can be stale or overwritten later. This causes data duplication.

## References

https://github.com/akka/alpakka-kafka/issues/758
https://github.com/akka/alpakka-kafka/issues/756