### PR TITLE
Benchmarks now support multi-partitioned topics tests

### DIFF
--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/PerfFixtureHelpers.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/PerfFixtureHelpers.scala
@@ -41,7 +41,7 @@ private[benchmarks] trait PerfFixtureHelpers extends LazyLogging {
               if (e == null) {
                 if (i % loggedStep == 0)
                   logger.info(s"Written $i elements to Kafka (${100 * i / msgCount}%)")
-                if (recordMetadata.offset() == msgCount - 1 && !lastElementStoredPromise.isCompleted)
+                if (i >= msgCount - 1 && !lastElementStoredPromise.isCompleted)
                   lastElementStoredPromise.success(())
               } else {
                 if (!lastElementStoredPromise.isCompleted) {

--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaConsumerFixtures.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaConsumerFixtures.scala
@@ -14,7 +14,7 @@ import akka.kafka.{ConsumerSettings, Subscriptions}
 import akka.stream.scaladsl.Source
 import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord}
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, StringDeserializer}
-case class ReactiveKafkaConsumerTestFixture[T](topic: String, msgCount: Int, source: Source[T, Control])
+case class ReactiveKafkaConsumerTestFixture[T](topic: String, msgCount: Int, source: Source[T, Control], numberOfPartitions: Int)
 
 object ReactiveKafkaConsumerFixtures extends PerfFixtureHelpers {
 
@@ -33,7 +33,7 @@ object ReactiveKafkaConsumerFixtures extends PerfFixtureHelpers {
         fillTopic(c.kafkaHost, topic, msgCount)
         val settings = createConsumerSettings(c.kafkaHost)
         val source = Consumer.plainSource(settings, Subscriptions.topics(topic))
-        ReactiveKafkaConsumerTestFixture(topic, msgCount, source)
+        ReactiveKafkaConsumerTestFixture(topic, msgCount, source, c.numberOfPartitions)
       }
     )
 
@@ -45,7 +45,7 @@ object ReactiveKafkaConsumerFixtures extends PerfFixtureHelpers {
         fillTopic(c.kafkaHost, topic, msgCount)
         val settings = createConsumerSettings(c.kafkaHost)
         val source = Consumer.committableSource(settings, Subscriptions.topics(topic))
-        ReactiveKafkaConsumerTestFixture(topic, msgCount, source)
+        ReactiveKafkaConsumerTestFixture(topic, msgCount, source, c.numberOfPartitions)
       }
     )
 
@@ -53,7 +53,7 @@ object ReactiveKafkaConsumerFixtures extends PerfFixtureHelpers {
     FixtureGen[ReactiveKafkaConsumerTestFixture[ConsumerRecord[Array[Byte], String]]](
       c,
       msgCount => {
-        ReactiveKafkaConsumerTestFixture("topic", msgCount, null)
+        ReactiveKafkaConsumerTestFixture("topic", msgCount, null, c.numberOfPartitions)
       }
     )
 

--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaConsumerFixtures.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaConsumerFixtures.scala
@@ -14,7 +14,11 @@ import akka.kafka.{ConsumerSettings, Subscriptions}
 import akka.stream.scaladsl.Source
 import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord}
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, StringDeserializer}
-case class ReactiveKafkaConsumerTestFixture[T](topic: String, msgCount: Int, source: Source[T, Control], numberOfPartitions: Int)
+
+case class ReactiveKafkaConsumerTestFixture[T](topic: String,
+                                               msgCount: Int,
+                                               source: Source[T, Control],
+                                               numberOfPartitions: Int)
 
 object ReactiveKafkaConsumerFixtures extends PerfFixtureHelpers {
 

--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaProducerFixtures.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/ReactiveKafkaProducerFixtures.scala
@@ -47,7 +47,7 @@ object ReactiveKafkaProducerFixtures extends PerfFixtureHelpers {
     FixtureGen[ReactiveKafkaConsumerTestFixture[ConsumerRecord[Array[Byte], String]]](
       c,
       msgCount => {
-        ReactiveKafkaConsumerTestFixture("topic", msgCount, null)
+        ReactiveKafkaConsumerTestFixture("topic", msgCount, null, c.numberOfPartitions)
       }
     )
 

--- a/benchmarks/src/main/scala/akka.kafka.benchmarks/app/RunTestCommand.scala
+++ b/benchmarks/src/main/scala/akka.kafka.benchmarks/app/RunTestCommand.scala
@@ -5,4 +5,4 @@
 
 package akka.kafka.benchmarks.app
 
-case class RunTestCommand(testName: String, kafkaHost: String, msgCount: Int)
+case class RunTestCommand(testName: String, kafkaHost: String, msgCount: Int, numberOfPartitions: Int = 1)


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

Current benchmarks do not support multi-partitioned topic tests.

## References

https://github.com/akka/alpakka-kafka/issues/773