### PR TITLE
Create predicate converter directly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,10 @@ jobs:
       name: "Compile all tests (with Scala 2.11)"
     - env: CMD="++2.13.0-RC3 Test/compile"
       name: "Compile all tests (with Scala 2.13)"
+    - env: CMD="+doc"
+      name: "Create all API docs for artifacts"
     - env: CMD="unidoc"
-      name: "Create all API docs"
+      name: "Create all API docs for website"
     - env: CMD="docs/paradox"
       name: "Create site with Paradox"
 

--- a/testkit/src/main/java/akka/kafka/testkit/javadsl/BaseKafkaTest.java
+++ b/testkit/src/main/java/akka/kafka/testkit/javadsl/BaseKafkaTest.java
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.ConsumerGroupState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.compat.java8.functionConverterImpls.FromJavaPredicate;
 
 import java.time.Duration;
 import java.util.Collection;
@@ -34,11 +35,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
-import static scala.compat.java8.FunctionConverters.package$.MODULE$;
-
 public abstract class BaseKafkaTest extends KafkaTestKitClass {
-
-  private static scala.compat.java8.FunctionConverters.package$ functionConverters = MODULE$;
 
   public static final int partition0 = 0;
 
@@ -88,7 +85,7 @@ public abstract class BaseKafkaTest extends KafkaTestKitClass {
         settings().clusterTimeout(),
         settings().checkInterval(),
         adminClient(),
-        functionConverters.asScalaFromPredicate(predicate),
+        new FromJavaPredicate(predicate),
         log());
   }
 
@@ -104,7 +101,7 @@ public abstract class BaseKafkaTest extends KafkaTestKitClass {
         settings().consumerGroupTimeout(),
         settings().checkInterval(),
         adminClient(),
-        functionConverters.asScalaFromPredicate(predicate),
+        new FromJavaPredicate(predicate),
         log());
   }
 


### PR DESCRIPTION
## Purpose

Fixes java-to-scala predicate converter when using with 2.13.0-RC3.

## References

The `testkit/Compile/doc` task failed for 2.13.0-RC3 with the following error:

```
[error] /home/travis/build/akka/alpakka-kafka/testkit/src/main/java/akka/kafka/testkit/javadsl/BaseKafkaTest.java:37:8: object package$ is not a member of package scala.compat.java8.FunctionConverters
[error] did you mean package?
[error] import static scala.compat.java8.FunctionConverters.package$.MODULE$;
[error]        ^
[error] /home/travis/build/akka/alpakka-kafka/testkit/src/main/java/akka/kafka/testkit/javadsl/BaseKafkaTest.java:41:18: not found: type scala
[error]   private static scala.compat.java8.FunctionConverters.package$ functionConverters = MODULE$;
[error]             
```

However `testkit/Compile/compile` completed successfully with Scala 2.13. This is a bit of a mystery why it failed only for scaladoc.

The fix in this PR creates the converter directly instead of going through the factory in the package object.

## Changes

* adds a CI task that builds API docs for all Scala versions. This is different than `unidoc`, as the latter merged the classpath from all of the modules to one.
* creates converter directly

## Background Context

https://travis-ci.org/akka/alpakka-kafka/jobs/540648775#L1015
