### PR TITLE
Clean up warnings from transactional PR

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
@@ -16,7 +16,7 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.clients.producer.Producer
 import org.apache.kafka.common.TopicPartition
 
-import scala.concurrent.{Future}
+import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration._
 import scala.collection.JavaConverters._
@@ -43,7 +43,7 @@ private object TransactionalProducerStage {
     def empty: TransactionBatch = new EmptyTransactionBatch()
   }
 
-  sealed trait TransactionBatch {
+  private[kafka] sealed trait TransactionBatch {
     def updated(partitionOffset: PartitionOffsetCommittedMarker): TransactionBatch
     def committingFailed(): Unit
   }

--- a/tests/src/test/java/docs/javadsl/AssignmentTest.java
+++ b/tests/src/test/java/docs/javadsl/AssignmentTest.java
@@ -91,8 +91,7 @@ public class AssignmentTest extends EmbeddedKafkaJunit4Test {
             .map(
                 msg ->
                     ProducerMessage.multi(
-                        topics
-                            .stream()
+                        topics.stream()
                             .map(t -> new ProducerRecord<>(t, 0, DefaultKey(), msg.toString()))
                             .collect(Collectors.toList())))
             .via(Producer.flexiFlow(producerDefaults()))

--- a/tests/src/test/java/docs/javadsl/FetchMetadataTest.java
+++ b/tests/src/test/java/docs/javadsl/FetchMetadataTest.java
@@ -68,14 +68,12 @@ public class FetchMetadataTest extends EmbeddedKafkaJunit4Test {
                 responseOptional ->
                     responseOptional.map(
                         map ->
-                            map.entrySet()
-                                .stream()
+                            map.entrySet().stream()
                                 .flatMap(
                                     entry -> {
                                       String topic = entry.getKey();
                                       List<PartitionInfo> partitionInfos = entry.getValue();
-                                      return partitionInfos
-                                          .stream()
+                                      return partitionInfos.stream()
                                           .map(info -> topic + ": " + info.toString());
                                     })
                                 .collect(Collectors.toList())));

--- a/tests/src/test/java/docs/javadsl/ProducerExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/ProducerExampleTest.java
@@ -200,8 +200,7 @@ class ProducerExampleTest extends EmbeddedKafkaTest {
                   } else if (result instanceof ProducerMessage.MultiResult) {
                     ProducerMessage.MultiResult<String, String, Integer> res =
                         (ProducerMessage.MultiResult<String, String, Integer>) result;
-                    return res.getParts()
-                        .stream()
+                    return res.getParts().stream()
                         .map(
                             part -> {
                               RecordMetadata meta = part.metadata();

--- a/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
@@ -31,7 +31,6 @@ import org.mockito.verification.VerificationMode
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 
 import scala.collection.JavaConverters._
-import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success, Try}
@@ -71,7 +70,7 @@ class ProducerSpec(_system: ActorSystem)
                        -1)
 
   def toMessage(tuple: (Record, RecordMetadata)) = Message(tuple._1, NotUsed)
-  def toTxMessage(tuple: (Record, RecordMetadata), committer: CommittedMarker) =
+  private[kafka] def toTxMessage(tuple: (Record, RecordMetadata), committer: CommittedMarker) =
     ProducerMessage.Message(
       tuple._1,
       ConsumerMessage
@@ -598,7 +597,7 @@ class CommittedMarkerMock {
       Future.successful(Done)
   })
 
-  def verifyOffsets(pos: ConsumerMessage.PartitionOffsetCommittedMarker*): Future[Done] =
+  private[kafka] def verifyOffsets(pos: ConsumerMessage.PartitionOffsetCommittedMarker*): Future[Done] =
     Mockito
       .verify(mock, Mockito.only())
       .committed(

--- a/tests/src/test/scala/akka/kafka/scaladsl/MisconfiguredProducerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/MisconfiguredProducerSpec.scala
@@ -32,10 +32,10 @@ class MisconfiguredProducerSpec
     "fail during materialization" in assertAllStagesStopped {
       val producerSettings =
         ProducerSettings(system, new StringSerializer, new StringSerializer)
-        .withBootstrapServers("invalid-bootstrap-server")
+          .withBootstrapServers("invalid-bootstrap-server")
 
       val exception = intercept[org.apache.kafka.common.KafkaException] {
-        val result = Source
+        Source
           .single(new ProducerRecord[String, String]("topic", "key", "value"))
           .runWith(Producer.plainSink(producerSettings))
       }

--- a/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
@@ -381,7 +381,7 @@ class TransactionsSpec extends SpecBase(KafkaPorts.TransactionsSpec) with Embedd
               ProducerMessage.single(new ProducerRecord[String, String](sinkTopic, msg.record.value),
                                      msg.partitionOffset)
             }
-            .take(batchSize)
+            .take(batchSize.toLong)
             .delay(3.seconds, strategy = DelayOverflowStrategy.backpressure)
             .addAttributes(Attributes.inputBuffer(batchSize, batchSize + 1))
             .via(Transactional.flow(producerDefaults, s"$group-$id"))
@@ -398,12 +398,12 @@ class TransactionsSpec extends SpecBase(KafkaPorts.TransactionsSpec) with Embedd
       val probeConsumerGroup = createGroupId(2)
       val probeConsumer = valuesProbeConsumer(probeConsumerSettings(probeConsumerGroup), sinkTopic)
 
-      periodicalCheck("Wait for elements written to Kafka", maxTries = 30, 1.second) {
-        elementsWrote.get
+      periodicalCheck("Wait for elements written to Kafka", maxTries = 30, 1.second) { () =>
+        elementsWrote.get()
       }(_ > 10)
 
       probeConsumer
-        .request(elements)
+        .request(elements.toLong)
         .expectNextUnorderedN((1 to elements).map(_.toString))
 
       probeConsumer.cancel()


### PR DESCRIPTION
## Purpose

#757 introduced some warnings where one indicated bad use of inner classes

## Changes

* remove unused imports
* move inner classes of `TransactionalSource` to a companion object
* mark a few more things explicitly `private[kafka]` to make the compiler happy