### PR TITLE
Benchmarks: Do not append message count to results file

### DIFF
--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/Timed.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/Timed.scala
@@ -39,7 +39,7 @@ object Timed extends LazyLogging {
     logger.info(s"Generating fixture for ${name}_$msgCount")
     val fixture = fixtureGen.generate(msgCount)
     val metrics = new MetricRegistry()
-    val meter = metrics.meter(name + "_" + msgCount)
+    val meter = metrics.meter(name)
     logger.info(s"Running benchmarks for ${name}_$msgCount")
     val now = System.nanoTime()
     testBody(fixture, meter)


### PR DESCRIPTION
## Purpose

We want to be able to adjust message count (or even go to time based instead of message count based tests in the future) without loosing the benchmark results history which is based on the benchmark name.