### PR TITLE
Use external Kafka in tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ val akkaVersion = "2.5.21"
 val kafkaVersion = "2.1.1"
 val kafkaVersionForDocs = "21"
 val scalatestVersion = "3.0.5"
+val testcontainersVersion = "1.11.2"
 val slf4jVersion = "1.7.26"
 val confluentAvroSerializerVersion = "5.0.1"
 
@@ -155,6 +156,7 @@ lazy val testkit = project
     libraryDependencies ++= Seq(
       "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion,
       "net.manub" %% "scalatest-embedded-kafka" % "2.0.0" exclude ("log4j", "log4j"),
+      "org.testcontainers" % "kafka" % testcontainersVersion % Provided,
       "org.apache.commons" % "commons-compress" % "1.18", // embedded Kafka pulls in Avro which pulls in commons-compress 1.8.1
       "org.scalatest" %% "scalatest" % scalatestVersion % Provided,
       "junit" % "junit" % "4.12" % Provided,
@@ -182,6 +184,7 @@ lazy val tests = project
       // See https://github.com/sbt/sbt/issues/3618#issuecomment-448951808
       "javax.ws.rs" % "javax.ws.rs-api" % "2.1.1" artifacts Artifact("javax.ws.rs-api", "jar", "jar"),
       "net.manub" %% "scalatest-embedded-schema-registry" % "2.0.0" % Test exclude ("log4j", "log4j") exclude ("org.slf4j", "slf4j-log4j12"),
+      "org.testcontainers" % "kafka" % testcontainersVersion % Test,
       "org.apache.commons" % "commons-compress" % "1.18", // embedded Kafka pulls in Avro, which pulls in commons-compress 1.8.1, see testing.md
       "org.scalatest" %% "scalatest" % scalatestVersion % Test,
       "io.spray" %% "spray-json" % "1.3.5" % Test,
@@ -245,13 +248,14 @@ lazy val docs = project
       ("\\.java\\.scala".r, _ => ".java")
     ),
     Paradox / siteSubdirName := s"docs/alpakka-kafka/${projectInfoVersion.value}",
-    Paradox / sourceDirectory := sourceDirectory.value / "main" / "paradox",
+    Paradox / sourceDirectory := sourceDirectory.value / "main",
     Paradox / paradoxGroups := Map("Language" -> Seq("Java", "Scala")),
     Paradox / paradoxProperties ++= Map(
       "akka.version" -> akkaVersion,
       "kafka.version" -> kafkaVersion,
       "confluent.version" -> confluentAvroSerializerVersion,
       "scalatest.version" -> scalatestVersion,
+      "testcontainers.version" -> testcontainersVersion,
       "extref.akka-docs.base_url" -> s"https://doc.akka.io/docs/akka/$akkaVersion/%s",
       "extref.kafka-docs.base_url" -> s"https://kafka.apache.org/$kafkaVersionForDocs/documentation/%s",
       "extref.java-docs.base_url" -> "https://docs.oracle.com/en/java/javase/11/%s",

--- a/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
@@ -10,7 +10,6 @@ import java.util.concurrent.atomic.AtomicInteger
 import akka.annotation.InternalApi
 import akka.kafka.ProducerMessage._
 import akka.stream._
-import akka.stream.stage._
 import org.apache.kafka.clients.producer.Producer
 
 import scala.concurrent.Future

--- a/docs/src/main/paradox/testing.md
+++ b/docs/src/main/paradox/testing.md
@@ -89,7 +89,7 @@ Some Alpakka Kafka tests implemented in Scala use [Scalatest](http://www.scalate
   scope=test
 }
 
-By mixin in `EmbeddedKafkaLike` an embedded Kafka instance will be started before the tests in this test class execute shut down after all tests in this test class are finished.
+By mixing in `EmbeddedKafkaLike` an embedded Kafka instance will be started before the tests in this test class execute shut down after all tests in this test class are finished.
 
 Scala
 : @@snip [snip](/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala) { #testkit #embeddedkafka }
@@ -125,7 +125,7 @@ The Testcontainers dependency must be added to your project explicitly.
   scope=test
 }
 
-By mixin in `TestcontainersKafkaLike` the Kafka Docker container will be started before the first test and shut down after all tests are finished.
+By mixing in `TestcontainersKafkaLike` the Kafka Docker container will be started before the first test and shut down after all tests are finished.
 
 Scala
 : @@snip [snip](/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala) { #testkit #testcontainers}

--- a/docs/src/main/paradox/testing.md
+++ b/docs/src/main/paradox/testing.md
@@ -1,6 +1,10 @@
 # Testing
 
-To simplify testing of streaming integrations with Alpakka Kafka, it provides the **Alpakka Kafka testkit**.
+To simplify testing of streaming integrations with Alpakka Kafka, it provides the **Alpakka Kafka testkit**. It provides help for
+
+* @ref:[mocking the Alpakka Kafka Consumers and Producers](#mocking-the-consumer-or-producer)
+* @ref:[using an embedded Kafka](#testing-with-an-embedded-kafka-server)
+* @ref:[starting and stopping Kafka in Docker](#testing-with-kafka-in-docker)
 
 @@project-info{ projectId="testkit" }
 
@@ -10,7 +14,7 @@ To simplify testing of streaming integrations with Alpakka Kafka, it provides th
   version=$project.version$
 }
 
-Note that Akka testkits do not promise binary compatibility. The API might be changed even between minor versions.
+Note that Akka testkits do not promise binary compatibility. The API might be changed even between patch releases.
 
 The table below shows Alpakka Kafka testkits's direct dependencies and the second tab shows all libraries it depends on transitively. We've overriden the `commons-compress` library to use a version with [fewer known security vulnerabilities](https://commons.apache.org/proper/commons-compress/security-reports.html).
 
@@ -61,7 +65,7 @@ Java JUnit 4
 Java JUnit 5
 : @@snip [snip](/tests/src/test/java/docs/javadsl/ProducerExampleTest.java) { #testkit }
 
-The JUnit test base classes run the [`assertAllStagesStopped`](https://doc.akka.io/api/akka/current/akka/stream/testkit/javadsl/StreamTestKit$.html#assertAllStagesStopped(mat:akka.stream.Materializer):Unit) check from Akka Stream testkit to ensure all stages are shut down properly within each test. This may interfere with the `stop-timeout` which delays shutdown for Alpakka Kafka consumers. You might need to configure a shorter timeout in your `application.conf` for tests.
+The JUnit test base classes run the [`assertAllStagesStopped`](https://doc.akka.io/api/akka/current/akka/stream/testkit/javadsl/StreamTestKit$.html#assertAllStagesStopped) check from Akka Stream testkit to ensure all stages are shut down properly within each test. This may interfere with the `stop-timeout` which delays shutdown for Alpakka Kafka consumers. You might need to configure a shorter timeout in your `application.conf` for tests.
 
 
 ### Testing from Scala code
@@ -76,18 +80,60 @@ The `KafkaSpec` class offers access to
 
 `EmbeddedKafkaLike` extends `KafkaSpec` to add automatic starting and stopping of the embedded Kafka broker.
 
-Most Alpakka Kafka tests implemented in Scala use [Scalatest](http://www.scalatest.org/) with the mix-ins shown below. You need to add Scalatest explicitly in your test dependencies (this release of Alpakka Kafka uses Scalatest $scalatest.version$.)
+Some Alpakka Kafka tests implemented in Scala use [Scalatest](http://www.scalatest.org/) with the mix-ins shown below. You need to add Scalatest explicitly in your test dependencies (this release of Alpakka Kafka uses Scalatest $scalatest.version$.)
+
+@@dependency [Maven,sbt,Gradle] {
+  group=org.scalatest
+  artifact=scalatest
+  version=$scalatest.version$
+  scope=test
+}
+
+By mixin in `EmbeddedKafkaLike` an embedded Kafka instance will be started before the tests in this test class execute shut down after all tests in this test class are finished.
 
 Scala
-: @@snip [snip](/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala) { #testkit }
+: @@snip [snip](/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala) { #testkit #embeddedkafka }
+
+With this `EmbeddedKafkaSpecBase` class test classes can extend it to automatically start and stop a Kafka broker to test with. To configure the Kafka broker non-default, override the `createKafkaConfig` as shown above.
+
+To ensure proper shutdown of all stages in every test, wrap your test code in [`assertAllStagesStopped`](https://doc.akka.io/api/akka/current/akka/stream/testkit/scaladsl/StreamTestKit$.html#assertAllStagesStopped). This may interfere with the `stop-timeout` which delays shutdown for Alpakka Kafka consumers. You might need to configure a shorter timeout in your `application.conf` for tests.
 
 
-With this `SpecBase` class test classes can extend it to automatically start and stop a Kafka broker to test with.
+## Testing with Kafka in Docker
+
+The [Testcontainers](https://www.testcontainers.org/) project contains a nice API to start and stop Apache Kafka in Docker containers. This becomes very relevant when your application code uses a Scala version which Apache Kafka doesn't support so that *EmbeddedKafka* can't be used.
+
+@@@note
+
+The Testcontainers support is new to Alpakka Kafka since 1.0.2 and may evolve a bit more.
+
+@@@
+
+### Testing from Java code
+
+Testcontainers is designed to be used with JUnit and you can follow [their documentation](https://www.testcontainers.org/modules/kafka/) to start and stop Kafka. To start a single instance for many tests see [Singleton containers](https://www.testcontainers.org/test_framework_integration/manual_lifecycle_control/).
+
+
+### Testing from Scala code
+
+The Testcontainers dependency must be added to your project explicitly.
+
+@@dependency [Maven,sbt,Gradle] {
+  group=org.testcontainers
+  artifact=kafka
+  version=$testcontainers.version$
+  scope=test
+}
+
+By mixin in `TestcontainersKafkaLike` the Kafka Docker container will be started before the first test and shut down after all tests are finished.
 
 Scala
-: @@snip [snip](/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala) { #testkit }
+: @@snip [snip](/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala) { #testkit #testcontainers}
 
-To ensure proper shutdown of all stages in every test, wrap your test code in [`assertAllStagesStopped`](https://doc.akka.io/api/akka/current/akka/stream/testkit/scaladsl/StreamTestKit$.html#assertAllStagesStopped[T](block:=%3ET)(implicitmaterializer:akka.stream.Materializer):T). This may interfere with the `stop-timeout` which delays shutdown for Alpakka Kafka consumers. You might need to configure a shorter timeout in your `application.conf` for tests.
+
+With this `TestcontainersSampleSpec` class test classes can extend it to automatically start and stop a Kafka broker to test with.
+
+To ensure proper shutdown of all stages in every test, wrap your test code in [`assertAllStagesStopped`](https://doc.akka.io/api/akka/current/akka/stream/testkit/scaladsl/StreamTestKit$.html#assertAllStagesStopped). This may interfere with the `stop-timeout` which delays shutdown for Alpakka Kafka consumers. You might need to configure a shorter timeout in your `application.conf` for tests.
 
 
 ## Alternative testing libraries

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
@@ -6,15 +6,14 @@
 package akka.kafka.testkit.internal
 
 import java.util
-import java.util.concurrent.{ExecutionException, TimeUnit}
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
-import java.util.{Arrays, Collections, Properties}
+import java.util.{Arrays, Properties}
 
 import akka.actor.ActorSystem
 import akka.kafka.{CommitterSettings, ConsumerSettings, ProducerSettings}
 import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
 import org.apache.kafka.clients.consumer.ConsumerConfig
-import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
 import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
 import org.slf4j.Logger
 
@@ -92,28 +91,6 @@ trait KafkaTestKit {
    */
   def createTopic(number: Int = 0, partitions: Int = 1, replication: Int = 1): String = {
     val topicName = createTopicName(number)
-    val configs = new util.HashMap[String, String]()
-    val createResult = adminClient.createTopics(
-      Arrays.asList(new NewTopic(topicName, partitions, replication.toShort).configs(configs))
-    )
-    createResult.all().get(10, TimeUnit.SECONDS)
-    topicName
-  }
-
-  /**
-   * Create a topic with given partition number and replication factor.
-   *
-   * This method will block and return only when the topic has been successfully created.
-   */
-  def createCleanTopic(number: Int = 0, partitions: Int = 1, replication: Int = 1): String = {
-    val topicName = createTopicName(number)
-    val deletion = adminClient.deleteTopics(Collections.singletonList(topicName))
-    try {
-      deletion.all().get(10, TimeUnit.SECONDS)
-      sleepMillis(80L * partitions, "topic deletion")
-    } catch {
-      case ee: ExecutionException if ee.getCause.isInstanceOf[UnknownTopicOrPartitionException] =>
-    }
     val configs = new util.HashMap[String, String]()
     val createResult = adminClient.createTopics(
       Arrays.asList(new NewTopic(topicName, partitions, replication.toShort).configs(configs))

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
@@ -14,7 +14,6 @@ import akka.actor.ActorSystem
 import akka.kafka.{CommitterSettings, ConsumerSettings, ProducerSettings}
 import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
 import org.apache.kafka.clients.consumer.ConsumerConfig
-import org.apache.kafka.common.KafkaFuture
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
 import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
 import org.slf4j.Logger
@@ -111,7 +110,7 @@ trait KafkaTestKit {
     val deletion = adminClient.deleteTopics(Collections.singletonList(topicName))
     try {
       deletion.all().get(10, TimeUnit.SECONDS)
-      sleepMillis(80 * partitions, "topic deletion")
+      sleepMillis(80L * partitions, "topic deletion")
     } catch {
       case ee: ExecutionException if ee.getCause.isInstanceOf[UnknownTopicOrPartitionException] =>
     }

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
@@ -6,14 +6,16 @@
 package akka.kafka.testkit.internal
 
 import java.util
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{ExecutionException, TimeUnit}
 import java.util.concurrent.atomic.AtomicInteger
-import java.util.{Arrays, Properties}
+import java.util.{Arrays, Collections, Properties}
 
 import akka.actor.ActorSystem
 import akka.kafka.{CommitterSettings, ConsumerSettings, ProducerSettings}
 import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
 import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.common.KafkaFuture
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException
 import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
 import org.slf4j.Logger
 
@@ -91,6 +93,28 @@ trait KafkaTestKit {
    */
   def createTopic(number: Int = 0, partitions: Int = 1, replication: Int = 1): String = {
     val topicName = createTopicName(number)
+    val configs = new util.HashMap[String, String]()
+    val createResult = adminClient.createTopics(
+      Arrays.asList(new NewTopic(topicName, partitions, replication.toShort).configs(configs))
+    )
+    createResult.all().get(10, TimeUnit.SECONDS)
+    topicName
+  }
+
+  /**
+   * Create a topic with given partition number and replication factor.
+   *
+   * This method will block and return only when the topic has been successfully created.
+   */
+  def createCleanTopic(number: Int = 0, partitions: Int = 1, replication: Int = 1): String = {
+    val topicName = createTopicName(number)
+    val deletion = adminClient.deleteTopics(Collections.singletonList(topicName))
+    try {
+      deletion.all().get(10, TimeUnit.SECONDS)
+      sleepMillis(80 * partitions, "topic deletion")
+    } catch {
+      case ee: ExecutionException if ee.getCause.isInstanceOf[UnknownTopicOrPartitionException] =>
+    }
     val configs = new util.HashMap[String, String]()
     val createResult = adminClient.createTopics(
       Arrays.asList(new NewTopic(topicName, partitions, replication.toShort).configs(configs))

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
@@ -37,7 +37,8 @@ import scala.util.{Failure, Success, Try}
 trait EmbeddedKafkaLike extends KafkaSpec {
 
   lazy implicit val embeddedKafkaConfig: EmbeddedKafkaConfig = createKafkaConfig
-  def createKafkaConfig: EmbeddedKafkaConfig
+
+  def createKafkaConfig: EmbeddedKafkaConfig = EmbeddedKafkaConfig(kafkaPort, zooKeeperPort)
 
   override def bootstrapServers =
     s"localhost:${embeddedKafkaConfig.kafkaPort}"
@@ -53,9 +54,11 @@ trait EmbeddedKafkaLike extends KafkaSpec {
   }
 }
 
-abstract class KafkaSpec(val kafkaPort: Int, val zooKeeperPort: Int, actorSystem: ActorSystem)
+abstract class KafkaSpec(_kafkaPort: Int, val zooKeeperPort: Int, actorSystem: ActorSystem)
     extends TestKit(actorSystem)
     with KafkaTestKit {
+
+  def kafkaPort: Int = _kafkaPort
 
   def this(kafkaPort: Int) = this(kafkaPort, kafkaPort + 1, ActorSystem("Spec"))
 

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/ScalatestKafkaSpec.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/ScalatestKafkaSpec.scala
@@ -8,7 +8,7 @@ package akka.kafka.testkit.scaladsl
 import akka.kafka.testkit.internal.TestFrameworkInterface
 import org.scalatest.Suite
 
-abstract class ScalatestKafkaSpec(override val kafkaPort: Int)
+abstract class ScalatestKafkaSpec(kafkaPort: Int)
     extends KafkaSpec(kafkaPort)
     with Suite
     with TestFrameworkInterface.Scalatest { this: Suite ⇒

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/TestcontainersKafkaLike.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/TestcontainersKafkaLike.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.testkit.scaladsl
+
+import org.testcontainers.containers.KafkaContainer
+
+/**
+ * Uses [Testcontainers](https://www.testcontainers.org/) to start a Kafka broker in a Docker container.
+ * The Testcontainers dependency has to be added explicitly.
+ */
+trait TestcontainersKafkaLike extends KafkaSpec {
+  import TestcontainersKafkaLike._
+
+  override def kafkaPort: Int = {
+    requireStarted()
+    kafkaPortInternal
+  }
+
+  override def bootstrapServers: String = {
+    requireStarted()
+    kafkaBootstrapServersInternal
+  }
+
+  override def setUp(): Unit = {
+    if (kafkaPortInternal == -1) {
+      val kafkaContainer = new KafkaContainer()
+      kafkaContainer.start()
+      kafkaBootstrapServersInternal = kafkaContainer.getBootstrapServers
+      kafkaPortInternal = kafkaBootstrapServersInternal.substring(kafkaBootstrapServersInternal.lastIndexOf(":") + 1).toInt
+    }
+    super.setUp()
+  }
+}
+
+private object TestcontainersKafkaLike {
+
+  private var kafkaBootstrapServersInternal: String = _
+  private var kafkaPortInternal: Int = -1
+
+  private def requireStarted(): Unit = require(kafkaPortInternal != -1, "Testcontainers Kafka hasn't been started via `setUp`")
+
+}

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/TestcontainersKafkaLike.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/TestcontainersKafkaLike.scala
@@ -29,7 +29,8 @@ trait TestcontainersKafkaLike extends KafkaSpec {
       val kafkaContainer = new KafkaContainer()
       kafkaContainer.start()
       kafkaBootstrapServersInternal = kafkaContainer.getBootstrapServers
-      kafkaPortInternal = kafkaBootstrapServersInternal.substring(kafkaBootstrapServersInternal.lastIndexOf(":") + 1).toInt
+      kafkaPortInternal =
+        kafkaBootstrapServersInternal.substring(kafkaBootstrapServersInternal.lastIndexOf(":") + 1).toInt
     }
     super.setUp()
   }
@@ -40,6 +41,7 @@ private object TestcontainersKafkaLike {
   private var kafkaBootstrapServersInternal: String = _
   private var kafkaPortInternal: Int = -1
 
-  private def requireStarted(): Unit = require(kafkaPortInternal != -1, "Testcontainers Kafka hasn't been started via `setUp`")
+  private def requireStarted(): Unit =
+    require(kafkaPortInternal != -1, "Testcontainers Kafka hasn't been started via `setUp`")
 
 }

--- a/tests/src/main/scala/akka/kafka/KafkaPorts.scala
+++ b/tests/src/main/scala/akka/kafka/KafkaPorts.scala
@@ -11,9 +11,7 @@ package akka.kafka
  */
 object KafkaPorts {
 
-  val DockerKafkaHostname = "linuxkit-025000000001"
-  val DockerKafkaPort = 32769
-  val DockerKafkaBootstrapServers: String = DockerKafkaHostname + ":" + DockerKafkaPort.toString
+  val DockerKafkaPort = -1
 
   val IntegrationSpec = 9002
   val RetentionPeriodSpec = 9012

--- a/tests/src/main/scala/akka/kafka/KafkaPorts.scala
+++ b/tests/src/main/scala/akka/kafka/KafkaPorts.scala
@@ -11,32 +11,29 @@ package akka.kafka
  */
 object KafkaPorts {
 
-  val DockerKafkaPort = -1
-
   val IntegrationSpec = 9002
   val RetentionPeriodSpec = 9012
   val TransactionsSpec = 9022
   val ReconnectSpec = 9032
   val ReconnectSpecProxy = 9034
-  val TimestampSpec = 9042
+  // val _ = 9042
   val MultiConsumerSpec = 9052
-  val ScalaConsumerExamples = 9062
+  // val _ = 9062
   val ScalaPartitionExamples = 9072
-  val ScalaAtLeastOnceExamples = 9082
-  val ScalaFetchMetadataExamples = 9092
+  // val _ = 9082
+  // val _ = 9092
   val ScalaTransactionsExamples = 9102
-  val ScalaProducerExamples = 9112
-  val PartitionedSourcesSpec = 9122
+  // val _ = 9112
+  // val _ = 9122
   val AssignmentSpec = 9132
   val AssignmentTest = 9142
   val ScalaAvroSerialization = 9152
   val SerializationTest = 9162
-  val NoBrokerSpec = 9172
+  // val _ = 9172
   val AtLeastOnceToManyTest = 9182
   val FetchMetadataTest = 9192
   val JavaProducerExamples = 9202
   val JavaTransactionsExamples = 9212
   val ConsumerExamplesTest = 9222
-  val CommittingSpec = 9232
 
 }

--- a/tests/src/main/scala/akka/kafka/KafkaPorts.scala
+++ b/tests/src/main/scala/akka/kafka/KafkaPorts.scala
@@ -11,6 +11,10 @@ package akka.kafka
  */
 object KafkaPorts {
 
+  val DockerKafkaHostname = "linuxkit-025000000001"
+  val DockerKafkaPort = 32769
+  val DockerKafkaBootstrapServers: String = DockerKafkaHostname + ":" + DockerKafkaPort.toString
+
   val IntegrationSpec = 9002
   val RetentionPeriodSpec = 9012
   val TransactionsSpec = 9022

--- a/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
@@ -10,12 +10,12 @@ import java.util.concurrent.atomic.AtomicInteger
 import akka.kafka.ConsumerMessage.CommittableOffsetBatch
 import akka.kafka.ProducerMessage.MultiMessage
 import akka.kafka._
+import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSink
 import akka.testkit.TestProbe
 import akka.{Done, NotUsed}
-import net.manub.embeddedkafka.EmbeddedKafkaConfig
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 import org.scalatest._
@@ -24,9 +24,7 @@ import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class CommittingSpec extends SpecBase(KafkaPorts.DockerKafkaPort) with Inside {
-
-  override val bootstrapServers: String = KafkaPorts.DockerKafkaBootstrapServers
+class CommittingSpec extends SpecBase(KafkaPorts.DockerKafkaPort) with TestcontainersKafkaLike with Inside {
 
   implicit val patience: PatienceConfig = PatienceConfig(30.seconds, 500.millis)
 

--- a/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
@@ -24,7 +24,7 @@ import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class CommittingSpec extends SpecBase(KafkaPorts.DockerKafkaPort) with TestcontainersKafkaLike with Inside {
+class CommittingSpec extends SpecBase with TestcontainersKafkaLike with Inside {
 
   implicit val patience: PatienceConfig = PatienceConfig(30.seconds, 500.millis)
 
@@ -35,7 +35,7 @@ class CommittingSpec extends SpecBase(KafkaPorts.DockerKafkaPort) with Testconta
 
     "ensure uncommitted messages are redelivered" in assertAllStagesStopped {
       val Messages = Numbers.take(100)
-      val topic1 = createCleanTopic(1)
+      val topic1 = createTopic(1)
       val group1 = createGroupId(1)
       val group2 = createGroupId(2)
 
@@ -95,7 +95,7 @@ class CommittingSpec extends SpecBase(KafkaPorts.DockerKafkaPort) with Testconta
 
     "work even if the partition gets balanced away and is not reassigned yet (#750)" in assertAllStagesStopped {
       val count = 10
-      val topic1 = createCleanTopic(1, partitions = 2)
+      val topic1 = createTopic(1, partitions = 2)
       val group1 = createGroupId(1)
       val consumerSettings = consumerDefaults
         .withGroupId(group1)
@@ -176,7 +176,7 @@ class CommittingSpec extends SpecBase(KafkaPorts.DockerKafkaPort) with Testconta
     }
 
     "work without demand" in assertAllStagesStopped {
-      val topic = createCleanTopic()
+      val topic = createTopic()
       val group = createGroupId()
 
       // important to use more messages than the internal buffer sizes
@@ -210,7 +210,7 @@ class CommittingSpec extends SpecBase(KafkaPorts.DockerKafkaPort) with Testconta
     }
 
     "work in batches" in assertAllStagesStopped {
-      val topic = createCleanTopic()
+      val topic = createTopic()
       val group = createGroupId()
 
       produce(topic, 1 to 100).futureValue shouldBe Done
@@ -246,7 +246,7 @@ class CommittingSpec extends SpecBase(KafkaPorts.DockerKafkaPort) with Testconta
     }
 
     "work with a committer sink" in assertAllStagesStopped {
-      val topic = createCleanTopic()
+      val topic = createTopic()
       val group = createGroupId()
 
       produce(topic, 1 to 100).futureValue shouldBe Done

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -34,7 +34,7 @@ class IntegrationSpec extends SpecBase(kafkaPort = KafkaPorts.IntegrationSpec) w
   "Kafka connector" must {
     "produce to plainSink and consume from plainSource" in {
       assertAllStagesStopped {
-        val topic1 = createCleanTopic(1)
+        val topic1 = createTopic(1)
         val group1 = createGroupId(1)
 
         Await.result(produce(topic1, 1 to 100), remainingOrDefault)
@@ -53,7 +53,7 @@ class IntegrationSpec extends SpecBase(kafkaPort = KafkaPorts.IntegrationSpec) w
       val partitions = 4
       val totalMessages = 200L
 
-      val topic = createCleanTopic(1, partitions)
+      val topic = createTopic(1, partitions)
       val allTps = (0 until partitions).map(p => new TopicPartition(topic, p))
       val group = createGroupId(1)
       val sourceSettings = consumerDefaults
@@ -126,8 +126,8 @@ class IntegrationSpec extends SpecBase(kafkaPort = KafkaPorts.IntegrationSpec) w
 
     "connect consumer to producer and commit in batches" in {
       assertAllStagesStopped {
-        val topic1 = createCleanTopic(1)
-        val topic2 = createCleanTopic(2)
+        val topic1 = createTopic(1)
+        val topic2 = createTopic(2)
         val group1 = createGroupId(1)
 
         awaitProduce(produce(topic1, 1 to 10))
@@ -156,7 +156,7 @@ class IntegrationSpec extends SpecBase(kafkaPort = KafkaPorts.IntegrationSpec) w
 
     "not produce any records after send-failure if stage is stopped" in {
       assertAllStagesStopped {
-        val topic1 = createCleanTopic(1)
+        val topic1 = createTopic(1)
         val group1 = createGroupId(1)
         // we use a 'max.block.ms' setting that will cause the metadata-retrieval to fail
         // effectively failing the production of the first messages
@@ -175,7 +175,7 @@ class IntegrationSpec extends SpecBase(kafkaPort = KafkaPorts.IntegrationSpec) w
     }
 
     "stop and shut down KafkaConsumerActor for committableSource used with take" in assertAllStagesStopped {
-      val topic1 = createCleanTopic(1)
+      val topic1 = createTopic(1)
       val group1 = createGroupId(1)
 
       Await.ready(produce(topic1, 1 to 10), remainingOrDefault)
@@ -193,7 +193,7 @@ class IntegrationSpec extends SpecBase(kafkaPort = KafkaPorts.IntegrationSpec) w
     }
 
     "expose missing groupId as error" in assertAllStagesStopped {
-      val topic1 = createCleanTopic(1)
+      val topic1 = createTopic(1)
 
       val control =
         Consumer
@@ -207,7 +207,7 @@ class IntegrationSpec extends SpecBase(kafkaPort = KafkaPorts.IntegrationSpec) w
     }
 
     "stop and shut down KafkaConsumerActor for atMostOnceSource used with take" in assertAllStagesStopped {
-      val topic1 = createCleanTopic(1)
+      val topic1 = createTopic(1)
       val group1 = createGroupId(1)
 
       Await.ready(produce(topic1, 1 to 10), remainingOrDefault)
@@ -226,7 +226,7 @@ class IntegrationSpec extends SpecBase(kafkaPort = KafkaPorts.IntegrationSpec) w
 
     "support metadata fetching on ConsumerActor" in {
       assertAllStagesStopped {
-        val topic = createCleanTopic(1)
+        val topic = createTopic(1)
         val group = createGroupId(1)
 
         Await.result(produce(topic, 1 to 100), remainingOrDefault)
@@ -305,7 +305,7 @@ class IntegrationSpec extends SpecBase(kafkaPort = KafkaPorts.IntegrationSpec) w
 
     "complete source when stopped" in
     assertAllStagesStopped {
-      val topic = createCleanTopic(1)
+      val topic = createTopic(1)
       val group = createGroupId(1)
 
       Await.result(produce(topic, 1 to 100), remainingOrDefault)
@@ -331,7 +331,7 @@ class IntegrationSpec extends SpecBase(kafkaPort = KafkaPorts.IntegrationSpec) w
 
     "complete partition sources when stopped" in
     assertAllStagesStopped {
-      val topic = createCleanTopic(1)
+      val topic = createTopic(1)
       val group = createGroupId(1)
 
       awaitProduce(produce(topic, 1 to 100))
@@ -358,7 +358,7 @@ class IntegrationSpec extends SpecBase(kafkaPort = KafkaPorts.IntegrationSpec) w
     }
 
     "access metrics" in assertAllStagesStopped {
-      val topic = createCleanTopic(number = 1, partitions = 1, replication = 1)
+      val topic = createTopic(number = 1, partitions = 1, replication = 1)
       val group = createGroupId(1)
 
       val control = Consumer

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -9,6 +9,7 @@ import akka.Done
 import akka.kafka.ConsumerMessage.CommittableOffsetBatch
 import akka.kafka._
 import akka.kafka.scaladsl.Consumer.DrainingControl
+import akka.kafka.testkit.scaladsl.EmbeddedKafkaLike
 import akka.pattern.ask
 import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.{Keep, Sink, Source}
@@ -26,9 +27,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 import scala.util.Success
 
-class IntegrationSpec extends SpecBase(KafkaPorts.DockerKafkaPort) with Inside {
-
-  override val bootstrapServers: String = KafkaPorts.DockerKafkaBootstrapServers
+class IntegrationSpec extends SpecBase(kafkaPort = KafkaPorts.IntegrationSpec) with EmbeddedKafkaLike with Inside {
 
   implicit val patience = PatienceConfig(30.seconds, 500.millis)
 

--- a/tests/src/test/scala/akka/kafka/scaladsl/MultiConsumerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/MultiConsumerSpec.scala
@@ -17,7 +17,7 @@ import scala.concurrent.{Await, Future}
 
 class MultiConsumerSpec extends SpecBase(kafkaPort = KafkaPorts.MultiConsumerSpec) with EmbeddedKafkaLike {
 
-  def createKafkaConfig: EmbeddedKafkaConfig =
+  override def createKafkaConfig: EmbeddedKafkaConfig =
     EmbeddedKafkaConfig(kafkaPort,
                         zooKeeperPort,
                         Map(

--- a/tests/src/test/scala/akka/kafka/scaladsl/MultiConsumerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/MultiConsumerSpec.scala
@@ -7,6 +7,7 @@ package akka.kafka.scaladsl
 
 import akka.Done
 import akka.kafka.KafkaPorts
+import akka.kafka.testkit.scaladsl.EmbeddedKafkaLike
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import net.manub.embeddedkafka.EmbeddedKafkaConfig
 
@@ -14,7 +15,7 @@ import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-class MultiConsumerSpec extends SpecBase(kafkaPort = KafkaPorts.MultiConsumerSpec) {
+class MultiConsumerSpec extends SpecBase(kafkaPort = KafkaPorts.MultiConsumerSpec) with EmbeddedKafkaLike {
 
   def createKafkaConfig: EmbeddedKafkaConfig =
     EmbeddedKafkaConfig(kafkaPort,

--- a/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicLong}
 import akka.Done
 import akka.kafka._
 import akka.kafka.scaladsl.Consumer.DrainingControl
+import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
 import akka.stream.{KillSwitches, OverflowStrategy}
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
@@ -26,10 +27,9 @@ import scala.util.{Failure, Success}
 
 class PartitionedSourcesSpec
     extends SpecBase(KafkaPorts.DockerKafkaPort)
+    with TestcontainersKafkaLike
     with Inside
     with OptionValues {
-
-  override val bootstrapServers: String = KafkaPorts.DockerKafkaBootstrapServers
 
   implicit val patience = PatienceConfig(15.seconds, 500.millis)
   override def sleepAfterProduce: FiniteDuration = 500.millis

--- a/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
@@ -25,11 +25,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{Future, Promise}
 import scala.util.{Failure, Success}
 
-class PartitionedSourcesSpec
-    extends SpecBase(KafkaPorts.DockerKafkaPort)
-    with TestcontainersKafkaLike
-    with Inside
-    with OptionValues {
+class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with Inside with OptionValues {
 
   implicit val patience = PatienceConfig(15.seconds, 500.millis)
   override def sleepAfterProduce: FiniteDuration = 500.millis
@@ -40,7 +36,7 @@ class PartitionedSourcesSpec
   "Partitioned source" must {
 
     "begin consuming from the beginning of the topic" in assertAllStagesStopped {
-      val topic = createCleanTopic(1)
+      val topic = createTopic(1)
       val group = createGroupId(1)
 
       awaitProduce(produce(topic, 1 to 100))
@@ -61,7 +57,7 @@ class PartitionedSourcesSpec
     }
 
     "begin consuming from the middle of the topic" in assertAllStagesStopped {
-      val topic = createCleanTopic(1)
+      val topic = createTopic(1)
       val group = createGroupId(1)
 
       givenInitializedTopic(topic)
@@ -88,7 +84,7 @@ class PartitionedSourcesSpec
       val partitions = 4
       val totalMessages = 400L
 
-      val topic = createCleanTopic(1, partitions)
+      val topic = createTopic(1, partitions)
       val allTps = (0 until partitions).map(p => new TopicPartition(topic, p))
       val group = createGroupId(1)
       val sourceSettings = consumerDefaults
@@ -141,7 +137,7 @@ class PartitionedSourcesSpec
       val initialMessage = 0L
       val initialized = Promise[Unit]
 
-      val topic = createCleanTopic(1, partitions)
+      val topic = createTopic(1, partitions)
       val group = createGroupId(1)
       val sourceSettings = consumerDefaults
         .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest")
@@ -235,7 +231,7 @@ class PartitionedSourcesSpec
       val initialMessage = 0L
       val initialized = Promise[Unit]
 
-      val topic = createCleanTopic(1, partitions)
+      val topic = createTopic(1, partitions)
       val allTps = (0 until partitions).map(p => new TopicPartition(topic, p))
       val group = createGroupId(1)
       val sourceSettings = consumerDefaults
@@ -322,7 +318,7 @@ class PartitionedSourcesSpec
 
     "call the onRevoked hook" in assertAllStagesStopped {
       val partitions = 4
-      val topic = createCleanTopic(1, partitions)
+      val topic = createTopic(1, partitions)
       val group = createGroupId(1)
 
       var partitionsAssigned = false
@@ -359,7 +355,7 @@ class PartitionedSourcesSpec
     }
 
     "not leave gaps when subsource is cancelled" in assertAllStagesStopped {
-      val topic = createCleanTopic()
+      val topic = createTopic()
       val group = createGroupId()
       val totalMessages = 100
 
@@ -386,7 +382,7 @@ class PartitionedSourcesSpec
     }
 
     "not leave gaps when subsource fails" in assertAllStagesStopped {
-      val topic = createCleanTopic()
+      val topic = createTopic()
       val group = createGroupId()
       val totalMessages = 105
 
@@ -429,7 +425,7 @@ class PartitionedSourcesSpec
       val totalMessages = 100L
       val exceptionTriggered = new AtomicBoolean(false)
 
-      val topic = createCleanTopic(1, partitions)
+      val topic = createTopic(1, partitions)
       val allTps = (0 until partitions).map(p => new TopicPartition(topic, p))
       val group = createGroupId(1)
       val sourceSettings = consumerDefaults

--- a/tests/src/test/scala/akka/kafka/scaladsl/ReconnectSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/ReconnectSpec.scala
@@ -11,7 +11,7 @@ import akka.kafka.testkit.scaladsl.EmbeddedKafkaLike
 import akka.stream.scaladsl.{Keep, Sink, Source, SourceQueueWithComplete, Tcp}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.{KillSwitches, OverflowStrategy, UniqueKillSwitch}
-import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
+import net.manub.embeddedkafka.EmbeddedKafka
 import org.apache.kafka.clients.producer.ProducerRecord
 
 import scala.concurrent.duration._
@@ -24,7 +24,7 @@ class ReconnectSpec extends SpecBase(KafkaPorts.ReconnectSpec) with EmbeddedKafk
   "A Producer" must {
 
     "continue to work when there is another Kafka port available" in assertAllStagesStopped {
-      val topic1 = createCleanTopic(1)
+      val topic1 = createTopic(1)
       val group1 = createGroupId(1)
 
       // start a TCP proxy forwarding to Kafka
@@ -68,7 +68,7 @@ class ReconnectSpec extends SpecBase(KafkaPorts.ReconnectSpec) with EmbeddedKafk
 
     "pick up again when the Kafka server comes back up" ignore /* because it is flaky */ {
       assertAllStagesStopped {
-        val topic1 = createCleanTopic(1)
+        val topic1 = createTopic(1)
         val group1 = createGroupId(1)
 
         val messagesProduced = 10
@@ -135,7 +135,7 @@ class ReconnectSpec extends SpecBase(KafkaPorts.ReconnectSpec) with EmbeddedKafk
   "A Consumer" must {
 
     "continue to work when there is another Kafka port available" in assertAllStagesStopped {
-      val topic1 = createCleanTopic(1)
+      val topic1 = createTopic(1)
       val group1 = createGroupId(1)
 
       // produce messages directly to Kafka
@@ -163,7 +163,7 @@ class ReconnectSpec extends SpecBase(KafkaPorts.ReconnectSpec) with EmbeddedKafk
     }
 
     "pick up again when the Kafka server comes back up" in assertAllStagesStopped {
-      val topic1 = createCleanTopic(1)
+      val topic1 = createTopic(1)
       val group1 = createGroupId(1)
 
       // produce messages

--- a/tests/src/test/scala/akka/kafka/scaladsl/ReconnectSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/ReconnectSpec.scala
@@ -21,13 +21,6 @@ class ReconnectSpec extends SpecBase(KafkaPorts.ReconnectSpec) with EmbeddedKafk
 
   val proxyPort = KafkaPorts.ReconnectSpecProxy
 
-  def createKafkaConfig: EmbeddedKafkaConfig =
-    EmbeddedKafkaConfig(kafkaPort,
-                        zooKeeperPort,
-                        Map(
-                          "offsets.topic.replication.factor" -> "1"
-                        ))
-
   "A Producer" must {
 
     "continue to work when there is another Kafka port available" in assertAllStagesStopped {

--- a/tests/src/test/scala/akka/kafka/scaladsl/ReconnectSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/ReconnectSpec.scala
@@ -7,6 +7,7 @@ package akka.kafka.scaladsl
 
 import akka.Done
 import akka.kafka._
+import akka.kafka.testkit.scaladsl.EmbeddedKafkaLike
 import akka.stream.scaladsl.{Keep, Sink, Source, SourceQueueWithComplete, Tcp}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.{KillSwitches, OverflowStrategy, UniqueKillSwitch}
@@ -16,7 +17,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-class ReconnectSpec extends SpecBase(kafkaPort = KafkaPorts.ReconnectSpec) {
+class ReconnectSpec extends SpecBase(KafkaPorts.ReconnectSpec) with EmbeddedKafkaLike {
 
   val proxyPort = KafkaPorts.ReconnectSpecProxy
 
@@ -30,10 +31,8 @@ class ReconnectSpec extends SpecBase(kafkaPort = KafkaPorts.ReconnectSpec) {
   "A Producer" must {
 
     "continue to work when there is another Kafka port available" in assertAllStagesStopped {
-      val topic1 = createTopicName(1)
+      val topic1 = createCleanTopic(1)
       val group1 = createGroupId(1)
-
-      givenInitializedTopic(topic1)
 
       // start a TCP proxy forwarding to Kafka
       val (proxyBinding, proxyKillSwtich) = createProxy()
@@ -76,10 +75,8 @@ class ReconnectSpec extends SpecBase(kafkaPort = KafkaPorts.ReconnectSpec) {
 
     "pick up again when the Kafka server comes back up" ignore /* because it is flaky */ {
       assertAllStagesStopped {
-        val topic1 = createTopicName(1)
+        val topic1 = createCleanTopic(1)
         val group1 = createGroupId(1)
-
-        givenInitializedTopic(topic1)
 
         val messagesProduced = 10
         val firstBatch = 2
@@ -145,10 +142,8 @@ class ReconnectSpec extends SpecBase(kafkaPort = KafkaPorts.ReconnectSpec) {
   "A Consumer" must {
 
     "continue to work when there is another Kafka port available" in assertAllStagesStopped {
-      val topic1 = createTopicName(1)
+      val topic1 = createCleanTopic(1)
       val group1 = createGroupId(1)
-
-      givenInitializedTopic(topic1)
 
       // produce messages directly to Kafka
       val messagesProduced = 100
@@ -175,10 +170,8 @@ class ReconnectSpec extends SpecBase(kafkaPort = KafkaPorts.ReconnectSpec) {
     }
 
     "pick up again when the Kafka server comes back up" in assertAllStagesStopped {
-      val topic1 = createTopicName(1)
+      val topic1 = createCleanTopic(1)
       val group1 = createGroupId(1)
-
-      givenInitializedTopic(topic1)
 
       // produce messages
       val messagesProduced = 100

--- a/tests/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 
 import akka.Done
 import akka.kafka._
+import akka.kafka.testkit.scaladsl.EmbeddedKafkaLike
 import akka.stream.scaladsl.Keep
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSink
@@ -18,7 +19,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class RetentionPeriodSpec extends SpecBase(kafkaPort = KafkaPorts.RetentionPeriodSpec) {
+class RetentionPeriodSpec extends SpecBase(kafkaPort = KafkaPorts.RetentionPeriodSpec)  with EmbeddedKafkaLike {
 
   def createKafkaConfig: EmbeddedKafkaConfig =
     EmbeddedKafkaConfig(kafkaPort,

--- a/tests/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
@@ -19,9 +19,9 @@ import scala.collection.JavaConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class RetentionPeriodSpec extends SpecBase(kafkaPort = KafkaPorts.RetentionPeriodSpec)  with EmbeddedKafkaLike {
+class RetentionPeriodSpec extends SpecBase(kafkaPort = KafkaPorts.RetentionPeriodSpec) with EmbeddedKafkaLike {
 
-  def createKafkaConfig: EmbeddedKafkaConfig =
+  override def createKafkaConfig: EmbeddedKafkaConfig =
     EmbeddedKafkaConfig(kafkaPort,
                         zooKeeperPort,
                         Map(

--- a/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
@@ -28,12 +28,12 @@ class EmbeddedKafkaSampleSpec extends SpecBase(kafkaPort = 1234) with EmbeddedKa
   // if a specific Kafka broker configuration is desired
   override def createKafkaConfig: EmbeddedKafkaConfig =
     EmbeddedKafkaConfig(kafkaPort,
-      zooKeeperPort,
-      Map(
-        "offsets.topic.replication.factor" -> "1",
-        "offsets.retention.minutes" -> "1",
-        "offsets.retention.check.interval.ms" -> "100"
-      ))
+                        zooKeeperPort,
+                        Map(
+                          "offsets.topic.replication.factor" -> "1",
+                          "offsets.retention.minutes" -> "1",
+                          "offsets.retention.check.interval.ms" -> "100"
+                        ))
 
   // ...
 }

--- a/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
@@ -8,7 +8,7 @@ package akka.kafka.scaladsl
 // #testkit
 import akka.kafka.testkit.scaladsl.ScalatestKafkaSpec
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.{Inside, Matchers, WordSpecLike}
 
 abstract class SpecBase(kafkaPort: Int)
     extends ScalatestKafkaSpec(kafkaPort)
@@ -16,4 +16,32 @@ abstract class SpecBase(kafkaPort: Int)
     with Matchers
     with ScalaFutures
     with Eventually
+
 // #testkit
+
+// #embeddedkafka
+import akka.kafka.testkit.scaladsl.EmbeddedKafkaLike
+import net.manub.embeddedkafka.EmbeddedKafkaConfig
+
+class EmbeddedKafkaSampleSpec extends SpecBase(kafkaPort = 1234) with EmbeddedKafkaLike {
+
+  // if a specific Kafka broker configuration is desired
+  override def createKafkaConfig: EmbeddedKafkaConfig =
+    EmbeddedKafkaConfig(kafkaPort,
+      zooKeeperPort,
+      Map(
+        "offsets.topic.replication.factor" -> "1",
+        "offsets.retention.minutes" -> "1",
+        "offsets.retention.check.interval.ms" -> "100"
+      ))
+
+  // ...
+}
+// #embeddedkafka
+// #testcontainers
+import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
+
+class TestcontainersSampleSpec extends SpecBase(kafkaPort = -1) with TestcontainersKafkaLike {
+  // ...
+}
+// #testcontainers

--- a/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
@@ -8,14 +8,17 @@ package akka.kafka.scaladsl
 // #testkit
 import akka.kafka.testkit.scaladsl.ScalatestKafkaSpec
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.{Inside, Matchers, WordSpecLike}
+import org.scalatest.{Matchers, WordSpecLike}
 
 abstract class SpecBase(kafkaPort: Int)
     extends ScalatestKafkaSpec(kafkaPort)
     with WordSpecLike
     with Matchers
     with ScalaFutures
-    with Eventually
+    with Eventually {
+
+  protected def this() = this(kafkaPort = -1)
+}
 
 // #testkit
 
@@ -41,7 +44,7 @@ class EmbeddedKafkaSampleSpec extends SpecBase(kafkaPort = 1234) with EmbeddedKa
 // #testcontainers
 import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
 
-class TestcontainersSampleSpec extends SpecBase(kafkaPort = -1) with TestcontainersKafkaLike {
+class TestcontainersSampleSpec extends SpecBase with TestcontainersKafkaLike {
   // ...
 }
 // #testcontainers

--- a/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
@@ -6,14 +6,13 @@
 package akka.kafka.scaladsl
 
 // #testkit
-import akka.kafka.testkit.scaladsl.{EmbeddedKafkaLike, ScalatestKafkaSpec}
+import akka.kafka.testkit.scaladsl.ScalatestKafkaSpec
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{Matchers, WordSpecLike}
 
 abstract class SpecBase(kafkaPort: Int)
     extends ScalatestKafkaSpec(kafkaPort)
     with WordSpecLike
-    with EmbeddedKafkaLike
     with Matchers
     with ScalaFutures
     with Eventually

--- a/tests/src/test/scala/akka/kafka/scaladsl/TimestampSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TimestampSpec.scala
@@ -8,7 +8,6 @@ package akka.kafka.scaladsl
 import akka.kafka.{KafkaPorts, Subscriptions}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSink
-import net.manub.embeddedkafka.EmbeddedKafkaConfig
 import org.apache.kafka.common.TopicPartition
 import org.scalatest.Inside
 
@@ -16,24 +15,17 @@ import scala.collection.JavaConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class TimestampSpec extends SpecBase(kafkaPort = KafkaPorts.TimestampSpec) with Inside {
+class TimestampSpec extends SpecBase(KafkaPorts.DockerKafkaPort) with Inside {
+
+  override val bootstrapServers: String = KafkaPorts.DockerKafkaBootstrapServers
 
   implicit val patience = PatienceConfig(5.second, 100.millis)
-
-  def createKafkaConfig: EmbeddedKafkaConfig =
-    EmbeddedKafkaConfig(kafkaPort,
-                        zooKeeperPort,
-                        Map(
-                          "offsets.topic.replication.factor" -> "1"
-                        ))
 
   "Kafka connector" must {
     "begin consuming from the given timestamp of the topic" in {
       assertAllStagesStopped {
-        val topic = createTopicName(1)
+        val topic = createCleanTopic(1)
         val group = createGroupId(1)
-
-        givenInitializedTopic(topic)
 
         val now = System.currentTimeMillis()
         Await.result(produceTimestamped(topic, (1 to 100).zip(now to (now + 100))), remainingOrDefault)
@@ -47,7 +39,6 @@ class TimestampSpec extends SpecBase(kafkaPort = KafkaPorts.TimestampSpec) with 
 
         val probe = Consumer
           .plainSource(consumerSettings, topicsAndTs)
-          .filterNot(_.value == InitialMsg)
           .map(_.value())
           .runWith(TestSink.probe)
 
@@ -61,10 +52,8 @@ class TimestampSpec extends SpecBase(kafkaPort = KafkaPorts.TimestampSpec) with 
 
     "handle topic that has no messages by timestamp" in {
       assertAllStagesStopped {
-        val topic = createTopicName(1)
+        val topic = createCleanTopic(1)
         val group = createGroupId(1)
-
-        givenInitializedTopic(topic)
 
         val now = System.currentTimeMillis()
 

--- a/tests/src/test/scala/akka/kafka/scaladsl/TimestampSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TimestampSpec.scala
@@ -6,7 +6,7 @@
 package akka.kafka.scaladsl
 
 import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
-import akka.kafka.{KafkaPorts, Subscriptions}
+import akka.kafka.Subscriptions
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSink
 import org.apache.kafka.common.TopicPartition
@@ -16,14 +16,14 @@ import scala.collection.JavaConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class TimestampSpec extends SpecBase(KafkaPorts.DockerKafkaPort) with TestcontainersKafkaLike with Inside {
+class TimestampSpec extends SpecBase with TestcontainersKafkaLike with Inside {
 
   implicit val patience = PatienceConfig(5.second, 100.millis)
 
   "Kafka connector" must {
     "begin consuming from the given timestamp of the topic" in {
       assertAllStagesStopped {
-        val topic = createCleanTopic(1)
+        val topic = createTopic(1)
         val group = createGroupId(1)
 
         val now = System.currentTimeMillis()
@@ -51,7 +51,7 @@ class TimestampSpec extends SpecBase(KafkaPorts.DockerKafkaPort) with Testcontai
 
     "handle topic that has no messages by timestamp" in {
       assertAllStagesStopped {
-        val topic = createCleanTopic(1)
+        val topic = createTopic(1)
         val group = createGroupId(1)
 
         val now = System.currentTimeMillis()

--- a/tests/src/test/scala/akka/kafka/scaladsl/TimestampSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TimestampSpec.scala
@@ -5,6 +5,7 @@
 
 package akka.kafka.scaladsl
 
+import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
 import akka.kafka.{KafkaPorts, Subscriptions}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSink
@@ -15,9 +16,7 @@ import scala.collection.JavaConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class TimestampSpec extends SpecBase(KafkaPorts.DockerKafkaPort) with Inside {
-
-  override val bootstrapServers: String = KafkaPorts.DockerKafkaBootstrapServers
+class TimestampSpec extends SpecBase(KafkaPorts.DockerKafkaPort) with TestcontainersKafkaLike with Inside {
 
   implicit val patience = PatienceConfig(5.second, 100.millis)
 

--- a/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
@@ -12,6 +12,7 @@ import akka.kafka.ConsumerMessage.PartitionOffset
 import akka.kafka.Subscriptions.TopicSubscription
 import akka.kafka.{ProducerMessage, _}
 import akka.kafka.scaladsl.Consumer.Control
+import akka.kafka.testkit.scaladsl.EmbeddedKafkaLike
 import akka.stream.{KillSwitches, UniqueKillSwitch}
 import akka.stream.scaladsl.{Flow, Keep, RestartSource, Sink, Source}
 import akka.stream.testkit.TestSubscriber
@@ -24,9 +25,7 @@ import scala.concurrent.{Await, Future, TimeoutException}
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
-class TransactionsSpec extends SpecBase(KafkaPorts.DockerKafkaPort) {
-
-  override val bootstrapServers: String = KafkaPorts.DockerKafkaBootstrapServers
+class TransactionsSpec extends SpecBase(KafkaPorts.TransactionsSpec) with EmbeddedKafkaLike {
 
   "A consume-transform-produce cycle" must {
 
@@ -297,7 +296,7 @@ class TransactionsSpec extends SpecBase(KafkaPorts.DockerKafkaPort) {
       }
 
       val consumer = valuesSource(probeConsumerSettings(probeConsumerGroup), sinkTopic)
-        .take(elements)
+        .take(elements.toLong)
         .idleTimeout(30.seconds)
         .alsoTo(
           Flow[String].scan(0) { case (count, _) => count + 1 }.filter(_ % 10000 == 0).log("received").to(Sink.ignore)

--- a/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
@@ -31,8 +31,8 @@ class TransactionsSpec extends SpecBase(KafkaPorts.TransactionsSpec) with Embedd
 
     "complete" in {
       assertAllStagesStopped {
-        val sourceTopic = createCleanTopic(1)
-        val sinkTopic = createCleanTopic(2)
+        val sourceTopic = createTopic(1)
+        val sinkTopic = createTopic(2)
         val group = createGroupId(1)
 
         Await.result(produce(sourceTopic, 1 to 100), remainingOrDefault)
@@ -57,8 +57,8 @@ class TransactionsSpec extends SpecBase(KafkaPorts.TransactionsSpec) with Embedd
     }
 
     "complete when messages are filtered out" in assertAllStagesStopped {
-      val sourceTopic = createCleanTopic(1)
-      val sinkTopic = createCleanTopic(2)
+      val sourceTopic = createTopic(1)
+      val sinkTopic = createTopic(2)
       val group = createGroupId(1)
 
       Await.result(produce(sourceTopic, 1 to 100), remainingOrDefault)
@@ -92,8 +92,8 @@ class TransactionsSpec extends SpecBase(KafkaPorts.TransactionsSpec) with Embedd
 
     "complete with transient failure causing an abort with restartable source" in {
       assertAllStagesStopped {
-        val sourceTopic = createCleanTopic(1)
-        val sinkTopic = createCleanTopic(2)
+        val sourceTopic = createTopic(1)
+        val sinkTopic = createTopic(2)
         val group = createGroupId(1)
 
         Await.result(produce(sourceTopic, 1 to 1000), remainingOrDefault)
@@ -145,8 +145,8 @@ class TransactionsSpec extends SpecBase(KafkaPorts.TransactionsSpec) with Embedd
     }
 
     "complete with messages filtered out and transient failure causing an abort with restartable source" in assertAllStagesStopped {
-      val sourceTopic = createCleanTopic(1)
-      val sinkTopic = createCleanTopic(2)
+      val sourceTopic = createTopic(1)
+      val sinkTopic = createTopic(2)
       val group = createGroupId(1)
 
       Await.result(produce(sourceTopic, 1 to 100), remainingOrDefault)
@@ -202,8 +202,8 @@ class TransactionsSpec extends SpecBase(KafkaPorts.TransactionsSpec) with Embedd
     }
 
     "provide consistency when using multiple transactional streams" in {
-      val sourceTopic = createCleanTopic(1)
-      val sinkTopic = createCleanTopic(2, partitions = 4)
+      val sourceTopic = createTopic(1)
+      val sinkTopic = createTopic(2, partitions = 4)
       val group = createGroupId(1)
 
       val elements = 50
@@ -242,8 +242,8 @@ class TransactionsSpec extends SpecBase(KafkaPorts.TransactionsSpec) with Embedd
       val destinationPartitions = 4
       val consumers = 3
 
-      val sourceTopic = createCleanTopic(1, sourcePartitions)
-      val sinkTopic = createCleanTopic(2, destinationPartitions)
+      val sourceTopic = createTopic(1, sourcePartitions)
+      val sinkTopic = createTopic(2, destinationPartitions)
       val group = createGroupId(1)
 
       val elements = 300 * 1000

--- a/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala
@@ -7,6 +7,7 @@ package docs.scaladsl
 
 import akka.Done
 import akka.kafka.scaladsl.{Consumer, Producer, SpecBase}
+import akka.kafka.testkit.scaladsl.EmbeddedKafkaLike
 import akka.kafka.{KafkaPorts, Subscriptions}
 import akka.stream.scaladsl.{Sink, Source}
 // #testkit
@@ -21,7 +22,7 @@ import scala.concurrent.duration._
 
 // #testkit
 
-class AssignmentSpec extends SpecBase(kafkaPort = KafkaPorts.AssignmentSpec) {
+class AssignmentSpec extends SpecBase(kafkaPort = KafkaPorts.AssignmentSpec) with EmbeddedKafkaLike {
 
   implicit val patience = PatienceConfig(15.seconds, 1.second)
 

--- a/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala
@@ -10,29 +10,16 @@ import akka.kafka.scaladsl.{Consumer, Producer, SpecBase}
 import akka.kafka.testkit.scaladsl.EmbeddedKafkaLike
 import akka.kafka.{KafkaPorts, Subscriptions}
 import akka.stream.scaladsl.{Sink, Source}
-// #testkit
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
-import net.manub.embeddedkafka.EmbeddedKafkaConfig
-// #testkit
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 
 import scala.collection.immutable
 import scala.concurrent.duration._
 
-// #testkit
-
 class AssignmentSpec extends SpecBase(kafkaPort = KafkaPorts.AssignmentSpec) with EmbeddedKafkaLike {
 
   implicit val patience = PatienceConfig(15.seconds, 1.second)
-
-  def createKafkaConfig: EmbeddedKafkaConfig =
-    EmbeddedKafkaConfig(kafkaPort,
-                        zooKeeperPort,
-                        Map(
-                          "offsets.topic.replication.factor" -> "1"
-                        ))
-  // #testkit
 
   "subscription with partition assignment" must {
 

--- a/tests/src/test/scala/docs/scaladsl/AtLeastOnce.scala
+++ b/tests/src/test/scala/docs/scaladsl/AtLeastOnce.scala
@@ -12,6 +12,7 @@ import akka.kafka.ProducerMessage.Envelope
 import akka.kafka.scaladsl.Consumer.DrainingControl
 import akka.kafka.{KafkaPorts, ProducerMessage, Subscriptions}
 import akka.kafka.scaladsl.{Committer, Consumer, Producer}
+import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
 import akka.stream.scaladsl.{Keep, Sink}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import org.apache.kafka.clients.producer.ProducerRecord
@@ -22,9 +23,7 @@ import scala.concurrent.duration._
 
 // #oneToMany
 
-class AtLeastOnce extends DocsSpecBase(KafkaPorts.DockerKafkaPort) {
-
-  override val bootstrapServers: String = KafkaPorts.DockerKafkaBootstrapServers
+class AtLeastOnce extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with TestcontainersKafkaLike {
 
   override def sleepAfterProduce: FiniteDuration = 10.seconds
 

--- a/tests/src/test/scala/docs/scaladsl/AtLeastOnce.scala
+++ b/tests/src/test/scala/docs/scaladsl/AtLeastOnce.scala
@@ -10,7 +10,7 @@ import akka.Done
 import akka.kafka.ConsumerMessage.CommittableOffset
 import akka.kafka.ProducerMessage.Envelope
 import akka.kafka.scaladsl.Consumer.DrainingControl
-import akka.kafka.{KafkaPorts, ProducerMessage, Subscriptions}
+import akka.kafka.{ProducerMessage, Subscriptions}
 import akka.kafka.scaladsl.{Committer, Consumer, Producer}
 import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
 import akka.stream.scaladsl.{Keep, Sink}
@@ -23,15 +23,15 @@ import scala.concurrent.duration._
 
 // #oneToMany
 
-class AtLeastOnce extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with TestcontainersKafkaLike {
+class AtLeastOnce extends DocsSpecBase with TestcontainersKafkaLike {
 
   override def sleepAfterProduce: FiniteDuration = 10.seconds
 
   "Connect a Consumer to Producer" should "map messages one-to-many, and commit in batches" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
-    val topic1 = createCleanTopic(1)
-    val topic2 = createCleanTopic(2)
-    val topic3 = createCleanTopic(3)
+    val topic1 = createTopic(1)
+    val topic2 = createTopic(2)
+    val topic3 = createTopic(3)
     val producerSettings = producerDefaults
     val committerSettings = committerDefaults
     val control =
@@ -71,10 +71,10 @@ class AtLeastOnce extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with Testcont
     def ignore(value: String): Boolean = "2" == value
 
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
-    val topic1 = createCleanTopic(1)
-    val topic2 = createCleanTopic(2)
-    val topic3 = createCleanTopic(3)
-    val topic4 = createCleanTopic(4)
+    val topic1 = createTopic(1)
+    val topic2 = createTopic(2)
+    val topic3 = createTopic(3)
+    val topic4 = createTopic(4)
     val producerSettings = producerDefaults
     val committerSettings = committerDefaults
     val control =

--- a/tests/src/test/scala/docs/scaladsl/AtLeastOnce.scala
+++ b/tests/src/test/scala/docs/scaladsl/AtLeastOnce.scala
@@ -14,7 +14,6 @@ import akka.kafka.{KafkaPorts, ProducerMessage, Subscriptions}
 import akka.kafka.scaladsl.{Committer, Consumer, Producer}
 import akka.stream.scaladsl.{Keep, Sink}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
-import net.manub.embeddedkafka.EmbeddedKafkaConfig
 import org.apache.kafka.clients.producer.ProducerRecord
 
 import scala.collection.immutable
@@ -23,16 +22,17 @@ import scala.concurrent.duration._
 
 // #oneToMany
 
-class AtLeastOnce extends DocsSpecBase(KafkaPorts.ScalaAtLeastOnceExamples) {
+class AtLeastOnce extends DocsSpecBase(KafkaPorts.DockerKafkaPort) {
 
-  def createKafkaConfig: EmbeddedKafkaConfig =
-    EmbeddedKafkaConfig(kafkaPort, zooKeeperPort)
+  override val bootstrapServers: String = KafkaPorts.DockerKafkaBootstrapServers
 
   override def sleepAfterProduce: FiniteDuration = 10.seconds
 
   "Connect a Consumer to Producer" should "map messages one-to-many, and commit in batches" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
-    val immutable.Seq(topic1, topic2, topic3) = createTopics(1, 2, 3)
+    val topic1 = createCleanTopic(1)
+    val topic2 = createCleanTopic(2)
+    val topic3 = createCleanTopic(3)
     val producerSettings = producerDefaults
     val committerSettings = committerDefaults
     val control =
@@ -72,7 +72,10 @@ class AtLeastOnce extends DocsSpecBase(KafkaPorts.ScalaAtLeastOnceExamples) {
     def ignore(value: String): Boolean = "2" == value
 
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
-    val immutable.Seq(topic1, topic2, topic3, topic4) = createTopics(1, 2, 3, 4)
+    val topic1 = createCleanTopic(1)
+    val topic2 = createCleanTopic(2)
+    val topic3 = createCleanTopic(3)
+    val topic4 = createCleanTopic(4)
     val producerSettings = producerDefaults
     val committerSettings = committerDefaults
     val control =

--- a/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
@@ -32,13 +32,13 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 
 // Consume messages and store a representation, including offset, in DB
-class ConsumerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with TestcontainersKafkaLike {
+class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
 
   override def sleepAfterProduce: FiniteDuration = 4.seconds
   private def waitBeforeValidation(): Unit = sleep(4.seconds)
 
   "ExternalOffsetStorage" should "work" in assertAllStagesStopped {
-    val topic = createCleanTopic()
+    val topic = createTopic()
     val consumerSettings = consumerDefaults.withClientId("externalOffsetStorage")
     // format: off
     // #plainSource
@@ -112,7 +112,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with Test
 
   "Consume messages at-most-once" should "work" in assertAllStagesStopped {
     val consumerSettings = createSettings().withGroupId(createGroupId())
-    val topic = createCleanTopic()
+    val topic = createTopic()
     val totalMessages = 10
     val lastMessage = Promise[Done]
 
@@ -146,7 +146,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with Test
 
   "Consume messages at-least-once" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
-    val topic = createCleanTopic()
+    val topic = createTopic()
     // #atLeastOnce
     val control =
       Consumer
@@ -173,7 +173,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with Test
 
   "Consume messages at-least-once, and commit in batches" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
-    val topic = createCleanTopic()
+    val topic = createTopic()
     // #commitWithMetadata
     def metadataFromRecord(record: ConsumerRecord[String, String]): String =
       record.timestamp().toString
@@ -195,7 +195,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with Test
 
   "Consume messages at-least-once, and commit with a committer sink" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
-    val topic = createCleanTopic()
+    val topic = createTopic()
     // #committerSink
     val committerSettings = CommitterSettings(system)
 
@@ -216,9 +216,9 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with Test
 
   "Connect a Consumer to Producer" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
-    val topic1 = createCleanTopic(1)
-    val topic2 = createCleanTopic(2)
-    val targetTopic = createCleanTopic(3)
+    val topic1 = createTopic(1)
+    val topic2 = createTopic(2)
+    val targetTopic = createTopic(3)
     val producerSettings = producerDefaults
     //format: off
     // #consumerToProducerSink
@@ -251,8 +251,8 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with Test
 
   "Connect a Consumer to Producer" should "support flows" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
-    val topic = createCleanTopic(1)
-    val targetTopic = createCleanTopic(2)
+    val topic = createTopic(1)
+    val targetTopic = createTopic(2)
     val producerSettings = producerDefaults
     val committerSettings = committerDefaults
     // #consumerToProducerFlow
@@ -284,7 +284,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with Test
 
   "Backpressure per partition with batch commit" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId()).withStopTimeout(10.millis)
-    val topic = createCleanTopic()
+    val topic = createTopic()
     val maxPartitions = 100
     // #committablePartitionedSource
     val control = Consumer
@@ -303,7 +303,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with Test
   "Flow per partition" should "Process each assigned partition separately" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId()).withStopTimeout(10.millis)
     val comitterSettings = committerDefaults
-    val topic = createCleanTopic()
+    val topic = createTopic()
     val maxPartitions = 100
     // #committablePartitionedSource-stream-per-partition
     val control = Consumer
@@ -325,7 +325,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with Test
 
   "Rebalance Listener" should "get messages" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
-    val topic = createCleanTopic()
+    val topic = createTopic()
     val assignedPromise = Promise[Done]
     val revokedPromise = Promise[Done]
     // format: off
@@ -373,7 +373,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with Test
 
   "Shutdown via Consumer.Control" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
-    val topic = createCleanTopic()
+    val topic = createTopic()
     val offset = 123456L
     // #shutdownPlainSource
     val (consumerControl, streamComplete) =
@@ -393,7 +393,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with Test
 
   "Shutdown when batching commits" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
-    val topic = createCleanTopic()
+    val topic = createTopic()
     val committerSettings = committerDefaults
     // #shutdownCommittableSource
     val drainingControl =
@@ -413,7 +413,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with Test
 
   "Restarting Stream" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
-    val topic = createCleanTopic()
+    val topic = createTopic()
     //#restartSource
     val control = new AtomicReference[Consumer.Control](Consumer.NoopControl)
 
@@ -443,7 +443,7 @@ class ConsumerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with Test
   it should "work with committable source" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val committerSettings = committerDefaults
-    val topic = createCleanTopic()
+    val topic = createTopic()
     val partitionNumber = 0
     val control = new AtomicReference[Consumer.Control](Consumer.NoopControl)
 

--- a/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
@@ -12,6 +12,7 @@ import akka.kafka.ConsumerMessage.{CommittableMessage, CommittableOffsetBatch}
 import akka.kafka._
 import akka.kafka.scaladsl.Consumer.DrainingControl
 import akka.kafka.scaladsl._
+import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
 import akka.stream.{ActorMaterializer, Materializer}
 import akka.stream.scaladsl.{Flow, Keep, RestartSource, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
@@ -31,9 +32,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 
 // Consume messages and store a representation, including offset, in DB
-class ConsumerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) {
-
-  override val bootstrapServers: String = KafkaPorts.DockerKafkaBootstrapServers
+class ConsumerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with TestcontainersKafkaLike {
 
   override def sleepAfterProduce: FiniteDuration = 4.seconds
   private def waitBeforeValidation(): Unit = sleep(4.seconds)

--- a/tests/src/test/scala/docs/scaladsl/DocsSpecBase.scala
+++ b/tests/src/test/scala/docs/scaladsl/DocsSpecBase.scala
@@ -23,6 +23,8 @@ abstract class DocsSpecBase(kafkaPort: Int)
 
   this: Suite ⇒
 
+  protected def this() = this(kafkaPort = -1)
+
   override implicit def patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(Span(5, Seconds)), interval = scaled(Span(15, Millis)))
 

--- a/tests/src/test/scala/docs/scaladsl/DocsSpecBase.scala
+++ b/tests/src/test/scala/docs/scaladsl/DocsSpecBase.scala
@@ -6,7 +6,7 @@
 package docs.scaladsl
 
 import akka.NotUsed
-import akka.kafka.testkit.scaladsl.{EmbeddedKafkaLike, KafkaSpec}
+import akka.kafka.testkit.scaladsl.KafkaSpec
 import akka.kafka.testkit.internal.TestFrameworkInterface
 import akka.stream.scaladsl.Flow
 import org.scalatest.{FlatSpecLike, Matchers, Suite}
@@ -17,7 +17,6 @@ abstract class DocsSpecBase(kafkaPort: Int)
     extends KafkaSpec(kafkaPort)
     with FlatSpecLike
     with TestFrameworkInterface.Scalatest
-    with EmbeddedKafkaLike
     with Matchers
     with ScalaFutures
     with Eventually {

--- a/tests/src/test/scala/docs/scaladsl/FetchMetadata.scala
+++ b/tests/src/test/scala/docs/scaladsl/FetchMetadata.scala
@@ -5,6 +5,7 @@
 
 package docs.scaladsl
 
+import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
 import org.scalatest.TryValues
 import org.scalatest.time.{Seconds, Span}
 
@@ -20,9 +21,7 @@ import scala.concurrent.duration._
 
 // #metadata
 
-class FetchMetadata extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with TryValues {
-
-  override val bootstrapServers: String = KafkaPorts.DockerKafkaBootstrapServers
+class FetchMetadata extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with TestcontainersKafkaLike with TryValues {
 
   override implicit def patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(Span(20, Seconds)), interval = scaled(Span(1, Seconds)))

--- a/tests/src/test/scala/docs/scaladsl/FetchMetadata.scala
+++ b/tests/src/test/scala/docs/scaladsl/FetchMetadata.scala
@@ -7,7 +7,6 @@ package docs.scaladsl
 
 import org.scalatest.TryValues
 import org.scalatest.time.{Seconds, Span}
-import net.manub.embeddedkafka.EmbeddedKafkaConfig
 
 // #metadata
 import akka.actor.ActorRef
@@ -21,17 +20,16 @@ import scala.concurrent.duration._
 
 // #metadata
 
-class FetchMetadata extends DocsSpecBase(KafkaPorts.ScalaFetchMetadataExamples) with TryValues {
+class FetchMetadata extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with TryValues {
+
+  override val bootstrapServers: String = KafkaPorts.DockerKafkaBootstrapServers
 
   override implicit def patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(Span(20, Seconds)), interval = scaled(Span(1, Seconds)))
 
-  def createKafkaConfig: EmbeddedKafkaConfig =
-    EmbeddedKafkaConfig(kafkaPort, zooKeeperPort)
-
   "Consumer metadata" should "be available" in {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
-    val topic = createTopic()
+    val topic = createCleanTopic()
     // #metadata
     val timeout = 5.seconds
     val settings = consumerSettings.withMetadataRequestTimeout(timeout)
@@ -59,7 +57,7 @@ class FetchMetadata extends DocsSpecBase(KafkaPorts.ScalaFetchMetadataExamples) 
     val consumerSettings = consumerDefaults
       .withGroupId(createGroupId())
       .withMetadataRequestTimeout(100.millis)
-    val topic = createTopic()
+    val topic = createCleanTopic()
     implicit val timeout = Timeout(consumerSettings.metadataRequestTimeout * 2)
 
     val consumer: ActorRef = system.actorOf(KafkaConsumerActor.props(consumerSettings))
@@ -78,7 +76,7 @@ class FetchMetadata extends DocsSpecBase(KafkaPorts.ScalaFetchMetadataExamples) 
     val consumerSettings = consumerDefaults
       .withGroupId(createGroupId())
       .withMetadataRequestTimeout(5.seconds)
-    val topic = createTopic()
+    val topic = createCleanTopic()
     implicit val timeout = Timeout(consumerSettings.metadataRequestTimeout * 2)
 
     val consumer: ActorRef = system.actorOf(KafkaConsumerActor.props(consumerSettings))

--- a/tests/src/test/scala/docs/scaladsl/FetchMetadata.scala
+++ b/tests/src/test/scala/docs/scaladsl/FetchMetadata.scala
@@ -11,7 +11,7 @@ import org.scalatest.time.{Seconds, Span}
 
 // #metadata
 import akka.actor.ActorRef
-import akka.kafka.{KafkaConsumerActor, KafkaPorts, Metadata}
+import akka.kafka.{KafkaConsumerActor, Metadata}
 import akka.pattern.ask
 import akka.util.Timeout
 import org.apache.kafka.common.TopicPartition
@@ -21,14 +21,14 @@ import scala.concurrent.duration._
 
 // #metadata
 
-class FetchMetadata extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with TestcontainersKafkaLike with TryValues {
+class FetchMetadata extends DocsSpecBase with TestcontainersKafkaLike with TryValues {
 
   override implicit def patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(Span(20, Seconds)), interval = scaled(Span(1, Seconds)))
 
   "Consumer metadata" should "be available" in {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
-    val topic = createCleanTopic()
+    val topic = createTopic()
     // #metadata
     val timeout = 5.seconds
     val settings = consumerSettings.withMetadataRequestTimeout(timeout)
@@ -56,7 +56,7 @@ class FetchMetadata extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with Testco
     val consumerSettings = consumerDefaults
       .withGroupId(createGroupId())
       .withMetadataRequestTimeout(100.millis)
-    val topic = createCleanTopic()
+    val topic = createTopic()
     implicit val timeout = Timeout(consumerSettings.metadataRequestTimeout * 2)
 
     val consumer: ActorRef = system.actorOf(KafkaConsumerActor.props(consumerSettings))
@@ -75,7 +75,7 @@ class FetchMetadata extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with Testco
     val consumerSettings = consumerDefaults
       .withGroupId(createGroupId())
       .withMetadataRequestTimeout(5.seconds)
-    val topic = createCleanTopic()
+    val topic = createTopic()
     implicit val timeout = Timeout(consumerSettings.metadataRequestTimeout * 2)
 
     val consumer: ActorRef = system.actorOf(KafkaConsumerActor.props(consumerSettings))

--- a/tests/src/test/scala/docs/scaladsl/PartitionExamples.scala
+++ b/tests/src/test/scala/docs/scaladsl/PartitionExamples.scala
@@ -7,6 +7,7 @@ package docs.scaladsl
 
 import akka.actor.ActorRef
 import akka.kafka.scaladsl.Consumer
+import akka.kafka.testkit.scaladsl.EmbeddedKafkaLike
 import akka.kafka.{KafkaConsumerActor, KafkaPorts, Subscriptions}
 import akka.stream.scaladsl.{Keep, Sink}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
@@ -16,7 +17,7 @@ import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
-class PartitionExamples extends DocsSpecBase(KafkaPorts.ScalaPartitionExamples) {
+class PartitionExamples extends DocsSpecBase(KafkaPorts.ScalaPartitionExamples) with EmbeddedKafkaLike {
 
   def createKafkaConfig: EmbeddedKafkaConfig =
     EmbeddedKafkaConfig(kafkaPort,

--- a/tests/src/test/scala/docs/scaladsl/PartitionExamples.scala
+++ b/tests/src/test/scala/docs/scaladsl/PartitionExamples.scala
@@ -19,7 +19,7 @@ import scala.concurrent.duration._
 
 class PartitionExamples extends DocsSpecBase(KafkaPorts.ScalaPartitionExamples) with EmbeddedKafkaLike {
 
-  def createKafkaConfig: EmbeddedKafkaConfig =
+  override def createKafkaConfig: EmbeddedKafkaConfig =
     EmbeddedKafkaConfig(kafkaPort,
                         zooKeeperPort,
                         Map(

--- a/tests/src/test/scala/docs/scaladsl/ProducerExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/ProducerExample.scala
@@ -15,13 +15,12 @@ import org.apache.kafka.common.serialization.StringSerializer
 import scala.concurrent.Future
 import akka.Done
 import akka.kafka.ProducerMessage.MultiResultPart
+import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
 
 import scala.concurrent.duration._
 import scala.concurrent.duration.FiniteDuration
 
-class ProducerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) {
-
-  override val bootstrapServers: String = KafkaPorts.DockerKafkaBootstrapServers
+class ProducerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with TestcontainersKafkaLike {
 
   override def sleepAfterProduce: FiniteDuration = 4.seconds
   private def waitBeforeValidation(): Unit = sleep(6.seconds)

--- a/tests/src/test/scala/docs/scaladsl/ProducerExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/ProducerExample.scala
@@ -15,14 +15,13 @@ import org.apache.kafka.common.serialization.StringSerializer
 import scala.concurrent.Future
 import akka.Done
 import akka.kafka.ProducerMessage.MultiResultPart
-import net.manub.embeddedkafka.EmbeddedKafkaConfig
 
 import scala.concurrent.duration._
 import scala.concurrent.duration.FiniteDuration
 
-class ProducerExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamples) {
-  def createKafkaConfig: EmbeddedKafkaConfig =
-    EmbeddedKafkaConfig(kafkaPort, zooKeeperPort)
+class ProducerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) {
+
+  override val bootstrapServers: String = KafkaPorts.DockerKafkaBootstrapServers
 
   override def sleepAfterProduce: FiniteDuration = 4.seconds
   private def waitBeforeValidation(): Unit = sleep(6.seconds)
@@ -35,7 +34,7 @@ class ProducerExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamples)
         .withBootstrapServers(bootstrapServers)
     // #settings
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
-    val topic = createTopic()
+    val topic = createCleanTopic()
     // #plainSink
     val done: Future[Done] =
       Source(1 to 100)
@@ -57,7 +56,7 @@ class ProducerExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamples)
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val producerSettings = producerDefaults
     val kafkaProducer = producerSettings.createKafkaProducer()
-    val topic = createTopic()
+    val topic = createCleanTopic()
     // #plainSinkWithProducer
     val done = Source(1 to 100)
       .map(_.toString)
@@ -146,7 +145,7 @@ class ProducerExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamples)
 
   "flexiFlow" should "work" in assertAllStagesStopped {
     val producerSettings = producerDefaults
-    val topic = createTopic()
+    val topic = createCleanTopic()
     def println(s: String): Unit = {}
     // format:off
     // #flow

--- a/tests/src/test/scala/docs/scaladsl/ProducerExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/ProducerExample.scala
@@ -5,7 +5,7 @@
 
 package docs.scaladsl
 
-import akka.kafka.{KafkaPorts, ProducerMessage, ProducerSettings, Subscriptions}
+import akka.kafka.{ProducerMessage, ProducerSettings, Subscriptions}
 import akka.kafka.scaladsl.{Consumer, Producer}
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
@@ -20,7 +20,7 @@ import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
 import scala.concurrent.duration._
 import scala.concurrent.duration.FiniteDuration
 
-class ProducerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with TestcontainersKafkaLike {
+class ProducerExample extends DocsSpecBase with TestcontainersKafkaLike {
 
   override def sleepAfterProduce: FiniteDuration = 4.seconds
   private def waitBeforeValidation(): Unit = sleep(6.seconds)
@@ -33,7 +33,7 @@ class ProducerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with Test
         .withBootstrapServers(bootstrapServers)
     // #settings
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
-    val topic = createCleanTopic()
+    val topic = createTopic()
     // #plainSink
     val done: Future[Done] =
       Source(1 to 100)
@@ -55,7 +55,7 @@ class ProducerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with Test
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val producerSettings = producerDefaults
     val kafkaProducer = producerSettings.createKafkaProducer()
-    val topic = createCleanTopic()
+    val topic = createTopic()
     // #plainSinkWithProducer
     val done = Source(1 to 100)
       .map(_.toString)
@@ -144,7 +144,7 @@ class ProducerExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) with Test
 
   "flexiFlow" should "work" in assertAllStagesStopped {
     val producerSettings = producerDefaults
-    val topic = createCleanTopic()
+    val topic = createTopic()
     def println(s: String): Unit = {}
     // format:off
     // #flow

--- a/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicReference
 import akka.Done
 import akka.kafka.scaladsl.Consumer.{Control, DrainingControl}
 import akka.kafka.scaladsl.{Consumer, Transactional}
+import akka.kafka.testkit.scaladsl.EmbeddedKafkaLike
 import akka.kafka.{KafkaPorts, ProducerMessage, Subscriptions}
 import akka.stream.scaladsl.{Keep, RestartSource, Sink}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
@@ -18,9 +19,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class TransactionsExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) {
-
-  override val bootstrapServers: String = KafkaPorts.DockerKafkaBootstrapServers
+class TransactionsExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamples) with EmbeddedKafkaLike {
 
   override def sleepAfterProduce: FiniteDuration = 10.seconds
 
@@ -28,7 +27,7 @@ class TransactionsExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val producerSettings = producerDefaults
     val sourceTopic = createCleanTopic(1)
-    val sinkTopic = createCleanTopic( 2)
+    val sinkTopic = createCleanTopic(2)
     val transactionalId = createTransactionalId()
     // #transactionalSink
     val control =
@@ -63,7 +62,7 @@ class TransactionsExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val producerSettings = producerDefaults
     val sourceTopic = createCleanTopic(1)
-    val sinkTopic = createCleanTopic( 2)
+    val sinkTopic = createCleanTopic(2)
     val transactionalId = createTransactionalId()
     // #transactionalFailureRetry
     val innerControl = new AtomicReference[Control](Consumer.NoopControl)

--- a/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
@@ -13,24 +13,22 @@ import akka.kafka.scaladsl.{Consumer, Transactional}
 import akka.kafka.{KafkaPorts, ProducerMessage, Subscriptions}
 import akka.stream.scaladsl.{Keep, RestartSource, Sink}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
-import net.manub.embeddedkafka.EmbeddedKafkaConfig
 import org.apache.kafka.clients.producer.ProducerRecord
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import scala.collection.immutable
 
-class TransactionsExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamples) {
+class TransactionsExample extends DocsSpecBase(KafkaPorts.DockerKafkaPort) {
 
-  def createKafkaConfig: EmbeddedKafkaConfig =
-    EmbeddedKafkaConfig(kafkaPort, zooKeeperPort)
+  override val bootstrapServers: String = KafkaPorts.DockerKafkaBootstrapServers
 
   override def sleepAfterProduce: FiniteDuration = 10.seconds
 
   "Transactional sink" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val producerSettings = producerDefaults
-    val immutable.Seq(sourceTopic, sinkTopic) = createTopics(1, 2)
+    val sourceTopic = createCleanTopic(1)
+    val sinkTopic = createCleanTopic( 2)
     val transactionalId = createTransactionalId()
     // #transactionalSink
     val control =
@@ -64,7 +62,8 @@ class TransactionsExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamp
   "TransactionsFailureRetryExample" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val producerSettings = producerDefaults
-    val immutable.Seq(sourceTopic, sinkTopic) = createTopics(1, 2)
+    val sourceTopic = createCleanTopic(1)
+    val sinkTopic = createCleanTopic( 2)
     val transactionalId = createTransactionalId()
     // #transactionalFailureRetry
     val innerControl = new AtomicReference[Control](Consumer.NoopControl)

--- a/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
@@ -26,8 +26,8 @@ class TransactionsExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamp
   "Transactional sink" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val producerSettings = producerDefaults
-    val sourceTopic = createCleanTopic(1)
-    val sinkTopic = createCleanTopic(2)
+    val sourceTopic = createTopic(1)
+    val sinkTopic = createTopic(2)
     val transactionalId = createTransactionalId()
     // #transactionalSink
     val control =
@@ -61,8 +61,8 @@ class TransactionsExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamp
   "TransactionsFailureRetryExample" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
     val producerSettings = producerDefaults
-    val sourceTopic = createCleanTopic(1)
-    val sinkTopic = createCleanTopic(2)
+    val sourceTopic = createTopic(1)
+    val sinkTopic = createTopic(2)
     val transactionalId = createTransactionalId()
     // #transactionalFailureRetry
     val innerControl = new AtomicReference[Control](Consumer.NoopControl)


### PR DESCRIPTION
## Purpose

Use external Kafka in Docker started and stopped by [Testcontainers](https://www.testcontainers.org) to run tests with.

## References

Preparation for #540

## Background Context

I don't expect Apache Kafka to use Scala 2.13 very soon, to run our tests with Scala 2.13 the Kafka instance cannot be in the same JVM.