### PR TITLE
Cache coursier data and sbt launchers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,8 +96,10 @@ before_cache:
 
 cache:
   directories:
+    - $HOME/.coursier
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot
+    - $HOME/.sbt/launchers
     - $HOME/.jabba/jdk
 
 env:


### PR DESCRIPTION
## Purpose

sbt launcher is being redownloaded on every sbt start.

coursier cache is where scalafmt artifacts are saved.