### PR TITLE
TransactionalSource: drain only partitions that were revoked

### DIFF
--- a/core/src/main/mima-filters/1.0.x.backwards.excludes
+++ b/core/src/main/mima-filters/1.0.x.backwards.excludes
@@ -1,0 +1,2 @@
+# always exclude changes to the internal APIs
+ProblemFilters.exclude[Problem]("akka.kafka.internal.*")


### PR DESCRIPTION
## Purpose
Currently, we drain all partitions when receiving revoke signal from kafka. It's better to drain only those that were revoked. Especially, given that Kafka sends also the signal with empty partitions list.


