### PR TITLE
Synchronous partition assignment handler (internal)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -273,11 +273,19 @@ lazy val tests = project
         "org.slf4j" % "jul-to-slf4j" % slf4jVersion % Test,
         "org.mockito" % "mockito-core" % "2.24.5" % Test
       ) ++ {
-        if (scalaBinaryVersion.value == "2.13") Seq()
-        else
-          Seq(
-            "io.github.embeddedkafka" %% "embedded-kafka-schema-registry" % embeddedKafkaSchemaRegistry % Test exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12")
-          )
+        scalaBinaryVersion.value match {
+          case "2.13" =>
+            Seq()
+          case "2.12" =>
+            Seq(
+              "com.typesafe.akka" %% "akka-actor-typed" % akkaVersion % Test,
+              "io.github.embeddedkafka" %% "embedded-kafka-schema-registry" % embeddedKafkaSchemaRegistry % Test exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12")
+            )
+          case "2.11" =>
+            Seq(
+              "io.github.embeddedkafka" %% "embedded-kafka-schema-registry" % embeddedKafkaSchemaRegistry % Test exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12")
+            )
+        }
       } ++
       Seq( // integration test dependencies
         "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % IntegrationTest,

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -101,6 +101,10 @@ akka.kafka.consumer {
   # Used in the transactional flow for exactly-once-semantics processing.
   eos-draining-check-interval = 30ms
 
+  # Issue warnings when a call to a partition assignment handler method takes
+  # longer than this.
+  partition-handler-warning = 5s
+
   # Settings for checking the connection to the Kafka broker. Connection checking uses `listTopics` requests with the timeout
   # configured by `consumer.metadata-request-timeout`
   connection-checker {

--- a/core/src/main/scala/akka/kafka/RestrictedConsumer.scala
+++ b/core/src/main/scala/akka/kafka/RestrictedConsumer.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka
+
+import akka.annotation.ApiMayChange
+import org.apache.kafka.clients.consumer.{Consumer, OffsetAndMetadata}
+import org.apache.kafka.common.TopicPartition
+
+/**
+ * Offers parts of the [[org.apache.kafka.clients.consumer.Consumer]] API which becomes available to
+ * the [[akka.kafka.scaladsl.PartitionAssignmentHandler]] callbacks.
+ */
+@ApiMayChange
+final class RestrictedConsumer(consumer: Consumer[_, _], duration: java.time.Duration) {
+
+  /**
+   * See [[org.apache.kafka.clients.consumer.KafkaConsumer#assignment]]
+   */
+  def assignment(): java.util.Set[TopicPartition] = consumer.assignment()
+
+  /**
+   * See [[org.apache.kafka.clients.consumer.KafkaConsumer#beginningOffsets()]]
+   */
+  def beginningOffsets(tps: java.util.Collection[TopicPartition]): java.util.Map[TopicPartition, java.lang.Long] =
+    consumer.beginningOffsets(tps, duration)
+
+  /**
+   * See [[org.apache.kafka.clients.consumer.KafkaConsumer#commitSync(Map, java.time.Duration)]]
+   */
+  def commitSync(offsets: java.util.Map[TopicPartition, OffsetAndMetadata]): Unit =
+    consumer.commitSync(offsets, duration)
+
+  /**
+   * See [[org.apache.kafka.clients.consumer.KafkaConsumer#committed(TopicPartition, Duration)]]
+   */
+  def committed(tp: TopicPartition): OffsetAndMetadata = consumer.committed(tp, duration)
+
+  /**
+   * See [[org.apache.kafka.clients.consumer.KafkaConsumer#endOffsets(java.util.Collection[TopicPartition], java.time.Duration)]]
+   */
+  def endOffsets(tps: java.util.Collection[TopicPartition]): java.util.Map[TopicPartition, java.lang.Long] =
+    consumer.endOffsets(tps, duration)
+
+  /**
+   * See [[org.apache.kafka.clients.consumer.KafkaConsumer#position(TopicPartition, java.time.Duration)]]
+   */
+  def position(tp: TopicPartition): Long = consumer.position(tp, duration)
+
+  /**
+   * See [[org.apache.kafka.clients.consumer.KafkaConsumer#seek(TopicPartition, Long)]]
+   */
+  def seek(tp: TopicPartition, offset: Long): Unit = consumer.seek(tp, offset)
+}

--- a/core/src/main/scala/akka/kafka/Subscriptions.scala
+++ b/core/src/main/scala/akka/kafka/Subscriptions.scala
@@ -61,7 +61,8 @@ object Subscriptions {
   private[kafka] final case class TopicSubscription(tps: Set[String], rebalanceListener: Option[ActorRef])
       extends AutoSubscription {
     def withRebalanceListener(ref: ActorRef): TopicSubscription =
-      TopicSubscription(tps, Some(ref))
+      copy(rebalanceListener = Some(ref))
+
     def renderStageAttribute: String = s"${tps.mkString(" ")}$renderListener"
   }
 
@@ -70,7 +71,8 @@ object Subscriptions {
   private[kafka] final case class TopicSubscriptionPattern(pattern: String, rebalanceListener: Option[ActorRef])
       extends AutoSubscription {
     def withRebalanceListener(ref: ActorRef): TopicSubscriptionPattern =
-      TopicSubscriptionPattern(pattern, Some(ref))
+      copy(rebalanceListener = Some(ref))
+
     def renderStageAttribute: String = s"pattern $pattern$renderListener"
   }
 
@@ -99,7 +101,8 @@ object Subscriptions {
   }
 
   /** Creates subscription for given set of topics */
-  def topics(ts: Set[String]): AutoSubscription = TopicSubscription(ts, None)
+  def topics(ts: Set[String]): AutoSubscription =
+    TopicSubscription(ts, rebalanceListener = None)
 
   /**
    * JAVA API
@@ -117,7 +120,8 @@ object Subscriptions {
   /**
    * Creates subscription for given topics pattern
    */
-  def topicPattern(pattern: String): AutoSubscription = TopicSubscriptionPattern(pattern, None)
+  def topicPattern(pattern: String): AutoSubscription =
+    TopicSubscriptionPattern(pattern, rebalanceListener = None)
 
   /**
    * Manually assign given topics and partitions

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -26,7 +26,7 @@ import akka.util.JavaDurationConverters._
 import akka.event.LoggingReceive
 import akka.kafka.KafkaConsumerActor.StoppingException
 import akka.kafka._
-import akka.stream.stage.AsyncCallback
+import akka.kafka.scaladsl.PartitionAssignmentHandler
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
 
@@ -51,12 +51,12 @@ import scala.util.control.NonFatal
     final case class AssignWithOffset(tps: Map[TopicPartition, Long]) extends NoSerializationVerificationNeeded
     final case class AssignOffsetsForTimes(timestampsToSearch: Map[TopicPartition, Long])
         extends NoSerializationVerificationNeeded
-    final case class Subscribe(topics: Set[String], listener: ListenerCallbacks)
+    final case class Subscribe(topics: Set[String], rebalanceHandler: PartitionAssignmentHandler)
         extends SubscriptionRequest
         with NoSerializationVerificationNeeded
     case object RequestMetrics extends NoSerializationVerificationNeeded
     // Could be optimized to contain a Pattern as it used during reconciliation now, tho only in exceptional circumstances
-    final case class SubscribePattern(pattern: String, listener: ListenerCallbacks)
+    final case class SubscribePattern(pattern: String, rebalanceHandler: PartitionAssignmentHandler)
         extends SubscriptionRequest
         with NoSerializationVerificationNeeded
     final case class Seek(tps: Map[TopicPartition, Long]) extends NoSerializationVerificationNeeded
@@ -87,36 +87,6 @@ import scala.util.control.NonFatal
     def nextNumber(): Int =
       number.incrementAndGet()
 
-  }
-
-  final case class ListenerCallbacks(onAssign: Set[TopicPartition] => Unit, onRevoke: Set[TopicPartition] => Unit)
-      extends NoSerializationVerificationNeeded
-
-  object ListenerCallbacks {
-    def apply(subscription: AutoSubscription,
-              sourceActor: ActorRef,
-              partitionAssignedCB: AsyncCallback[Set[TopicPartition]],
-              partitionRevokedCB: AsyncCallback[Set[TopicPartition]],
-              revokedBlockingCallback: Set[TopicPartition] => Unit = _ => ()): ListenerCallbacks =
-      KafkaConsumerActor.ListenerCallbacks(
-        assignedTps => {
-          subscription.rebalanceListener.foreach {
-            _.tell(TopicPartitionsAssigned(subscription, assignedTps), sourceActor)
-          }
-          if (assignedTps.nonEmpty) {
-            partitionAssignedCB.invoke(assignedTps)
-          }
-        },
-        revokedTps => {
-          subscription.rebalanceListener.foreach {
-            _.tell(TopicPartitionsRevoked(subscription, revokedTps), sourceActor)
-          }
-          if (revokedTps.nonEmpty) {
-            partitionRevokedCB.invoke(revokedTps)
-          }
-          revokedBlockingCallback(revokedTps)
-        }
-      )
   }
 
   private[KafkaConsumerActor] trait CommitRefreshing {
@@ -231,7 +201,7 @@ import scala.util.control.NonFatal
   /** Limits the blocking on offsetForTimes */
   private val offsetForTimesTimeout = settings.getOffsetForTimesTimeout
 
-  /** Limits the blocking on position in [[WrappedAutoPausedListener]] */
+  /** Limits the blocking on position in [[RebalanceListenerImpl]] */
   private val positionTimeout = settings.getPositionTimeout
 
   private var requests = Map.empty[ActorRef, RequestMessages]
@@ -247,7 +217,7 @@ import scala.util.control.NonFatal
 
   /**
    * While `true`, committing is delayed.
-   * Changed by `onPartitionsRevoked` and `onPartitionsAssigned` in [[WrappedAutoPausedListener]].
+   * Changed by `onPartitionsRevoked` and `onPartitionsAssigned` in [[RebalanceListenerImpl]].
    */
   private var rebalanceInProgress = false
 
@@ -262,6 +232,7 @@ import scala.util.control.NonFatal
   private var rebalanceCommitSenders = Vector.empty[ActorRef]
 
   private var delayedPollInFlight = false
+  private var partitionAssignmentHandler: RebalanceListener = RebalanceListener.Empty
 
   def receive: Receive = LoggingReceive {
     case Assign(assignedTps) =>
@@ -366,10 +337,14 @@ import scala.util.control.NonFatal
   def handleSubscription(subscription: SubscriptionRequest): Unit =
     try {
       subscription match {
-        case Subscribe(topics, listener) =>
-          consumer.subscribe(topics.toList.asJava, new WrappedAutoPausedListener(listener))
-        case SubscribePattern(pattern, listener) =>
-          consumer.subscribe(Pattern.compile(pattern), new WrappedAutoPausedListener(listener))
+        case Subscribe(topics, rebalanceHandler) =>
+          val callback = new RebalanceListenerImpl(rebalanceHandler)
+          partitionAssignmentHandler = callback
+          consumer.subscribe(topics.toList.asJava, callback)
+        case SubscribePattern(pattern, rebalanceHandler) =>
+          val callback = new RebalanceListenerImpl(rebalanceHandler)
+          partitionAssignmentHandler = callback
+          consumer.subscribe(Pattern.compile(pattern), callback)
       }
 
       scheduleFirstPollTask()
@@ -419,6 +394,7 @@ import scala.util.control.NonFatal
       case (ref, req) =>
         ref ! Messages(req.requestId, Iterator.empty)
     }
+    partitionAssignmentHandler.postStop()
     consumer.close(settings.getCloseTimeout)
     super.postStop()
   }
@@ -644,23 +620,65 @@ import scala.util.control.NonFatal
    * So these methods are always called on the same thread as the actor and we're safe to
    * touch internal state.
    */
-  private final class WrappedAutoPausedListener(listener: ListenerCallbacks)
+  private[KafkaConsumerActor] sealed trait RebalanceListener
       extends ConsumerRebalanceListener
       with NoSerializationVerificationNeeded {
+    override def onPartitionsAssigned(partitions: java.util.Collection[TopicPartition]): Unit
+    override def onPartitionsRevoked(partitions: java.util.Collection[TopicPartition]): Unit
+    def postStop(): Unit = ()
+  }
+
+  private[KafkaConsumerActor] object RebalanceListener {
+    object Empty extends RebalanceListener {
+      override def onPartitionsAssigned(partitions: java.util.Collection[TopicPartition]): Unit = ()
+
+      override def onPartitionsRevoked(partitions: java.util.Collection[TopicPartition]): Unit = ()
+
+      override def postStop(): Unit = ()
+    }
+  }
+
+  private[KafkaConsumerActor] final class RebalanceListenerImpl(
+      partitionAssignmentHandler: PartitionAssignmentHandler
+  ) extends RebalanceListener {
+
+    private val restrictedConsumer = new RestrictedConsumer(consumer, settings.partitionHandlerWarning.*(0.95d).asJava)
+    private val warningDuration = settings.partitionHandlerWarning.toNanos
 
     override def onPartitionsAssigned(partitions: java.util.Collection[TopicPartition]): Unit = {
       consumer.pause(partitions)
       val tps = partitions.asScala.toSet
       commitRefreshing.assignedPositions(tps, consumer, positionTimeout)
-      listener.onAssign(tps)
+      val startTime = System.nanoTime()
+      partitionAssignmentHandler.onAssign(tps, restrictedConsumer)
+      checkDuration(startTime, "onAssign")
       rebalanceInProgress = false
     }
 
     override def onPartitionsRevoked(partitions: java.util.Collection[TopicPartition]): Unit = {
       val revokedTps = partitions.asScala.toSet
-      listener.onRevoke(revokedTps)
+      val startTime = System.nanoTime()
+      partitionAssignmentHandler.onRevoke(revokedTps, restrictedConsumer)
+      checkDuration(startTime, "onRevoke")
       commitRefreshing.revoke(revokedTps)
       rebalanceInProgress = true
+    }
+
+    override def postStop(): Unit = {
+      val currentTps = consumer.assignment()
+      consumer.pause(currentTps)
+      val startTime = System.nanoTime()
+      partitionAssignmentHandler.onStop(currentTps.asScala.toSet, restrictedConsumer)
+      checkDuration(startTime, "onStop")
+    }
+
+    private def checkDuration(startTime: Long, method: String): Unit = {
+      val duration = System.nanoTime() - startTime
+      if (duration > warningDuration) {
+        log.warning("Partition assignment handler `{}` took longer than `partition-handler-warning`: {} ms",
+                    method,
+                    duration / 1000000L)
+      }
     }
   }
 

--- a/core/src/main/scala/akka/kafka/internal/PartitionAssignmentHelpers.scala
+++ b/core/src/main/scala/akka/kafka/internal/PartitionAssignmentHelpers.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.internal
+
+import akka.actor.ActorRef
+import akka.annotation.InternalApi
+import akka.kafka.scaladsl.PartitionAssignmentHandler
+import akka.kafka.{AutoSubscription, RestrictedConsumer, TopicPartitionsAssigned, TopicPartitionsRevoked}
+import akka.stream.stage.AsyncCallback
+import org.apache.kafka.common.TopicPartition
+
+/**
+ * Internal API.
+ *
+ * Implementations of [[PartitionAssignmentHandler]] for internal use.
+ */
+@InternalApi
+object PartitionAssignmentHelpers {
+
+  @InternalApi
+  object EmptyPartitionAssignmentHandler extends PartitionAssignmentHandler {
+    override def onRevoke(revokedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = ()
+
+    override def onAssign(assignedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = ()
+
+    override def onStop(revokedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = ()
+  }
+
+  @InternalApi
+  final class AsyncCallbacks(subscription: AutoSubscription,
+                             sourceActor: ActorRef,
+                             partitionAssignedCB: AsyncCallback[Set[TopicPartition]],
+                             partitionRevokedCB: AsyncCallback[Set[TopicPartition]])
+      extends PartitionAssignmentHandler {
+
+    override def onRevoke(revokedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = {
+      subscription.rebalanceListener.foreach {
+        _.tell(TopicPartitionsRevoked(subscription, revokedTps), sourceActor)
+      }
+      if (revokedTps.nonEmpty) {
+        partitionRevokedCB.invoke(revokedTps)
+      }
+    }
+
+    override def onAssign(assignedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = {
+      subscription.rebalanceListener.foreach {
+        _.tell(TopicPartitionsAssigned(subscription, assignedTps), sourceActor)
+      }
+      if (assignedTps.nonEmpty) {
+        partitionAssignedCB.invoke(assignedTps)
+      }
+    }
+
+    override def onStop(revokedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = ()
+  }
+
+  @InternalApi
+  final class Chain(handler1: PartitionAssignmentHandler, handler2: PartitionAssignmentHandler)
+      extends PartitionAssignmentHandler {
+    override def onRevoke(revokedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = {
+      handler1.onRevoke(revokedTps, consumer)
+      handler2.onRevoke(revokedTps, consumer)
+    }
+
+    override def onAssign(assignedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = {
+      handler1.onAssign(assignedTps, consumer)
+      handler2.onAssign(assignedTps, consumer)
+    }
+
+    override def onStop(revokedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = {
+      handler1.onStop(revokedTps, consumer)
+      handler2.onStop(revokedTps, consumer)
+    }
+  }
+
+}

--- a/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
@@ -74,7 +74,7 @@ object Consumer {
    * one, so that the stream can be stopped in a controlled way without losing
    * commits.
    */
-  final class DrainingControl[T] private[javadsl] (control: Control, streamCompletion: CompletionStage[T])
+  final class DrainingControl[T] private[javadsl] (control: Control, val streamCompletion: CompletionStage[T])
       extends Control {
 
     override def stop(): CompletionStage[Done] = control.stop()

--- a/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
@@ -83,7 +83,7 @@ object Consumer {
    * one, so that the stream can be stopped in a controlled way without losing
    * commits.
    */
-  final class DrainingControl[T] private (control: Control, streamCompletion: Future[T]) extends Control {
+  final class DrainingControl[T] private (control: Control, val streamCompletion: Future[T]) extends Control {
 
     override def stop(): Future[Done] = control.stop()
 

--- a/core/src/main/scala/akka/kafka/scaladsl/PartitionAssignmentHandler.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/PartitionAssignmentHandler.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.scaladsl
+
+import akka.annotation.ApiMayChange
+import akka.kafka.RestrictedConsumer
+import org.apache.kafka.common.TopicPartition
+
+/**
+ * The API is new and may change in further releases.
+ *
+ * Allows to execute user code when Kafka rebalances partitions between consumers, or an Alpakka Kafka consumer is stopped.
+ * Use with care: These callbacks are called synchronously on the same thread Kafka's `poll()` is called.
+ * A warning will be logged if a callback takes longer than the configured `partition-handler-warning`.
+ *
+ * There is no point in calling `CommittableOffset`'s commit methods as their committing won't be executed as long as any of
+ * the callbacks in this class are called.
+ *
+ * This complements the methods of Kafka's [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener ConsumerRebalanceListener]] with
+ * an `onStop` callback.
+ */
+@ApiMayChange
+trait PartitionAssignmentHandler {
+
+  /**
+   * See [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener#onPartitionsRevoked]]
+   *
+   * @param revokedTps The list of partitions that were assigned to the consumer on the last rebalance
+   * @param consumer A restricted version of the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
+   */
+  def onRevoke(revokedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit
+
+  /**
+   * See [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener#onPartitionsAssigned]]
+   *
+   * @param assignedTps The list of partitions that are now assigned to the consumer (may include partitions previously assigned to the consumer)
+   * @param consumer A restricted version of the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
+   */
+  def onAssign(assignedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit
+
+  /**
+   * Called before a consumer is closed.
+   * See [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener#onPartitionsRevoked]]
+   *
+   * @param revokedTps The list of partitions that are currently assigned to the consumer
+   * @param consumer A restricted version of the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
+   */
+  def onStop(revokedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit
+}

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
@@ -46,6 +46,7 @@ abstract class KafkaSpec(_kafkaPort: Int, val zooKeeperPort: Int, actorSystem: A
 
   implicit val mat: Materializer = ActorMaterializer()
   implicit val ec: ExecutionContext = system.dispatcher
+  implicit val scheduler: akka.actor.Scheduler = system.scheduler
 
   var testProducer: KProducer[String, String] = _
 

--- a/tests/src/main/scala/akka/kafka/KafkaPorts.scala
+++ b/tests/src/main/scala/akka/kafka/KafkaPorts.scala
@@ -24,4 +24,5 @@ object KafkaPorts {
   val JavaTransactionsExamples = 9102
   val ProducerExamplesTest = 9112
   val KafkaConnectionCheckerTest = 9122
+  val PartitionAssignmentHandlerSpec = 9132
 }

--- a/tests/src/test/scala/akka/kafka/internal/ConsumerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConsumerSpec.scala
@@ -83,6 +83,7 @@ class ConsumerSpec(_system: ActorSystem)
         .create(system, new StringDeserializer, new StringDeserializer)
         .withGroupId(groupId)
         .withCloseTimeout(ConsumerMock.closeTimeout)
+        .withCommitTimeout(500.millis)
         .withConsumerFactory(_ => mock),
       Subscriptions.topics(topics)
     )

--- a/tests/src/test/scala/akka/kafka/internal/SubscriptionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/SubscriptionsSpec.scala
@@ -16,11 +16,13 @@ class SubscriptionsSpec extends WordSpec with Matchers {
 
   "URL encoded subscription" should {
     "be readable for topics" in {
-      encode(Subscriptions.topics(Set("topic1", "topic2"))) should be("topic1+topic2")
+      encode(Subscriptions.topics(Set("topic1", "topic2"))) should be(
+        "topic1+topic2+EmptyPartitionAssignmentHandler%24"
+      )
     }
 
     "be readable for patterns" in {
-      encode(Subscriptions.topicPattern("topic.*")) should be("pattern+topic.*")
+      encode(Subscriptions.topicPattern("topic.*")) should be("pattern+topic.*+EmptyPartitionAssignmentHandler%24")
     }
 
     "be readable for assignments" in {

--- a/tests/src/test/scala/akka/kafka/internal/SubscriptionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/SubscriptionsSpec.scala
@@ -17,12 +17,12 @@ class SubscriptionsSpec extends WordSpec with Matchers {
   "URL encoded subscription" should {
     "be readable for topics" in {
       encode(Subscriptions.topics(Set("topic1", "topic2"))) should be(
-        "topic1+topic2+EmptyPartitionAssignmentHandler%24"
+        "topic1+topic2"
       )
     }
 
     "be readable for patterns" in {
-      encode(Subscriptions.topicPattern("topic.*")) should be("pattern+topic.*+EmptyPartitionAssignmentHandler%24")
+      encode(Subscriptions.topicPattern("topic.*")) should be("pattern+topic.*")
     }
 
     "be readable for assignments" in {

--- a/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
@@ -233,7 +233,7 @@ class CommittingSpec extends SpecBase with TestcontainersKafkaLike with Inside {
       rebalanceActor2.expectMsg(TopicPartitionsAssigned(subscription2, Set(new TopicPartition(topic1, partition1))))
 
       // commit ALL messages via consumer 1
-      val consumer1Read = Future.sequence(
+      Future.sequence(
         committables1
           .map { elem =>
             elem.committableOffset.commitScaladsl().map { _ =>
@@ -243,8 +243,8 @@ class CommittingSpec extends SpecBase with TestcontainersKafkaLike with Inside {
       )
 
       val committables2: immutable.Seq[ConsumerMessage.CommittableMessage[String, String]] = probe2
-        .request(count)
-        .expectNextN(count)
+        .request(count.toLong)
+        .expectNextN(count.toLong)
 
       // messages that belonged to the revoked partition show up in the new consumer, even though they were
       // committed after the rebalance


### PR DESCRIPTION
## Purpose

**For now this PR just introduces the synchronous partition assignment handler internally without a user-facing API as the use-cases for this need to be understood better.**

Introduce a new callback for changes in partitions assigned to an Alpakka Kafka consumer. This allows executing code before a rebalance continues, and querying the underlying Kafka consumer.

These callbacks are much more powerful (and dangerous) than the current rebalance listener actor. The callbacks are executed on the same thread that called `poll()` (the actor thread) so they are allowed to call into the Kafka consumer eg. to query current offsets, commit offsets or to seek to an offset position. The callbacks add to the time `poll()` is executed and block the internal Kafka consumer actor from doing any other work. As this can easily make influence other Kafka consumer actors running on the same dispatcher, the time the callbacks take is checked and warnings are issued to the logs if they pass a configurable threshold.

This allows for new ways to handle offsets which might show more efficient for certain use-cases. The tests show an example for external offset storage and one example which commits on rebalance only.

## Background Context

It has been discussed in #539 that the lack of blocking user-defined call-backs to react on Kafka's partition rebalancing makes certain use cases impossible with Alpakka Kafka.

In particular, it is impossible to combine Kafka's partition assignment with external offset storage.

## References

References #539 
Follow up #841 	
