### PR TITLE
Release notes 1.0.4

### DIFF
--- a/docs/src/main/paradox/home.md
+++ b/docs/src/main/paradox/home.md
@@ -10,15 +10,25 @@ This **Alpakka Kafka connector** lets you connect [Apache Kafka](https://kafka.a
 
 ## Matching Kafka Versions
 
-|Kafka  | Akka version | Alpakka Kafka Connector
-|-------|--------------|-------------------------
-|[2.1.1](https://dist.apache.org/repos/dist/release/kafka/2.1.1/RELEASE_NOTES.html) | 2.5.x        | @ref:[release 1.0.1](release-notes/1.0.x.md#1-0-1)
-|[2.1.0](https://dist.apache.org/repos/dist/release/kafka/2.1.0/RELEASE_NOTES.html) | 2.5.x        | @ref:[release 1.0](release-notes/1.0.x.md#1-0)
-|2.0.x  | 2.5.x        | @ref:[release 1.0-M1](release-notes/1.0-M1.md)
-|1.1.x  | 2.5.x        | [release 0.20+](https://github.com/akka/reactive-kafka/releases)
-|1.0.x  | 2.5.x        | [release 0.20+](https://github.com/akka/reactive-kafka/releases)
-|0.11.x | 2.5.x        | [release 0.19](https://github.com/akka/reactive-kafka/milestone/19?closed=1)
+|Kafka client | Scala Versions | Akka version | Alpakka Kafka Connector
+|-------------|----------------|--------------|-------------------------
+|[2.1.1](https://dist.apache.org/repos/dist/release/kafka/2.1.1/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.x        | @ref:[release 1.0.4](release-notes/1.0.x.md#1-0-4)
+|[2.1.1](https://dist.apache.org/repos/dist/release/kafka/2.1.1/RELEASE_NOTES.html) | 2.12, 2.11       | 2.5.x        | @ref:[release 1.0.1](release-notes/1.0.x.md#1-0-1)
+|[2.1.0](https://dist.apache.org/repos/dist/release/kafka/2.1.0/RELEASE_NOTES.html) | 2.12, 2.11       | 2.5.x        | @ref:[release 1.0](release-notes/1.0.x.md#1-0)
+|2.0.x        | 2.12, 2.11 | 2.5.x        | @ref:[release 1.0-M1](release-notes/1.0-M1.md)
+|1.1.x        | 2.12, 2.11 | 2.5.x        | [release 0.20+](https://github.com/akka/reactive-kafka/releases)
+|1.0.x        | 2.12, 2.11 | 2.5.x        | [release 0.20+](https://github.com/akka/reactive-kafka/releases)
+|0.11.x       | 2.12, 2.11 | 2.5.x        | [release 0.19](https://github.com/akka/reactive-kafka/milestone/19?closed=1)
 
+@@@ note
+
+As Kakfka's client protocol negotiates the version to use with the Kafka broker, you may use a Kafka client version that is different than the Kafka broker's version.
+
+These client can communicate with brokers that are version 0.10.0 or newer. Older or newer brokers may not support certain features. For example, 0.10.0 brokers do not support offsetsForTimes, because this feature was added in version 0.10.1. You will receive an UnsupportedVersionException when invoking an API that is not available on the running broker version.
+
+-- [Javadoc for `KafkaConsumer`](https://kafka.apache.org/21/javadoc/index.html?org/apache/kafka/clients/consumer/KafkaConsumer.html) 
+
+@@@
 
 ## Dependencies
 

--- a/docs/src/main/paradox/release-notes/1.0.x.md
+++ b/docs/src/main/paradox/release-notes/1.0.x.md
@@ -4,6 +4,34 @@
 In case you are browsing a specific version's documentation: check out the [latest release notes](https://doc.akka.io/docs/alpakka-kafka/current/release-notes/index.html)
 @@@
 
+# 1.0.4
+
+Released: 2019-06-11
+
+Alpakka Kafka 1.0.4 is released for Scala 2.13, 2.12 and 2.11.
+
+## Most important changes since 1.0.3
+
+* Compile with Scala 2.13 [#817](https://github.com/akka/alpakka-kafka/pull/817)
+* Add `Committer.batchFlow` that emits `CommittableOffsetBatch` for every committed batch. [#799](https://github.com/akka/alpakka-kafka/pull/799)
+
+The detailed list of changes is found in [the milestone](https://github.com/akka/alpakka-kafka/milestone/32?closed=1).
+
+### General information
+
+This release is compiled and tested against [Akka 2.5](https://doc.akka.io/docs/akka/2.5/) and Scala 2.11, 2.12, 2.13.0 on Adopt OpenJDK 8 and 11.
+
+This release was made possible by:
+
+
+| Author | Commits | Lines added | Lines removed |
+| ------ | ------- | ----------- | ------------- |
+| [<img width="20" alt="2m" src="https://avatars3.githubusercontent.com/u/422086?v=4&s=40"> **2m**](https://github.com/2m) | 30 | 2947 | 2735 |
+| [<img width="20" alt="ennru" src="https://avatars3.githubusercontent.com/u/458526?v=4&s=40"> **ennru**](https://github.com/ennru) | 3 | 966 | 301 |
+| [<img width="20" alt="mowczare" src="https://avatars0.githubusercontent.com/u/9057533?s=40&v=4"/> **mowczare**](https://github.com/mowczare) | 2 | 40 | 32 |
+| [<img width="20" alt="mowczare" src="https://avatars2.githubusercontent.com/u/22529514?s=40&v=4"/> **Jimmycheong**](https://github.com/Jimmycheong) | 1 | 3 | 3 |
+
+
 # 1.0.3
 
 Released: 2019-05-09
@@ -23,7 +51,7 @@ The detailed list of changes is found in [the milestone](https://github.com/akka
 
 ### General information
 
-This release is compiled and tested against [Akka 2.5](https://doc.akka.io/docs/akka/current/) and Scala 2.11 and 2.12 on Adopt OpenJDK 1.8.
+This release is compiled and tested against [Akka 2.5](https://doc.akka.io/docs/akka/2.5/) and Scala 2.11 and 2.12 on Adopt OpenJDK 1.8.
 
 This release was made possible by:
 
@@ -52,7 +80,7 @@ The detailed list of changes is found in [the milestone](https://github.com/akka
 
 ### General information
 
-This release is compiled and tested against [Akka 2.5](https://doc.akka.io/docs/akka/current/) and Scala 2.11 and 2.12 on Adopt OpenJDK 1.8.
+This release is compiled and tested against [Akka 2.5](https://doc.akka.io/docs/akka/2.5/) and Scala 2.11 and 2.12 on Adopt OpenJDK 1.8.
 
 This release was made possible by:
 
@@ -79,7 +107,7 @@ The upgrade to the Apache Kafka client 2.1.1 is the only change compared to rele
 
 ### General information
 
-This release is compiled and tested against [Akka 2.5](https://doc.akka.io/docs/akka/current/) and Scala 2.11 and 2.12.
+This release is compiled and tested against [Akka 2.5](https://doc.akka.io/docs/akka/2.5/) and Scala 2.11 and 2.12.
 
 This release was made possible by:
 
@@ -132,6 +160,6 @@ Alpakka Kafka 1.0 uses the Apache Kafka Java client 2.1.0 internally.
 
 * Java APIs for all settings classes [#616](https://github.com/akka/alpakka-kafka/pull/616)
 
-* [Alpakka Kafka testkit](https://doc.akka.io/docs/alpakka-kafka/current/testing.html)
+* @ref:[Alpakka Kafka testkit](../testing.md)
 
 For more detailed information on all changes, please refer to the release notes of @ref[1.0-M1](1.0-M1.md), @ref[1.0-RC1](1.0-RC1.md), @ref[1.0-RC2](1.0-RC2.md).


### PR DESCRIPTION
Add release notes for the upcoming 1.0.4 release with Scala 2.13.