### PR TITLE
Transactional revoke on consumer thread

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -95,7 +95,8 @@ import scala.util.control.NonFatal
     def apply(subscription: AutoSubscription,
               sourceActor: ActorRef,
               partitionAssignedCB: AsyncCallback[Set[TopicPartition]],
-              partitionRevokedCB: AsyncCallback[Set[TopicPartition]]): ListenerCallbacks =
+              partitionRevokedCB: AsyncCallback[Set[TopicPartition]],
+              revokedBlockingCallback: Set[TopicPartition] => Unit = _ => ()): ListenerCallbacks =
       KafkaConsumerActor.ListenerCallbacks(
         assignedTps => {
           subscription.rebalanceListener.foreach {
@@ -112,6 +113,7 @@ import scala.util.control.NonFatal
           if (revokedTps.nonEmpty) {
             partitionRevokedCB.invoke(revokedTps)
           }
+          revokedBlockingCallback(revokedTps)
         }
       )
   }

--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -38,7 +38,11 @@ import scala.concurrent.{Future, Promise}
 
       val revokedCB = getAsyncCallback[Set[TopicPartition]](partitionRevokedHandler)
 
-      KafkaConsumerActor.ListenerCallbacks(autoSubscription, sourceActor.ref, assignedCB, revokedCB)
+      KafkaConsumerActor.ListenerCallbacks(autoSubscription,
+                                           sourceActor.ref,
+                                           assignedCB,
+                                           revokedCB,
+                                           blockingRevokedHandler)
     }
 
     subscription match {
@@ -97,4 +101,6 @@ import scala.concurrent.{Future, Promise}
     tps --= revokedTps
     log.debug("Revoked partitions: {}. All partitions: {}", revokedTps, tps)
   }
+
+  protected def blockingRevokedHandler(revokedTps: Set[TopicPartition]): Unit = {}
 }

--- a/core/src/main/scala/akka/kafka/internal/TransactionalSource.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalSource.scala
@@ -145,15 +145,13 @@ private[kafka] final class TransactionalSource[K, V](consumerSettings: ConsumerS
                              sourceActor.ref)
 
       // This is invoked in the KafkaConsumerActor thread when doing poll.
-      override def partitionRevokedHandler(revokedTps: Set[TopicPartition]): Unit = {
+      override def blockingRevokedHandler(revokedTps: Set[TopicPartition]): Unit =
         if (waitForDraining(revokedTps)) {
           sourceActor.ref ! Revoked(revokedTps.toList)
         } else {
           sourceActor.ref ! Failure(new Error("Timeout while draining"))
           consumerActor ! KafkaConsumerActor.Internal.Stop
         }
-        super.partitionRevokedHandler(revokedTps)
-      }
 
       def waitForDraining(partitions: Set[TopicPartition]): Boolean = {
         import akka.pattern.ask


### PR DESCRIPTION
## Purpose

As observed by @charlibot waiting for draining on the source actor thread is wrong (this happens because of using `asyncCallback`), because we never receive a message that the stream is drained. This fix is intended to fix that by forcing waiting for the draining on the consumer thread.
It also blocks the consumer from polling/releasing partitions, which was my intention from the beginning.

This is a quick fix. We should implement a proper fix on top of #761 

## References

References #785 #784 #761 
