### PR TITLE
Use Produer Send API with callback

### DIFF
--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaProducerBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaProducerBenchmarks.scala
@@ -7,7 +7,8 @@ package akka.kafka.benchmarks
 
 import com.codahale.metrics.Meter
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata}
+
 import scala.concurrent.duration._
 
 object KafkaProducerBenchmarks extends LazyLogging {
@@ -24,8 +25,9 @@ object KafkaProducerBenchmarks extends LazyLogging {
     val msg = PerfFixtureHelpers.stringOfSize(fixture.msgSize)
 
     for (i <- 1 to fixture.msgCount) {
-      producer.send(new ProducerRecord[Array[Byte], String](fixture.topic, msg))
-      meter.mark()
+      producer.send(new ProducerRecord[Array[Byte], String](fixture.topic, msg),
+                    (_: RecordMetadata, _: Exception) => meter.mark())
+
       if (i % logStep == 0) {
         val lastPartEnd = System.nanoTime()
         val took = (lastPartEnd - lastPartStart).nanos

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaTransactionBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaTransactionBenchmarks.scala
@@ -9,7 +9,7 @@ import akka.kafka.benchmarks.KafkaConsumerBenchmarks.pollTimeoutMs
 import com.codahale.metrics.Meter
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.kafka.clients.consumer._
-import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata}
 import org.apache.kafka.common.TopicPartition
 
 import scala.annotation.tailrec
@@ -62,8 +62,7 @@ object KafkaTransactionBenchmarks extends LazyLogging {
           lastProcessedOffset = record.offset()
 
           val producerRecord = new ProducerRecord(fixture.sinkTopic, record.partition(), record.key(), record.value())
-          producer.send(producerRecord)
-          meter.mark()
+          producer.send(producerRecord, (_: RecordMetadata, _: Exception) => meter.mark())
           if (lastProcessedOffset % loggedStep == 0)
             logger.info(
               s"Transformed $lastProcessedOffset elements to Kafka (${100 * lastProcessedOffset / msgCount}%)"


### PR DESCRIPTION
## Purpose

Alpakka Kafka uses Kafka Producer Send API with callback support. We should use the same in raw Apache Kafka benchmarks.