### PR TITLE
Use latest scalafmt

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 2.0.0-RC7
+version = 2.0.0-RC8
 
 style = defaultWithAlign
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.1")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.4.4")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.2.0")


### PR DESCRIPTION
## Purpose

Switches to the latest scalafmt

## References

Latest scalafmt has a fix (https://github.com/scalameta/scalafmt/pull/1384) for concurrent scalafmt artifact downloads. Without the fix, scalafmt might fail, if the artifacts have not been downloaded yet.