### PR TITLE
Add benchmarks for consumptions from multiple partitions

### DIFF
--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/Benchmarks.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/Benchmarks.scala
@@ -63,8 +63,19 @@ class ApacheKafkaBatchedConsumer extends BenchmarksBase() {
   it should "bench with normal messages" in {
     val cmd = RunTestCommand("apache-kafka-batched-consumer-normal-msg", bootstrapServers, 1000 * 1000, 5 * 1000)
     runPerfTest(cmd,
-      KafkaConsumerFixtures.filledTopics(cmd),
-      KafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
+                KafkaConsumerFixtures.filledTopics(cmd),
+                KafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
+  }
+
+  it should "bench with normal messages and eight partitions" in {
+    val cmd = RunTestCommand("apache-kafka-batched-consumer-normal-msg-8-partitions",
+                             bootstrapServers,
+                             msgCount = 1000 * 1000,
+                             msgSize = 5 * 1000,
+                             numberOfPartitions = 8)
+    runPerfTest(cmd,
+                KafkaConsumerFixtures.filledTopics(cmd),
+                KafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
   }
 }
 
@@ -79,8 +90,19 @@ class AlpakkaKafkaBatchedConsumer extends BenchmarksBase() {
   it should "bench with normal messages" in {
     val cmd = RunTestCommand("alpakka-kafka-batched-consumer-normal-msg", bootstrapServers, 1000 * 1000, 5 * 1000)
     runPerfTest(cmd,
-      ReactiveKafkaConsumerFixtures.committableSources(cmd),
-      ReactiveKafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
+                ReactiveKafkaConsumerFixtures.committableSources(cmd),
+                ReactiveKafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
+  }
+
+  it should "bench with normal messages and eight partitions" in {
+    val cmd = RunTestCommand("alpakka-kafka-batched-consumer-normal-msg-8-partitions",
+                             bootstrapServers,
+                             msgCount = 1000 * 1000,
+                             msgSize = 5 * 1000,
+                             numberOfPartitions = 8)
+    runPerfTest(cmd,
+                ReactiveKafkaConsumerFixtures.committableSources(cmd),
+                ReactiveKafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
   }
 }
 

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaConsumerFixtureGen.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaConsumerFixtureGen.scala
@@ -28,7 +28,7 @@ object KafkaConsumerFixtures extends PerfFixtureHelpers {
     c,
     msgCount => {
       val topic = randomId()
-      fillTopic(c.kafkaHost, topic, msgCount, c.msgSize)
+      fillTopic(topic, c)
       val consumerJavaProps = new java.util.Properties
       consumerJavaProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, c.kafkaHost)
       consumerJavaProps.put(ConsumerConfig.CLIENT_ID_CONFIG, randomId())

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaProducerFixtureGen.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaProducerFixtureGen.scala
@@ -28,7 +28,7 @@ object KafkaProducerFixtures extends PerfFixtureHelpers {
     c,
     msgCount => {
       val topic = randomId()
-      val rawProducer = initTopicAndProducer(c.kafkaHost, topic, 1, c.msgSize)
+      val rawProducer = initTopicAndProducer(topic, c.copy(msgCount = 1))
       KafkaProducerTestFixture(topic, msgCount, c.msgSize, rawProducer)
     }
   )

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaTransactionFixtureGen.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaTransactionFixtureGen.scala
@@ -44,7 +44,7 @@ object KafkaTransactionFixtures extends PerfFixtureHelpers {
       c,
       msgCount => {
         val sourceTopic = randomId()
-        fillTopic(c.kafkaHost, sourceTopic, msgCount, c.msgSize)
+        fillTopic(sourceTopic, c)
         val groupId = randomId()
         val sinkTopic = randomId()
 

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaConsumerFixtures.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaConsumerFixtures.scala
@@ -34,7 +34,7 @@ object ReactiveKafkaConsumerFixtures extends PerfFixtureHelpers {
       c,
       msgCount => {
         val topic = randomId()
-        fillTopic(c.kafkaHost, topic, msgCount, c.msgSize)
+        fillTopic(topic, c)
         val settings = createConsumerSettings(c.kafkaHost)
         val source = Consumer.plainSource(settings, Subscriptions.topics(topic))
         ReactiveKafkaConsumerTestFixture(topic, msgCount, source, c.numberOfPartitions)
@@ -46,7 +46,7 @@ object ReactiveKafkaConsumerFixtures extends PerfFixtureHelpers {
       c,
       msgCount => {
         val topic = randomId()
-        fillTopic(c.kafkaHost, topic, msgCount, c.msgSize)
+        fillTopic(topic, c)
         val settings = createConsumerSettings(c.kafkaHost)
         val source = Consumer.committableSource(settings, Subscriptions.topics(topic))
         ReactiveKafkaConsumerTestFixture(topic, msgCount, source, c.numberOfPartitions)

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaProducerFixtures.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaProducerFixtures.scala
@@ -41,7 +41,7 @@ object ReactiveKafkaProducerFixtures extends PerfFixtureHelpers {
       msgCount => {
         val flow: FlowType[Int] = Producer.flexiFlow(createProducerSettings(c.kafkaHost))
         val topic = randomId()
-        initTopicAndProducer(c.kafkaHost, topic, 1, c.msgSize)
+        initTopicAndProducer(topic, c.copy(msgCount = 1))
         ReactiveKafkaProducerTestFixture(topic, msgCount, c.msgSize, flow)
       }
     )

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaTransactionFixtures.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaTransactionFixtures.scala
@@ -56,7 +56,7 @@ object ReactiveKafkaTransactionFixtures extends PerfFixtureHelpers {
       c,
       msgCount => {
         val sourceTopic = randomId()
-        fillTopic(c.kafkaHost, sourceTopic, msgCount, c.msgSize)
+        fillTopic(sourceTopic, c)
         val sinkTopic = randomId()
 
         val consumerSettings = createConsumerSettings(c.kafkaHost)

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/app/RunTestCommand.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/app/RunTestCommand.scala
@@ -5,4 +5,12 @@
 
 package akka.kafka.benchmarks.app
 
-case class RunTestCommand(testName: String, kafkaHost: String, msgCount: Int, msgSize: Int, numberOfPartitions: Int = 1)
+import akka.kafka.benchmarks.BuildInfo
+
+case class RunTestCommand(testName: String,
+                          kafkaHost: String,
+                          msgCount: Int,
+                          msgSize: Int,
+                          numberOfPartitions: Int = 1) {
+  def replicationFactor = BuildInfo.kafkaScale
+}


### PR DESCRIPTION
## Purpose

Adds benchmarks, that consumer from multiple partitions.

## References

Investigating #773

## Changes

Now benchmarks explicitly create topics with a defined number of partitions. Topics are still being filled in without specifying a partition, which makes Kafka to round-robin messages across all topic partitions.