### PR TITLE
Typo in reference.conf

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -7,7 +7,7 @@ akka.kafka.producer {
   # Tuning parameter of how many sends that can run in parallel.
   parallelism = 100
 
-  # Duration to wait for `KafkaConsumer.close` to finish.
+  # Duration to wait for `KafkaProducer.close` to finish.
   close-timeout = 60s
 
   # Fully qualified config path which holds the dispatcher configuration


### PR DESCRIPTION
Change `KafkaConsumer` -> `KafkaProducer` typo.