### PR TITLE
New DSL for offset commit with no callback when using a committable source

### DIFF
--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -50,6 +50,7 @@ object ConsumerMessage {
   @DoNotInherit trait Committable {
     def commitScaladsl(): Future[Done]
     def commitJavadsl(): CompletionStage[Done]
+    def commitWithNoCallback(): Unit
 
     /**
      * Get a number of processed messages this committable contains

--- a/core/src/main/scala/akka/kafka/javadsl/Committer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Committer.scala
@@ -30,6 +30,13 @@ object Committer {
     scaladsl.Committer.batchFlow(settings).asJava
 
   /**
+   * Batches offsets and commits them to Kafka without acknowledging a successful commit callback.  Emits
+   * `CommittableOffsetBatch` for every committed batch.
+   */
+  def batchFlowWithNoCallback[C <: Committable](settings: CommitterSettings): Flow[C, CommittableOffsetBatch, NotUsed] =
+    scaladsl.Committer.batchFlowWithNoCallback(settings).asJava
+
+  /**
    * API MAY CHANGE
    *
    * Batches offsets from context and commits them to Kafka, emits no useful value, but keeps the committed
@@ -42,10 +49,28 @@ object Committer {
     scaladsl.Committer.flowWithOffsetContext[E](settings).asJava
 
   /**
+   * API MAY CHANGE
+   *
+   * Batches offsets and commits them to Kafka without acknowledging a successful commit callback.  Emits
+   * `CommittableOffsetBatch` for every committed batch.
+   */
+  @ApiMayChange
+  def flowWithOffsetContextAndNoCallback[E, C <: CommittableOffset](
+      settings: CommitterSettings
+  ): FlowWithContext[E, C, NotUsed, CommittableOffsetBatch, NotUsed] =
+    scaladsl.Committer.flowWithOffsetContextAndNoCallback(settings).asJava
+
+  /**
    * Batches offsets and commits them to Kafka.
    */
   def sink[C <: Committable](settings: CommitterSettings): Sink[C, CompletionStage[Done]] =
     scaladsl.Committer.sink(settings).mapMaterializedValue(_.toJava).asJava
+
+  /**
+   * Batches offsets and commits them to Kafka without acknowledging a successful commit callback.
+   */
+  def sinkWithNoCallback[C <: Committable](settings: CommitterSettings): Sink[C, CompletionStage[Done]] =
+    scaladsl.Committer.sinkWithNoCallback(settings).mapMaterializedValue(_.toJava).asJava
 
   /**
    * API MAY CHANGE
@@ -60,6 +85,22 @@ object Committer {
       .Flow[Pair[E, C]]
       .map(_.toScala)
       .toMat(scaladsl.Committer.sinkWithOffsetContext(settings))(akka.stream.scaladsl.Keep.right)
+      .mapMaterializedValue[CompletionStage[Done]](_.toJava)
+      .asJava[Pair[E, C]]
+
+  /**
+   * API MAY CHANGE
+   *
+   * Batches offsets and commits them to Kafka without acknowledging a successful commit callback.
+   */
+  @ApiMayChange
+  def sinkWithOffsetContextAndNoCallback[E, C <: CommittableOffset](
+      settings: CommitterSettings
+  ): Sink[Pair[E, C], CompletionStage[Done]] =
+    akka.stream.scaladsl
+      .Flow[Pair[E, C]]
+      .map(_.toScala)
+      .toMat(scaladsl.Committer.sinkWithOffsetContextAndNoCallback(settings))(akka.stream.scaladsl.Keep.right)
       .mapMaterializedValue[CompletionStage[Done]](_.toJava)
       .asJava[Pair[E, C]]
 }

--- a/testkit/src/main/scala/akka/kafka/testkit/ConsumerResultFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/ConsumerResultFactory.scala
@@ -26,6 +26,8 @@ object ConsumerResultFactory {
         offsets: immutable.Seq[ConsumerMessage.PartitionOffsetMetadata]
     ): Future[Done] = Future.successful(Done)
     override def commit(batch: ConsumerMessage.CommittableOffsetBatch): Future[Done] = Future.successful(Done)
+    override def commitWithNoCallback(offsets: immutable.Seq[ConsumerMessage.PartitionOffsetMetadata]): Unit = ()
+    override def commitWithNoCallback(offsets: ConsumerMessage.CommittableOffsetBatch): Unit = ()
   }
 
   def partitionOffset(groupId: String, topic: String, partition: Int, offset: Long): ConsumerMessage.PartitionOffset =


### PR DESCRIPTION
## Purpose

Allow the user to commit offsets back to Kafka asynchronously without waiting for a response.

## References

Issue #845

## Changes

* Add more options to the `Committer` and `Committable` DSLs to commit offsets without waiting for a callback

## Background Context

The `Committer.batchFlow` will use `mayAsync` to backpressure offset commit callbacks.  When we call `commitScalaDsl` we will use the Ask pattern to ask the `KafkaConsumerActor` to commit the offset map immediately (using `KafkaConsumer.commitAsync`) and reply with a response when the commit response is handled during a subsequent poll.  This implementation has the benefit of making sure we lose as few messages as possible in the event of a failure while using at least once message delivery, but it can also considerably slow down the whole consuming stream.  A compromise would be to commit and not wait for a reply which would allow the stream to process records faster, with the tradeoff of potentially reprocessing more records after a failure or rebalance.

This implementation provides the user with a DSL to "fire and forget" the commit so we don't back-pressure in the `Committer.flow` waiting for replies.  We also don't create the overhead of additional unnecessary callback threads, though the Kafka consumer will create threads internally for its default callback which logs errors when they occur.

I'm on the fence about calling the implementation "WithNoCallback".  I also considered calling it "Async", but since the original impl. is actually async as well this didn't seem appropriate.  I'm open to suggestions.

I can add doc updates once an initial review has been done.