### PR TITLE
Configurable testkit settings when waiting for the desired cluster state

### DIFF
--- a/testkit/src/main/java/akka/kafka/testkit/javadsl/BaseKafkaTest.java
+++ b/testkit/src/main/java/akka/kafka/testkit/javadsl/BaseKafkaTest.java
@@ -11,22 +11,33 @@ import akka.kafka.Subscriptions;
 import akka.kafka.javadsl.Consumer;
 import akka.kafka.javadsl.Producer;
 import akka.kafka.testkit.internal.KafkaTestKitClass;
+import akka.kafka.testkit.internal.KafkaTestKit;
 import akka.stream.Materializer;
 import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
+import org.apache.kafka.clients.admin.ConsumerGroupDescription;
+import org.apache.kafka.clients.admin.DescribeClusterResult;
+import org.apache.kafka.clients.admin.MemberDescription;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.ConsumerGroupState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
+import static scala.compat.java8.FunctionConverters.package$.MODULE$;
+
 public abstract class BaseKafkaTest extends KafkaTestKitClass {
+
+  private static scala.compat.java8.FunctionConverters.package$ functionConverters = MODULE$;
 
   public static final int partition0 = 0;
 
@@ -64,6 +75,54 @@ public abstract class BaseKafkaTest extends KafkaTestKitClass {
         .toMat(Sink.seq(), Keep.both())
         .mapMaterializedValue(Consumer::createDrainingControl)
         .run(materializer);
+  }
+
+  /**
+   * Periodically checks if a given predicate on cluster state holds.
+   *
+   * <p>If the predicate does not hold after configured amount of time, throws an exception.
+   */
+  public void waitUntilCluster(Predicate<DescribeClusterResult> predicate) {
+    KafkaTestKit.waitUntilCluster(
+        settings().clusterTimeout(),
+        settings().checkInterval(),
+        adminClient(),
+        functionConverters.asScalaFromPredicate(predicate),
+        log());
+  }
+
+  /**
+   * Periodically checks if the given predicate on consumer group state holds.
+   *
+   * <p>If the predicate does not hold after configured amount of time, throws an exception.
+   */
+  public void waitUntilConsumerGroup(
+      String groupId, Predicate<ConsumerGroupDescription> predicate) {
+    KafkaTestKit.waitUntilConsumerGroup(
+        groupId,
+        settings().consumerGroupTimeout(),
+        settings().checkInterval(),
+        adminClient(),
+        functionConverters.asScalaFromPredicate(predicate),
+        log());
+  }
+
+  /**
+   * Periodically checks if the given predicate on consumer summary holds.
+   *
+   * <p>If the predicate does not hold after configured amount of time, throws an exception.
+   */
+  public void waitUntilConsumerSummary(
+      String groupId, Predicate<Collection<MemberDescription>> predicate) {
+    waitUntilConsumerGroup(
+        groupId,
+        group -> {
+          try {
+            return group.state() == ConsumerGroupState.STABLE && predicate.test(group.members());
+          } catch (Exception ex) {
+            return false;
+          }
+        });
   }
 
   protected <T> T resultOf(CompletionStage<T> stage) throws Exception {

--- a/testkit/src/main/java/akka/kafka/testkit/javadsl/BaseKafkaTest.java
+++ b/testkit/src/main/java/akka/kafka/testkit/javadsl/BaseKafkaTest.java
@@ -10,6 +10,7 @@ import akka.actor.ActorSystem;
 import akka.kafka.Subscriptions;
 import akka.kafka.javadsl.Consumer;
 import akka.kafka.javadsl.Producer;
+import akka.kafka.testkit.internal.KafkaTestKitChecks;
 import akka.kafka.testkit.internal.KafkaTestKitClass;
 import akka.kafka.testkit.internal.KafkaTestKit;
 import akka.stream.Materializer;
@@ -83,7 +84,7 @@ public abstract class BaseKafkaTest extends KafkaTestKitClass {
    * <p>If the predicate does not hold after configured amount of time, throws an exception.
    */
   public void waitUntilCluster(Predicate<DescribeClusterResult> predicate) {
-    KafkaTestKit.waitUntilCluster(
+    KafkaTestKitChecks.waitUntilCluster(
         settings().clusterTimeout(),
         settings().checkInterval(),
         adminClient(),
@@ -98,7 +99,7 @@ public abstract class BaseKafkaTest extends KafkaTestKitClass {
    */
   public void waitUntilConsumerGroup(
       String groupId, Predicate<ConsumerGroupDescription> predicate) {
-    KafkaTestKit.waitUntilConsumerGroup(
+    KafkaTestKitChecks.waitUntilConsumerGroup(
         groupId,
         settings().consumerGroupTimeout(),
         settings().checkInterval(),

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -1,7 +1,7 @@
 akka.kafka.testkit {
 
   # amount of time to wait until the desired cluster state is reached
-  cluster-timeout = 1 second
+  cluster-timeout = 10 seconds
 
   # amount of time to wait until the desired consumer group state is reached
   consumer-group-timeout = 10 seconds

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -1,3 +1,12 @@
 akka.kafka.testkit {
 
+  # amount of time to wait until the desired cluster state is reached
+  cluster-timeout = 1 second
+
+  # amount of time to wait until the desired consumer group state is reached
+  consumer-group-timeout = 1 second
+
+  # amount of time to wait until the desired consumer state is reached
+  consumer-summary-timeout = 1 second
+
 }

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -4,9 +4,8 @@ akka.kafka.testkit {
   cluster-timeout = 1 second
 
   # amount of time to wait until the desired consumer group state is reached
-  consumer-group-timeout = 1 second
+  consumer-group-timeout = 10 seconds
 
-  # amount of time to wait until the desired consumer state is reached
-  consumer-summary-timeout = 1 second
-
+  # amount of time to wait in-between state checks
+  check-interval = 100 ms
 }

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -1,0 +1,3 @@
+akka.kafka.testkit {
+
+}

--- a/testkit/src/main/scala/akka/kafka/testkit/KafkaTestkitSettings.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/KafkaTestkitSettings.scala
@@ -12,7 +12,7 @@ import scala.concurrent.duration._
 
 class KafkaTestkitSettings private (val clusterTimeout: FiniteDuration,
                                     val consumerGroupTimeout: FiniteDuration,
-                                    val consumerSummaryTimeout: FiniteDuration) {
+                                    val checkInterval: FiniteDuration) {
 
   /**
    * Java Api
@@ -27,7 +27,7 @@ class KafkaTestkitSettings private (val clusterTimeout: FiniteDuration,
   /**
    * Java Api
    */
-  def getConsumerSummaryTimeout(): java.time.Duration = java.time.Duration.ofMillis(consumerSummaryTimeout.toMillis)
+  def getCheckInterval(): java.time.Duration = java.time.Duration.ofMillis(checkInterval.toMillis)
 }
 
 object KafkaTestkitSettings {
@@ -52,9 +52,9 @@ object KafkaTestkitSettings {
   def apply(config: Config): KafkaTestkitSettings = {
     val clusterTimeout = config.getDuration("cluster-timeout").toMillis.millis
     val consumerGroupTimeout = config.getDuration("consumer-group-timeout").toMillis.millis
-    val consumerSummaryTimeout = config.getDuration("consumer-summary-timeout").toMillis.millis
+    val checkInterval = config.getDuration("check-interval").toMillis.millis
 
-    new KafkaTestkitSettings(clusterTimeout, consumerGroupTimeout, consumerSummaryTimeout)
+    new KafkaTestkitSettings(clusterTimeout, consumerGroupTimeout, checkInterval)
   }
 
   /**

--- a/testkit/src/main/scala/akka/kafka/testkit/KafkaTestkitSettings.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/KafkaTestkitSettings.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.testkit
+
+import akka.actor.ActorSystem
+import com.typesafe.config.Config
+
+import scala.concurrent.duration._
+
+class KafkaTestkitSettings private (val clusterTimeout: FiniteDuration,
+                                    val consumerGroupTimeout: FiniteDuration,
+                                    val consumerSummaryTimeout: FiniteDuration) {
+
+  /**
+   * Java Api
+   */
+  def getClusterTimeout(): java.time.Duration = java.time.Duration.ofMillis(clusterTimeout.toMillis)
+
+  /**
+   * Java Api
+   */
+  def getConsumerGroupTimeout(): java.time.Duration = java.time.Duration.ofMillis(consumerGroupTimeout.toMillis)
+
+  /**
+   * Java Api
+   */
+  def getConsumerSummaryTimeout(): java.time.Duration = java.time.Duration.ofMillis(consumerSummaryTimeout.toMillis)
+}
+
+object KafkaTestkitSettings {
+  final val ConfigPath = "akka.kafka.testkit"
+
+  /**
+   * Create testkit settings from ActorSystem settings.
+   */
+  def apply(system: ActorSystem): KafkaTestkitSettings =
+    KafkaTestkitSettings(system.settings.config.getConfig(ConfigPath))
+
+  /**
+   * Java Api
+   *
+   * Create testkit settings from ActorSystem settings.
+   */
+  def create(system: ActorSystem): KafkaTestkitSettings = KafkaTestkitSettings(system)
+
+  /**
+   * Create testkit settings from a Config.
+   */
+  def apply(config: Config): KafkaTestkitSettings = {
+    val clusterTimeout = config.getDuration("cluster-timeout").toMillis.millis
+    val consumerGroupTimeout = config.getDuration("consumer-group-timeout").toMillis.millis
+    val consumerSummaryTimeout = config.getDuration("consumer-summary-timeout").toMillis.millis
+
+    new KafkaTestkitSettings(clusterTimeout, consumerGroupTimeout, consumerSummaryTimeout)
+  }
+
+  /**
+   * Java Api
+   *
+   * Create testkit settings from a Config.
+   */
+  def create(config: Config): KafkaTestkitSettings = KafkaTestkitSettings(config)
+}

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
@@ -11,6 +11,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.{Arrays, Properties}
 
 import akka.actor.ActorSystem
+import akka.kafka.testkit.KafkaTestkitSettings
 import akka.kafka.{CommitterSettings, ConsumerSettings, ProducerSettings}
 import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
 import org.apache.kafka.clients.consumer.ConsumerConfig
@@ -74,6 +75,8 @@ trait KafkaTestKit {
 
   def system: ActorSystem
   def bootstrapServers: String
+
+  val settings = KafkaTestkitSettings(system)
 
   private lazy val adminDefaults = {
     val config = new Properties()

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
@@ -8,29 +8,15 @@ package akka.kafka.testkit.internal
 import java.util
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
-import java.util.{Arrays, Collections, Properties}
+import java.util.{Arrays, Properties}
 
 import akka.actor.ActorSystem
 import akka.kafka.testkit.KafkaTestkitSettings
 import akka.kafka.{CommitterSettings, ConsumerSettings, ProducerSettings}
-import org.apache.kafka.clients.admin.{
-  AdminClient,
-  AdminClientConfig,
-  ConsumerGroupDescription,
-  DescribeClusterResult,
-  DescribeConsumerGroupsOptions,
-  MemberDescription,
-  NewTopic
-}
+import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
 import org.apache.kafka.clients.consumer.ConsumerConfig
-import org.apache.kafka.common.ConsumerGroupState
 import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
 import org.slf4j.Logger
-
-import scala.annotation.tailrec
-import scala.collection.JavaConverters._
-import scala.concurrent.duration.{Duration, FiniteDuration}
-import scala.util.{Failure, Success, Try}
 
 /**
  * Common functions for scaladsl and javadsl Testkit.
@@ -183,57 +169,4 @@ object KafkaTestKitClass {
   def createReplicationFactorBrokerProps(replicationFactor: Int): Map[String, String] = Map(
     "offsets.topic.replication.factor" -> s"$replicationFactor"
   )
-}
-
-object KafkaTestKit {
-  def waitUntilCluster(timeout: FiniteDuration,
-                       sleepInBetween: FiniteDuration,
-                       adminClient: AdminClient,
-                       predicate: DescribeClusterResult => Boolean,
-                       log: Logger): Unit =
-    periodicalCheck("cluster state", timeout, sleepInBetween)(() => adminClient.describeCluster())(predicate)(log)
-
-  def waitUntilConsumerGroup(groupId: String,
-                             timeout: FiniteDuration,
-                             sleepInBetween: FiniteDuration,
-                             adminClient: AdminClient,
-                             predicate: ConsumerGroupDescription => Boolean,
-                             log: Logger): Unit =
-    periodicalCheck("consumer group state", timeout, sleepInBetween)(
-      () =>
-        adminClient
-          .describeConsumerGroups(
-            Collections.singleton(groupId),
-            new DescribeConsumerGroupsOptions().timeoutMs(timeout.toMillis.toInt)
-          )
-          .describedGroups()
-          .get(groupId)
-          .get(timeout.toMillis, TimeUnit.MILLISECONDS)
-    )(predicate)(log)
-
-  def periodicalCheck[T](description: String, timeout: FiniteDuration, sleepInBetween: FiniteDuration)(
-      data: () => T
-  )(predicate: T => Boolean)(log: Logger): Unit = {
-    val maxTries = (timeout / sleepInBetween).toInt
-
-    @tailrec def check(triesLeft: Int): Unit =
-      Try(predicate(data())).recover {
-        case ex =>
-          log.debug(s"Ignoring [${ex.getClass.getName}: ${ex.getMessage}] while waiting for desired state")
-          false
-      } match {
-        case Success(false) if triesLeft > 0 =>
-          Thread.sleep(sleepInBetween.toMillis)
-          check(triesLeft - 1)
-        case Success(false) =>
-          throw new Error(
-            s"Timeout while waiting for desired $description. Tried [$maxTries] times, slept [$sleepInBetween] in between."
-          )
-        case Failure(ex) =>
-          throw ex
-        case Success(true) => // predicate has been fulfilled, stop checking
-      }
-
-    check(maxTries)
-  }
 }

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
@@ -17,6 +17,11 @@ import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.{StringDeserializer, StringSerializer}
 import org.slf4j.Logger
 
+/**
+ * Common functions for scaladsl and javadsl Testkit.
+ *
+ * Mixed-in in both, scaladsl and javadsl classes, therefore API should be usable from both - Scala and Java.
+ */
 trait KafkaTestKit {
 
   def log: Logger
@@ -40,13 +45,32 @@ trait KafkaTestKit {
 
   def committerDefaults: CommitterSettings = committerDefaultsInstance
 
-  def nextNumber(): Int = KafkaTestKitClass.topicCounter.incrementAndGet()
+  private def nextNumber(): Int = KafkaTestKitClass.topicCounter.incrementAndGet()
 
-  def createTopicName(number: Int) = s"topic-$number-${nextNumber}"
+  /**
+   * Return a unique topic name.
+   */
+  def createTopicName(suffix: Int): String = s"topic-$suffix-$nextNumber"
 
-  def createGroupId(number: Int = 0) = s"group-$number-${nextNumber}"
+  /**
+   * Return a unique group id with a default suffix.
+   */
+  def createGroupId(): String = createGroupId(0)
 
-  def createTransactionalId(number: Int = 0) = s"transactionalId-$number-${nextNumber}"
+  /**
+   * Return a unique group id with a given suffix.
+   */
+  def createGroupId(suffix: Int): String = s"group-$suffix-$nextNumber"
+
+  /**
+   * Return a unique transactional id with a default suffix.
+   */
+  def createTransactionalId(): String = createTransactionalId(0)
+
+  /**
+   * Return a unique transactional id with a given suffix.
+   */
+  def createTransactionalId(suffix: Int): String = s"transactionalId-$suffix-$nextNumber"
 
   def system: ActorSystem
   def bootstrapServers: String
@@ -59,6 +83,9 @@ trait KafkaTestKit {
 
   private var adminClientVar: AdminClient = _
 
+  /**
+   * Access to the Kafka AdminClient which life
+   */
   def adminClient: AdminClient = {
     assert(adminClientVar != null,
            "admin client not created, be sure to call setupAdminClient() and cleanupAdminClient()")
@@ -85,12 +112,33 @@ trait KafkaTestKit {
     }
 
   /**
-   * Create a topic with given partition number and replication factor.
+   * Create a topic with a default suffix, single partition and a replication factor of one.
    *
    * This method will block and return only when the topic has been successfully created.
    */
-  def createTopic(number: Int = 0, partitions: Int = 1, replication: Int = 1): String = {
-    val topicName = createTopicName(number)
+  def createTopic(): String = createTopic(0, 1, 1)
+
+  /**
+   * Create a topic with a given suffix, single partitions and a replication factor of one.
+   *
+   * This method will block and return only when the topic has been successfully created.
+   */
+  def createTopic(suffix: Int): String = createTopic(suffix, 1, 1)
+
+  /**
+   * Create a topic with a given suffix, partition number and a replication factor of one.
+   *
+   * This method will block and return only when the topic has been successfully created.
+   */
+  def createTopic(suffix: Int, partitions: Int): String = createTopic(suffix, partitions, 1)
+
+  /**
+   * Create a topic with given suffix, partition number and replication factor.
+   *
+   * This method will block and return only when the topic has been successfully created.
+   */
+  def createTopic(suffix: Int, partitions: Int, replication: Int): String = {
+    val topicName = createTopicName(suffix)
     val configs = new util.HashMap[String, String]()
     val createResult = adminClient.createTopics(
       Arrays.asList(new NewTopic(topicName, partitions, replication.toShort).configs(configs))

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKitChecks.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKitChecks.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.testkit.internal
+
+import java.util.Collections
+import java.util.concurrent.TimeUnit
+
+import org.apache.kafka.clients.admin.{
+  AdminClient,
+  ConsumerGroupDescription,
+  DescribeClusterResult,
+  DescribeConsumerGroupsOptions
+}
+import org.slf4j.Logger
+
+import scala.annotation.tailrec
+import scala.concurrent.duration.FiniteDuration
+import scala.util.{Failure, Success, Try}
+
+object KafkaTestKitChecks {
+  def waitUntilCluster(timeout: FiniteDuration,
+                       sleepInBetween: FiniteDuration,
+                       adminClient: AdminClient,
+                       predicate: DescribeClusterResult => Boolean,
+                       log: Logger): Unit =
+    periodicalCheck("cluster state", timeout, sleepInBetween)(() => adminClient.describeCluster())(predicate)(log)
+
+  def waitUntilConsumerGroup(groupId: String,
+                             timeout: FiniteDuration,
+                             sleepInBetween: FiniteDuration,
+                             adminClient: AdminClient,
+                             predicate: ConsumerGroupDescription => Boolean,
+                             log: Logger): Unit =
+    periodicalCheck("consumer group state", timeout, sleepInBetween)(
+      () =>
+        adminClient
+          .describeConsumerGroups(
+            Collections.singleton(groupId),
+            new DescribeConsumerGroupsOptions().timeoutMs(timeout.toMillis.toInt)
+          )
+          .describedGroups()
+          .get(groupId)
+          .get(timeout.toMillis, TimeUnit.MILLISECONDS)
+    )(predicate)(log)
+
+  def periodicalCheck[T](description: String, timeout: FiniteDuration, sleepInBetween: FiniteDuration)(
+      data: () => T
+  )(predicate: T => Boolean)(log: Logger): Unit = {
+    val maxTries = (timeout / sleepInBetween).toInt
+
+    @tailrec def check(triesLeft: Int): Unit =
+      Try(predicate(data())).recover {
+        case ex =>
+          log.debug(s"Ignoring [${ex.getClass.getName}: ${ex.getMessage}] while waiting for desired state")
+          false
+      } match {
+        case Success(false) if triesLeft > 0 =>
+          Thread.sleep(sleepInBetween.toMillis)
+          check(triesLeft - 1)
+        case Success(false) =>
+          throw new Error(
+            s"Timeout while waiting for desired $description. Tried [$maxTries] times, slept [$sleepInBetween] in between."
+          )
+        case Failure(ex) =>
+          throw ex
+        case Success(true) => // predicate has been fulfilled, stop checking
+      }
+
+    check(maxTries)
+  }
+}

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
@@ -72,9 +72,6 @@ abstract class KafkaSpec(_kafkaPort: Int, val zooKeeperPort: Int, actorSystem: A
 
   var testProducer: KProducer[String, String] = _
 
-  val InitialMsg =
-    "initial msg in topic, required to create the topic before any consumer subscribes to it"
-
   def setUp(): Unit = {
     testProducer = producerDefaults.createKafkaProducer()
     setUpAdminClient()
@@ -105,9 +102,6 @@ abstract class KafkaSpec(_kafkaPort: Int, val zooKeeperPort: Int, actorSystem: A
   }
 
   val partition0 = 0
-
-  def givenInitializedTopic(topic: String): Unit =
-    testProducer.send(new ProducerRecord(topic, partition0, DefaultKey, InitialMsg))
 
   /**
    * Periodically checks if a given predicate on cluster state holds.
@@ -256,7 +250,6 @@ abstract class KafkaSpec(_kafkaPort: Int, val zooKeeperPort: Int, actorSystem: A
                   topic: String*): (Control, TestSubscriber.Probe[String]) =
     Consumer
       .plainSource(consumerSettings, Subscriptions.topics(topic.toSet))
-      .filterNot(_.value == InitialMsg)
       .map(_.value)
       .toMat(TestSink.probe)(Keep.both)
       .run()

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
@@ -158,7 +158,7 @@ abstract class KafkaSpec(_kafkaPort: Int, val zooKeeperPort: Int, actorSystem: A
       Try(predicate(group.members().asScala.toList)).getOrElse(false)
     }
 
-  def periodicalCheck[T](description: String, maxTries: Int = 10, sleepInBetween: FiniteDuration = 100.millis)(
+  def periodicalCheck[T](description: String, maxTries: Int = 50, sleepInBetween: FiniteDuration = 100.millis)(
       data: () => T
   )(predicate: T => Boolean): Unit = {
     @tailrec def check(triesLeft: Int): Unit =

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
@@ -14,7 +14,7 @@ import akka.event.LoggingAdapter
 import akka.kafka._
 import akka.kafka.scaladsl.Consumer.Control
 import akka.kafka.scaladsl.{Consumer, Producer}
-import akka.kafka.testkit.internal.KafkaTestKit
+import akka.kafka.testkit.internal.{KafkaTestKit, KafkaTestKitChecks}
 import akka.stream.scaladsl.{Keep, Source}
 import akka.stream.testkit.TestSubscriber
 import akka.stream.testkit.scaladsl.TestSink
@@ -108,7 +108,8 @@ abstract class KafkaSpec(_kafkaPort: Int, val zooKeeperPort: Int, actorSystem: A
    */
   def waitUntilCluster()(
       predicate: DescribeClusterResult => Boolean
-  ): Unit = KafkaTestKit.waitUntilCluster(settings.clusterTimeout, settings.checkInterval, adminClient, predicate, log)
+  ): Unit =
+    KafkaTestKitChecks.waitUntilCluster(settings.clusterTimeout, settings.checkInterval, adminClient, predicate, log)
 
   /**
    * Periodically checks if the given predicate on consumer group state holds.
@@ -116,12 +117,12 @@ abstract class KafkaSpec(_kafkaPort: Int, val zooKeeperPort: Int, actorSystem: A
    * If the predicate does not hold after configured amount of time, throws an exception.
    */
   def waitUntilConsumerGroup(groupId: String)(predicate: ConsumerGroupDescription => Boolean): Unit =
-    KafkaTestKit.waitUntilConsumerGroup(groupId,
-                                        settings.consumerGroupTimeout,
-                                        settings.checkInterval,
-                                        adminClient,
-                                        predicate,
-                                        log)
+    KafkaTestKitChecks.waitUntilConsumerGroup(groupId,
+                                              settings.consumerGroupTimeout,
+                                              settings.checkInterval,
+                                              adminClient,
+                                              predicate,
+                                              log)
 
   /**
    * Periodically checks if the given predicate on consumer summary holds.
@@ -150,7 +151,7 @@ abstract class KafkaSpec(_kafkaPort: Int, val zooKeeperPort: Int, actorSystem: A
   def periodicalCheck[T](description: String, maxTries: Int, sleepInBetween: FiniteDuration)(
       data: () => T
   )(predicate: T => Boolean) =
-    KafkaTestKit.periodicalCheck(description, maxTries * sleepInBetween, sleepInBetween)(data)(predicate)(log)
+    KafkaTestKitChecks.periodicalCheck(description, maxTries * sleepInBetween, sleepInBetween)(data)(predicate)(log)
 
   /**
    * Produce messages to topic using specified range and return

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
@@ -6,7 +6,6 @@
 package akka.kafka.testkit.scaladsl
 
 import java.util
-import java.util.Collections
 import java.util.concurrent.TimeUnit
 
 import akka.Done
@@ -23,16 +22,15 @@ import akka.stream.{ActorMaterializer, Materializer}
 import akka.testkit.TestKit
 import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 import org.apache.kafka.clients.admin._
-import org.apache.kafka.clients.producer.{Producer => KProducer, ProducerRecord}
+import org.apache.kafka.clients.producer.{ProducerRecord, Producer => KProducer}
 import org.apache.kafka.common.ConsumerGroupState
 import org.slf4j.{Logger, LoggerFactory}
 
-import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 trait EmbeddedKafkaLike extends KafkaSpec {
 
@@ -106,75 +104,35 @@ abstract class KafkaSpec(_kafkaPort: Int, val zooKeeperPort: Int, actorSystem: A
   /**
    * Periodically checks if a given predicate on cluster state holds.
    *
-   * If the predicate does not hold after `maxTries`, throws an exception.
+   * If the predicate does not hold after configured amount of time, throws an exception.
    */
-  def waitUntilCluster(maxTries: Int = 10, sleepInBetween: FiniteDuration = 100.millis)(
+  def waitUntilCluster()(
       predicate: DescribeClusterResult => Boolean
-  ): Unit =
-    periodicalCheck("cluster state", maxTries, sleepInBetween)(() => adminClient.describeCluster())(predicate)
+  ): Unit = KafkaTestKit.waitUntilCluster(settings.clusterTimeout, settings.checkInterval, adminClient, predicate, log)
 
   /**
    * Periodically checks if the given predicate on consumer group state holds.
    *
-   * If the predicate does not hold after `maxTries`, throws an exception.
+   * If the predicate does not hold after configured amount of time, throws an exception.
    */
-  def waitUntilConsumerGroup(
-      groupId: String,
-      timeout: Duration = 1.second,
-      sleepInBetween: FiniteDuration = 100.millis
-  )(predicate: ConsumerGroupDescription => Boolean): Unit = {
-    val admin = adminClient
-    periodicalCheck("consumer group state", (timeout / sleepInBetween).toInt, sleepInBetween)(
-      () =>
-        admin
-          .describeConsumerGroups(
-            Collections.singleton(groupId),
-            new DescribeConsumerGroupsOptions().timeoutMs(timeout.toMillis.toInt)
-          )
-          .describedGroups()
-          .get(groupId)
-          .get(timeout.toMillis, TimeUnit.MILLISECONDS)
-    )(predicate)
-  }
+  def waitUntilConsumerGroup(groupId: String)(predicate: ConsumerGroupDescription => Boolean): Unit =
+    KafkaTestKit.waitUntilConsumerGroup(groupId,
+                                        settings.consumerGroupTimeout,
+                                        settings.checkInterval,
+                                        adminClient,
+                                        predicate,
+                                        log)
 
   /**
    * Periodically checks if the given predicate on consumer summary holds.
    *
-   * If the predicate does not hold after `maxTries`, throws an exception.
+   * If the predicate does not hold after configured amount of time, throws an exception.
    */
-  def waitUntilConsumerSummary(
-      groupId: String,
-      timeout: Duration = 1.second,
-      sleepInBetween: FiniteDuration = 100.millis
-  )(predicate: PartialFunction[List[MemberDescription], Boolean]): Unit =
-    waitUntilConsumerGroup(groupId, timeout, sleepInBetween) { group =>
+  def waitUntilConsumerSummary(groupId: String)(predicate: PartialFunction[List[MemberDescription], Boolean]): Unit =
+    waitUntilConsumerGroup(groupId) { group =>
       group.state() == ConsumerGroupState.STABLE &&
       Try(predicate(group.members().asScala.toList)).getOrElse(false)
     }
-
-  def periodicalCheck[T](description: String, maxTries: Int = 50, sleepInBetween: FiniteDuration = 100.millis)(
-      data: () => T
-  )(predicate: T => Boolean): Unit = {
-    @tailrec def check(triesLeft: Int): Unit =
-      Try(predicate(data())).recover {
-        case ex =>
-          log.debug(s"Ignoring [${ex.getClass.getName}: ${ex.getMessage}] while waiting for desired state")
-          false
-      } match {
-        case Success(false) if triesLeft > 0 =>
-          sleepQuietly(sleepInBetween)
-          check(triesLeft - 1)
-        case Success(false) =>
-          throw new Error(
-            s"Timeout while waiting for desired $description. Tried [$maxTries] times, slept [$sleepInBetween] in between."
-          )
-        case Failure(ex) =>
-          throw ex
-        case Success(true) => // predicate has been fulfilled, stop checking
-      }
-
-    check(maxTries)
-  }
 
   def createTopics(topics: Int*): immutable.Seq[String] = {
     val topicNames = topics.toList.map { number =>
@@ -188,6 +146,11 @@ abstract class KafkaSpec(_kafkaPort: Int, val zooKeeperPort: Int, actorSystem: A
     createResult.all().get(10, TimeUnit.SECONDS)
     topicNames
   }
+
+  def periodicalCheck[T](description: String, maxTries: Int, sleepInBetween: FiniteDuration)(
+      data: () => T
+  )(predicate: T => Boolean) =
+    KafkaTestKit.periodicalCheck(description, maxTries * sleepInBetween, sleepInBetween)(data)(predicate)(log)
 
   /**
    * Produce messages to topic using specified range and return

--- a/tests/src/it/scala/akka/kafka/PlainSourceFailoverSpec.scala
+++ b/tests/src/it/scala/akka/kafka/PlainSourceFailoverSpec.scala
@@ -39,7 +39,7 @@ class PlainSourceFailoverSpec extends ScalatestKafkaSpec(PlainSourceFailoverSpec
         _.nodes().get().size == BuildInfo.kafkaScale
       }
 
-      val topic = createTopic(partitions = partitions, replication = 3)
+      val topic = createTopic(suffix = 0, partitions, replication = 3)
       val groupId = createGroupId(0)
 
       val consumerConfig = consumerDefaults
@@ -55,7 +55,7 @@ class PlainSourceFailoverSpec extends ScalatestKafkaSpec(PlainSourceFailoverSpec
         }
         .runWith(Sink.last)
 
-      waitUntilConsumerSummary(groupId, timeout = 5.seconds) {
+      waitUntilConsumerSummary(groupId) {
         case singleConsumer :: Nil => singleConsumer.assignment.topicPartitions.size == partitions
       }
 

--- a/tests/src/test/java/docs/javadsl/AssignmentTest.java
+++ b/tests/src/test/java/docs/javadsl/AssignmentTest.java
@@ -55,8 +55,8 @@ public class AssignmentTest extends EmbeddedKafkaJunit4Test {
 
   @Test
   public void mustConsumeFromTheSpecifiedSingleTopic() throws Exception {
-    final String topic = createTopic(0, 1, 1);
-    final String group = createGroupId(0);
+    final String topic = createTopic();
+    final String group = createGroupId();
     final Integer totalMessages = 100;
     final CompletionStage<Done> producerCompletion =
         Source.range(1, totalMessages)
@@ -83,8 +83,8 @@ public class AssignmentTest extends EmbeddedKafkaJunit4Test {
 
   @Test
   public void mustConsumeFromTheSpecifiedTopicPattern() throws Exception {
-    final List<String> topics = Arrays.asList(createTopic(9001, 1, 1), createTopic(9002, 1, 1));
-    final String group = createGroupId(0);
+    final List<String> topics = Arrays.asList(createTopic(9001), createTopic(9002));
+    final String group = createGroupId();
     final Integer totalMessages = 100;
     final CompletionStage<Done> producerCompletion =
         Source.range(1, totalMessages)
@@ -115,7 +115,7 @@ public class AssignmentTest extends EmbeddedKafkaJunit4Test {
 
   @Test
   public void mustConsumeFromTheSpecifiedPartition() throws Exception {
-    final String topic = createTopic(2, 2, 1);
+    final String topic = createTopic(2, 2);
     final Integer totalMessages = 100;
     final CompletionStage<Done> producerCompletion =
         Source.range(1, totalMessages)
@@ -147,7 +147,7 @@ public class AssignmentTest extends EmbeddedKafkaJunit4Test {
 
   @Test
   public void mustConsumeFromTheSpecifiedPartitionAndOffset() throws Exception {
-    final String topic = createTopic(3, 1, 1);
+    final String topic = createTopic(3);
     final Integer totalMessages = 100;
     final CompletionStage<Done> producerCompletion =
         Source.range(1, totalMessages)
@@ -173,7 +173,7 @@ public class AssignmentTest extends EmbeddedKafkaJunit4Test {
 
   @Test
   public void mustConsumeFromTheSpecifiedPartitionAndTimestamp() throws Exception {
-    final String topic = createTopic(4, 1, 1);
+    final String topic = createTopic(4);
     final Integer totalMessages = 100;
     final CompletionStage<Done> producerCompletion =
         Source.range(1, totalMessages)

--- a/tests/src/test/java/docs/javadsl/AtLeastOnceTest.java
+++ b/tests/src/test/java/docs/javadsl/AtLeastOnceTest.java
@@ -55,10 +55,10 @@ public class AtLeastOnceTest extends EmbeddedKafkaJunit4Test {
   @Test
   public void consumeOneProduceMany() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
-        consumerDefaults().withGroupId(createGroupId(0));
-    String topic1 = createTopic(1, 1, 1);
-    String topic2 = createTopic(2, 1, 1);
-    String topic3 = createTopic(3, 1, 1);
+        consumerDefaults().withGroupId(createGroupId());
+    String topic1 = createTopic(1);
+    String topic2 = createTopic(2);
+    String topic3 = createTopic(3);
     ProducerSettings<String, String> producerSettings = producerDefaults();
     CommitterSettings committerSettings = committerDefaults();
     Consumer.DrainingControl<Done> control =
@@ -106,11 +106,11 @@ public class AtLeastOnceTest extends EmbeddedKafkaJunit4Test {
   @Test
   public void consumerOneProduceConditional() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
-        consumerDefaults().withGroupId(createGroupId(0));
-    String topic1 = createTopic(1, 1, 1);
-    String topic2 = createTopic(2, 1, 1);
-    String topic3 = createTopic(3, 1, 1);
-    String topic4 = createTopic(4, 1, 1);
+        consumerDefaults().withGroupId(createGroupId());
+    String topic1 = createTopic(1);
+    String topic2 = createTopic(2);
+    String topic3 = createTopic(3);
+    String topic4 = createTopic(4);
     ProducerSettings<String, String> producerSettings = producerDefaults();
     CommitterSettings committerSettings = committerDefaults();
     Consumer.DrainingControl<Done> control =

--- a/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java
@@ -89,8 +89,8 @@ class ConsumerExampleTest extends EmbeddedKafkaTest {
   @Test
   void plainSourceWithExternalOffsetStorage() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
-        consumerDefaults().withGroupId(createGroupId(1));
-    String topic = createTopic(1, 1, 1);
+        consumerDefaults().withGroupId(createGroupId());
+    String topic = createTopic();
     // #plainSource
     final OffsetStorage db = new OffsetStorage();
 
@@ -146,8 +146,8 @@ class ConsumerExampleTest extends EmbeddedKafkaTest {
   @Test
   void atMostOnce() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
-        consumerDefaults().withGroupId(createGroupId(1));
-    String topic = createTopic(1, 1, 1);
+        consumerDefaults().withGroupId(createGroupId());
+    String topic = createTopic();
     // #atMostOnce
     Consumer.Control control =
         Consumer.atMostOnceSource(consumerSettings, Subscriptions.topics(topic))
@@ -169,9 +169,9 @@ class ConsumerExampleTest extends EmbeddedKafkaTest {
   @Test
   void atLeastOnce() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
-        consumerDefaults().withGroupId(createGroupId(1));
+        consumerDefaults().withGroupId(createGroupId());
     CommitterSettings committerSettings = committerDefaults();
-    String topic = createTopic(1, 1, 1);
+    String topic = createTopic();
     // #atLeastOnce
     Consumer.DrainingControl<Done> control =
         Consumer.committableSource(consumerSettings, Subscriptions.topics(topic))
@@ -192,8 +192,8 @@ class ConsumerExampleTest extends EmbeddedKafkaTest {
   @Test
   void atLeastOnceWithCommitterSink() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
-        consumerDefaults().withGroupId(createGroupId(1));
-    String topic = createTopic(1, 1, 1);
+        consumerDefaults().withGroupId(createGroupId());
+    String topic = createTopic();
     Config config = system.settings().config().getConfig(CommitterSettings.configPath());
     // #committerSink
     CommitterSettings committerSettings = CommitterSettings.create(config);
@@ -216,9 +216,9 @@ class ConsumerExampleTest extends EmbeddedKafkaTest {
   @Test
   void commitWithMetadata() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
-        consumerDefaults().withGroupId(createGroupId(1));
+        consumerDefaults().withGroupId(createGroupId());
     CommitterSettings committerSettings = committerDefaults();
-    String topic = createTopic(1, 1, 1);
+    String topic = createTopic();
     // #commitWithMetadata
     Consumer.DrainingControl<Done> control =
         Consumer.commitWithMetadataSource(
@@ -241,12 +241,12 @@ class ConsumerExampleTest extends EmbeddedKafkaTest {
   @Test
   void consumerToProducer() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
-        consumerDefaults().withGroupId(createGroupId(1));
+        consumerDefaults().withGroupId(createGroupId());
     ProducerSettings<String, String> producerSettings = producerDefaults();
     CommitterSettings committerSettings = committerDefaults();
-    String topic1 = createTopic(1, 1, 1);
-    String topic2 = createTopic(2, 1, 1);
-    String targetTopic = createTopic(10, 1, 1);
+    String topic1 = createTopic(1);
+    String topic2 = createTopic(2);
+    String targetTopic = createTopic(10);
     // #consumerToProducerSink
     Consumer.DrainingControl<Done> control =
         Consumer.committableSource(consumerSettings, Subscriptions.topics(topic1, topic2))
@@ -271,11 +271,11 @@ class ConsumerExampleTest extends EmbeddedKafkaTest {
   @Test
   void consumerToProducerFlow() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
-        consumerDefaults().withGroupId(createGroupId(1));
+        consumerDefaults().withGroupId(createGroupId());
     ProducerSettings<String, String> producerSettings = producerDefaults();
     CommitterSettings committerSettings = committerDefaults();
-    String topic = createTopic(1, 1, 1);
-    String targetTopic = createTopic(20, 1, 1);
+    String topic = createTopic(1);
+    String targetTopic = createTopic(20);
     // #consumerToProducerFlow
     Consumer.DrainingControl<Done> control =
         Consumer.committableSource(consumerSettings, Subscriptions.topics(topic))
@@ -300,12 +300,12 @@ class ConsumerExampleTest extends EmbeddedKafkaTest {
   }
 
   @Test
-  void committableParitionedSource() throws Exception {
+  void committablePartitionedSource() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
-        consumerDefaults().withGroupId(createGroupId(1)).withStopTimeout(Duration.ofMillis(10));
+        consumerDefaults().withGroupId(createGroupId()).withStopTimeout(Duration.ofMillis(10));
     CommitterSettings committerSettings = committerDefaults();
     int maxPartitions = 2;
-    String topic = createTopic(1, maxPartitions, 1);
+    String topic = createTopic(1, maxPartitions);
     // #committablePartitionedSource
     Consumer.DrainingControl<Done> control =
         Consumer.committablePartitionedSource(consumerSettings, Subscriptions.topics(topic))
@@ -323,10 +323,10 @@ class ConsumerExampleTest extends EmbeddedKafkaTest {
   @Test
   void streamPerPartition() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
-        consumerDefaults().withGroupId(createGroupId(1)).withStopTimeout(Duration.ofMillis(10));
+        consumerDefaults().withGroupId(createGroupId()).withStopTimeout(Duration.ofMillis(10));
     CommitterSettings committerSettings = committerDefaults();
     int maxPartitions = 2;
-    String topic = createTopic(1, maxPartitions, 1);
+    String topic = createTopic(1, maxPartitions);
     // #committablePartitionedSource-stream-per-partition
     Consumer.DrainingControl<Done> control =
         Consumer.committablePartitionedSource(consumerSettings, Subscriptions.topics(topic))
@@ -351,9 +351,9 @@ class ConsumerExampleTest extends EmbeddedKafkaTest {
   @Test
   void consumerActor() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
-        consumerDefaults().withGroupId(createGroupId(1));
+        consumerDefaults().withGroupId(createGroupId());
     ActorRef self = system.deadLetters();
-    String topic = createTopic(1, 2, 1);
+    String topic = createTopic(1, 2);
     int partition0 = 0;
     int partition1 = 1;
     // #consumerActor
@@ -392,8 +392,8 @@ class ConsumerExampleTest extends EmbeddedKafkaTest {
   @Test
   void restartSource() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
-        consumerDefaults().withGroupId(createGroupId(1));
-    String topic = createTopic(1, 2, 1);
+        consumerDefaults().withGroupId(createGroupId());
+    String topic = createTopic(1, 2);
     // #restartSource
     AtomicReference<Consumer.Control> control = new AtomicReference<>(Consumer.createNoopControl());
 
@@ -443,8 +443,8 @@ class ConsumerExampleTest extends EmbeddedKafkaTest {
   @Test
   void withRebalanceListener() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
-        consumerDefaults().withGroupId(createGroupId(1));
-    String topic = createTopic(1, 1, 1);
+        consumerDefaults().withGroupId(createGroupId());
+    String topic = createTopic();
     int messageCount = 10;
     // #withRebalanceListenerActor
     ActorRef rebalanceListener = system.actorOf(Props.create(RebalanceListener.class));
@@ -472,8 +472,8 @@ class ConsumerExampleTest extends EmbeddedKafkaTest {
   @Test
   void consumerMetrics() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
-        consumerDefaults().withGroupId(createGroupId(1));
-    String topic = createTopic(1, 1, 1);
+        consumerDefaults().withGroupId(createGroupId());
+    String topic = createTopic();
     // #consumerMetrics
     // run the stream to obtain the materialized Control value
     Consumer.DrainingControl<Done> control =
@@ -498,8 +498,8 @@ class ConsumerExampleTest extends EmbeddedKafkaTest {
   @Test
   void shutdownPlainSource() {
     ConsumerSettings<String, String> consumerSettings =
-        consumerDefaults().withGroupId(createGroupId(1));
-    String topic = createTopic(1, 1, 1);
+        consumerDefaults().withGroupId(createGroupId());
+    String topic = createTopic();
     // #shutdownPlainSource
     final OffsetStorage db = new OffsetStorage();
 
@@ -528,8 +528,8 @@ class ConsumerExampleTest extends EmbeddedKafkaTest {
   @Test
   void shutdownCommittable() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
-        consumerDefaults().withGroupId(createGroupId(1));
-    String topic = createTopic(1, 1, 1);
+        consumerDefaults().withGroupId(createGroupId());
+    String topic = createTopic();
     CommitterSettings committerSettings = committerDefaults();
     // TODO there is a problem with combining `take` and committing.
     int messageCount = 1;

--- a/tests/src/test/java/docs/javadsl/FetchMetadataTest.java
+++ b/tests/src/test/java/docs/javadsl/FetchMetadataTest.java
@@ -48,7 +48,7 @@ public class FetchMetadataTest extends EmbeddedKafkaJunit4Test {
   @Test
   public void demo() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
-        consumerDefaults().withGroupId(createGroupId(0));
+        consumerDefaults().withGroupId(createGroupId());
     // #metadata
     Duration timeout = Duration.ofSeconds(2);
     ConsumerSettings<String, String> settings =

--- a/tests/src/test/java/docs/javadsl/ProducerExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/ProducerExampleTest.java
@@ -79,7 +79,7 @@ class ProducerExampleTest extends EmbeddedKafkaTest {
 
   @Test
   void plainSink() throws Exception {
-    String topic = createTopic(1, 1, 1);
+    String topic = createTopic();
     // #plainSink
     CompletionStage<Done> done =
         Source.range(1, 100)
@@ -99,7 +99,7 @@ class ProducerExampleTest extends EmbeddedKafkaTest {
 
   @Test
   void plainSinkWithSharedProducer() throws Exception {
-    String topic = createTopic(1, 1, 1);
+    String topic = createTopic();
     final org.apache.kafka.clients.producer.Producer<String, String> kafkaProducer =
         producerSettings.createKafkaProducer();
     // #plainSinkWithProducer
@@ -169,7 +169,7 @@ class ProducerExampleTest extends EmbeddedKafkaTest {
 
   @Test
   void producerFlowExample() throws Exception {
-    String topic = createTopic(1, 1, 1);
+    String topic = createTopic();
     // #flow
     CompletionStage<Done> done =
         Source.range(1, 100)

--- a/tests/src/test/java/docs/javadsl/SerializationTest.java
+++ b/tests/src/test/java/docs/javadsl/SerializationTest.java
@@ -71,8 +71,8 @@ public class SerializationTest extends EmbeddedKafkaWithSchemaRegistryTest {
 
   @Test
   public void jacksonDeSer() throws Exception {
-    final String topic = createTopic(1, 1, 1);
-    final String group = createGroupId(1);
+    final String topic = createTopic();
+    final String group = createGroupId();
 
     ConsumerSettings<String, String> consumerSettings = consumerDefaults().withGroupId(group);
 
@@ -141,8 +141,8 @@ public class SerializationTest extends EmbeddedKafkaWithSchemaRegistryTest {
 
   @Test
   public void avroDeSerMustWorkWithSchemaRegistry() throws Exception {
-    final String topic = createTopic(1, 1, 1);
-    final String group = createGroupId(1);
+    final String topic = createTopic();
+    final String group = createGroupId();
 
     // #serializer #de-serializer
 

--- a/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java
@@ -56,10 +56,10 @@ public class TransactionsExampleTest extends EmbeddedKafkaJunit4Test {
   @Test
   public void sourceSink() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
-        consumerDefaults().withGroupId(createGroupId(1));
-    String sourceTopic = createTopic(1, 1, 1);
-    String targetTopic = createTopic(2, 1, 1);
-    String transactionalId = createTransactionalId(1);
+        consumerDefaults().withGroupId(createGroupId());
+    String sourceTopic = createTopic(1);
+    String targetTopic = createTopic(2);
+    String transactionalId = createTransactionalId();
     // #transactionalSink
     Consumer.DrainingControl<Done> control =
         Transactional.source(consumerSettings, Subscriptions.topics(sourceTopic))
@@ -90,10 +90,10 @@ public class TransactionsExampleTest extends EmbeddedKafkaJunit4Test {
   @Test
   public void usingRestartSource() throws Exception {
     ConsumerSettings<String, String> consumerSettings =
-        consumerDefaults().withGroupId(createGroupId(1));
-    String sourceTopic = createTopic(1, 1, 1);
-    String targetTopic = createTopic(2, 1, 1);
-    String transactionalId = createTransactionalId(1);
+        consumerDefaults().withGroupId(createGroupId());
+    String sourceTopic = createTopic(1);
+    String targetTopic = createTopic(2);
+    String transactionalId = createTransactionalId();
     // #transactionalFailureRetry
     AtomicReference<Consumer.Control> innerControl =
         new AtomicReference<>(Consumer.createNoopControl());

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -358,7 +358,7 @@ class IntegrationSpec extends SpecBase(kafkaPort = KafkaPorts.IntegrationSpec) w
     }
 
     "access metrics" in assertAllStagesStopped {
-      val topic = createTopic(number = 1, partitions = 1, replication = 1)
+      val topic = createTopic(suffix = 1, partitions = 1, replication = 1)
       val group = createGroupId(1)
 
       val control = Consumer

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -91,7 +91,7 @@ class IntegrationSpec extends SpecBase(kafkaPort = KafkaPorts.IntegrationSpec) w
       val control = createAndRunConsumer(subscription1)
 
       // waits until all partitions are assigned to the single consumer
-      waitUntilConsumerSummary(group, timeout = 5.seconds) {
+      waitUntilConsumerSummary(group) {
         case singleConsumer :: Nil => singleConsumer.assignment.topicPartitions.size == partitions
       }
 
@@ -104,7 +104,7 @@ class IntegrationSpec extends SpecBase(kafkaPort = KafkaPorts.IntegrationSpec) w
       val control2 = createAndRunConsumer(subscription2)
 
       // waits until partitions are assigned across both consumers
-      waitUntilConsumerSummary(group, timeout = 10.seconds) {
+      waitUntilConsumerSummary(group) {
         case consumer1 :: consumer2 :: Nil =>
           val half = partitions / 2
           consumer1.assignment.topicPartitions.size == half && consumer2.assignment.topicPartitions.size == half

--- a/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
@@ -113,7 +113,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
         .run()
 
       // waits until all partitions are assigned to the single consumer
-      waitUntilConsumerSummary(group, timeout = 5.seconds) {
+      waitUntilConsumerSummary(group) {
         case singleConsumer :: Nil => singleConsumer.assignment.topicPartitions.size == partitions
       }
 
@@ -176,7 +176,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
       val control = createAndRunConsumer()
 
       // waits until all partitions are assigned to the single consumer
-      waitUntilConsumerSummary(group, timeout = 5.seconds) {
+      waitUntilConsumerSummary(group) {
         case singleConsumer :: Nil => singleConsumer.assignment.topicPartitions.size == partitions
       }
 
@@ -205,7 +205,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
       producer.futureValue shouldBe Done
 
       // waits until partitions are assigned across both consumers
-      waitUntilConsumerSummary(group, timeout = 5.seconds) {
+      waitUntilConsumerSummary(group) {
         case consumer1 :: consumer2 :: Nil =>
           val half = partitions / 2
           consumer1.assignment.topicPartitions.size == half && consumer2.assignment.topicPartitions.size == half
@@ -262,7 +262,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
       val control = createAndRunConsumer(subscription1)
 
       // waits until all partitions are assigned to the single consumer
-      waitUntilConsumerSummary(group, timeout = 5.seconds) {
+      waitUntilConsumerSummary(group) {
         case singleConsumer :: Nil => singleConsumer.assignment.topicPartitions.size == partitions
       }
 
@@ -294,7 +294,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
       rebalanceActor.expectMsg(TopicPartitionsAssigned(subscription1, Set(allTps: _*)))
 
       // waits until partitions are assigned across both consumers
-      waitUntilConsumerSummary(group, timeout = 5.seconds) {
+      waitUntilConsumerSummary(group) {
         case consumer1 :: consumer2 :: Nil =>
           val half = partitions / 2
           consumer1.assignment.topicPartitions.size == half && consumer2.assignment.topicPartitions.size == half
@@ -326,7 +326,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
         .plainPartitionedManualOffsetSource(
           consumerDefaults.withGroupId(group),
           Subscriptions.topics(topic),
-          getOffsetsOnAssign = tps => {
+          getOffsetsOnAssign = _ => {
             partitionsAssigned = true
             Future.successful(Map.empty)
           },
@@ -473,7 +473,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
         .run()
 
       // waits until all partitions are assigned to the single consumer
-      waitUntilConsumerSummary(group, timeout = 5.seconds) {
+      waitUntilConsumerSummary(group) {
         case singleConsumer :: Nil => singleConsumer.assignment.topicPartitions.size == partitions
       }
 

--- a/tests/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
@@ -33,10 +33,9 @@ class RetentionPeriodSpec extends SpecBase(kafkaPort = KafkaPorts.RetentionPerio
   "After retention period (1 min) consumer" must {
 
     "resume from committed offset" in assertAllStagesStopped {
-      val topic1 = createTopicName(1)
-      val group1 = createGroupId(1)
+      val topic1 = createTopic()
+      val group1 = createGroupId()
 
-      givenInitializedTopic(topic1)
       produce(topic1, 1 to 100)
 
       val committedElements = new ConcurrentLinkedQueue[Int]()
@@ -45,7 +44,6 @@ class RetentionPeriodSpec extends SpecBase(kafkaPort = KafkaPorts.RetentionPerio
 
       val (control, probe1) = Consumer
         .committableSource(consumerSettings, Subscriptions.topics(topic1))
-        .filterNot(_.record.value == InitialMsg)
         .mapAsync(10) { elem =>
           elem.committableOffset.commitScaladsl().map { _ =>
             committedElements.add(elem.record.value.toInt)

--- a/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala
@@ -47,7 +47,7 @@ class AssignmentSpec extends SpecBase(kafkaPort = KafkaPorts.AssignmentSpec) wit
     }
 
     "consume from the specified topic pattern" in assertAllStagesStopped {
-      val topics = immutable.Seq(createTopic(number = 1), createTopic(number = 1))
+      val topics = immutable.Seq(createTopic(), createTopic())
       val group = createGroupId()
       val totalMessages = 100
       val producerCompletion =
@@ -72,7 +72,7 @@ class AssignmentSpec extends SpecBase(kafkaPort = KafkaPorts.AssignmentSpec) wit
     }
 
     "consume from the specified partition" in assertAllStagesStopped {
-      val topic = createTopic(partitions = 2)
+      val topic = createTopic(suffix = 0, partitions = 2)
       val totalMessages = 100
       val producerCompletion =
         Source(1 to totalMessages)

--- a/tests/src/test/scala/docs/scaladsl/PartitionExamples.scala
+++ b/tests/src/test/scala/docs/scaladsl/PartitionExamples.scala
@@ -31,7 +31,7 @@ class PartitionExamples extends DocsSpecBase(KafkaPorts.ScalaPartitionExamples) 
 
   "Externally controlled kafka consumer" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
-    val topic = createTopic(partitions = 3)
+    val topic = createTopic(suffix = 0, partitions = 3)
     val partition1 = 1
     val partition2 = 2
     // #consumerActor
@@ -81,7 +81,7 @@ class PartitionExamples extends DocsSpecBase(KafkaPorts.ScalaPartitionExamples) 
 
   "Consumer Metrics" should "work" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId())
-    val topic = createTopic(partitions = 3)
+    val topic = createTopic(suffix = 0, partitions = 3)
     val partition = 1
     def println(s: String): Unit = {}
     // #consumerMetrics

--- a/tests/src/test/scala/docs/scaladsl/SerializationSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/SerializationSpec.scala
@@ -224,7 +224,7 @@ class SerializationSpec
 
   it should "signal to all streams of a shared actor in same request, and keep others alive" in assertAllStagesStopped {
     val group = createGroupId()
-    val topic = createTopic(partitions = 3)
+    val topic = createTopic(suffix = 0, partitions = 3)
 
     val consumerActor =
       system.actorOf(KafkaConsumerActor.props(specificRecordConsumerSettings(group)), "sharedKafkaConsumerActor")


### PR DESCRIPTION
## Purpose

This PR adds TestKit configuration, that allows to configure the amount of time testkit waits until the desired Kafka cluster state is reached.

## References

Previously such timeouts where specified in the code, and would be too short in Travis: https://travis-ci.org/akka/alpakka-kafka/jobs/527234960#L7401

## Changes

* TestKit now was KafkaTeskitSettings class that load settings from config
* state waiting helpers are added to the `...javadsl.BaseKafkaTest`
* topic/groupid/transactionalid creation helpers are now usable from Java tests