### PR TITLE
Make EmbeddedKafkaJunit4Test extend KafkaJunit4Test

### DIFF
--- a/testkit/src/main/java/akka/kafka/testkit/javadsl/EmbeddedKafkaJunit4Test.java
+++ b/testkit/src/main/java/akka/kafka/testkit/javadsl/EmbeddedKafkaJunit4Test.java
@@ -20,7 +20,7 @@ import scala.collection.immutable.HashMap$;
  * to create a single instance of the test class with `@BeforeAll` and `@AfterAll` annotated methods
  * called by the test framework.
  */
-public abstract class EmbeddedKafkaJunit4Test extends KafkaTest {
+public abstract class EmbeddedKafkaJunit4Test extends KafkaJunit4Test {
 
   private static EmbeddedKafkaConfig embeddedKafkaConfig(
       int kafkaPort, int zookeeperPort, int replicationFactor) {

--- a/tests/src/test/resources/logback-test.xml
+++ b/tests/src/test/resources/logback-test.xml
@@ -36,6 +36,8 @@
     <logger name="org.jboss" level="WARN"/>
     <logger name="org.glassfish" level="WARN"/>
     <logger name="io.confluent" level="WARN"/>
+    <logger name="org.testcontainers" level="WARN"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
 
     <root level="DEBUG">
         <!--<appender-ref ref="STDOUT" /-->

--- a/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala
@@ -6,9 +6,9 @@
 package docs.scaladsl
 
 import akka.Done
+import akka.kafka.Subscriptions
 import akka.kafka.scaladsl.{Consumer, Producer, SpecBase}
-import akka.kafka.testkit.scaladsl.EmbeddedKafkaLike
-import akka.kafka.{KafkaPorts, Subscriptions}
+import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
 import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import org.apache.kafka.clients.producer.ProducerRecord
@@ -17,7 +17,7 @@ import org.apache.kafka.common.TopicPartition
 import scala.collection.immutable
 import scala.concurrent.duration._
 
-class AssignmentSpec extends SpecBase(kafkaPort = KafkaPorts.AssignmentSpec) with EmbeddedKafkaLike {
+class AssignmentSpec extends SpecBase with TestcontainersKafkaLike {
 
   implicit val patience = PatienceConfig(15.seconds, 1.second)
 


### PR DESCRIPTION
## Purpose

It turns out that `EmbeddedKafkaJunit4Test` extends `KafkaTest` which uses JUnit 5 annotations, this PR make it extend the correct `KafkaJunit4Test` instead.

## Changes

* Make EmbeddedKafkaJunit4Test extend KafkaJunit4Test
* Use Testcontainers with `AssignmentSpec`
* Hide Testcontainers logging from tests logging