### PR TITLE
Use Graal JIT compiler when running tests with JDK11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ jobs:
 
     - env:
       - JDK="adopt@~1.11.0-2"
+      - _JAVA_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
       - CMD="+test"
       name: "Run tests (AdoptOpenJDK 11)"
 


### PR DESCRIPTION
## Purpose

Use Graal JIT compiler when running tests with JDK11.

## Changes

Command flags are added to the `JAVA_OPTS` environment flag which is automatically picked up by sbt.