### PR TITLE
Remove crossScalaVersion on root project

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -141,7 +141,6 @@ lazy val `alpakka-kafka` =
     .settings(commonSettings)
     .settings(
       skip in publish := true,
-      crossScalaVersions := Nil,
       dockerComposeIgnore := true,
       ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(core, testkit),
       onLoadMessage :=


### PR DESCRIPTION
As all projects in the build now support all cross scala versions, nil-ing it on the root can be removed.