### PR TITLE
Accumulate and commit offsets at poll time

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -134,13 +134,10 @@ akka.kafka.consumer {
 akka.kafka.committer {
 
   # Maximum number of messages in a single commit batch
-  max-batch = 1000
+  max-batch = 100000
 
   # Maximum interval between commits
-  max-interval = 10s
-
-  # Parallelsim for async committing
-  parallelism = 1
+  max-interval = 50ms
 }
 # // #committer-settings
 

--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -48,8 +48,13 @@ object ConsumerMessage {
    * This interface might move into `akka.stream`
    */
   @DoNotInherit trait Committable {
+    @deprecated("Commits responses no longer back pressure the committer.  Commits occur asynchronously at every poll.",
+                "1.0.5")
     def commitScaladsl(): Future[Done]
+    @deprecated("Commits responses no longer back pressure the committer.  Commits occur asynchronously at every poll.",
+                "1.0.5")
     def commitJavadsl(): CompletionStage[Done]
+    def commit(): Unit
 
     /**
      * Get a number of processed messages this committable contains

--- a/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
+++ b/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
@@ -142,9 +142,9 @@ private[kafka] trait OffsetContextBuilder[K, V]
 ) extends CommittableOffsetMetadata {
   private lazy val offsets = immutable.Seq(partitionOffset.withMetadata(metadata))
 
-  override def commitScaladsl(): Future[Done] = Future.successful {
-    committer.commit(offsets)
-    Done
+  override def commitScaladsl(): Future[Done] = {
+    commit()
+    Future.successful(Done)
   }
   override def commitJavadsl(): CompletionStage[Done] = commitScaladsl().toJava
   override def commit(): Unit = committer.commit(offsets)

--- a/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
@@ -222,10 +222,13 @@ object Consumer {
    * Convenience for "at-most once delivery" semantics. The offset of each message is committed to Kafka
    * before being emitted downstream.
    */
+  // TODO: this should probably be deprecated since it can no longer be guaranteed
+  //   we should guide the user to using auto commit interval setting of the Consumer to do this instead
   def atMostOnceSource[K, V](settings: ConsumerSettings[K, V],
                              subscription: Subscription): Source[ConsumerRecord[K, V], Control] =
-    committableSource[K, V](settings, subscription).mapAsync(1) { m =>
-      m.committableOffset.commitScaladsl().map(_ => m.record)(ExecutionContexts.sameThreadExecutionContext)
+    committableSource[K, V](settings, subscription).map { m =>
+      m.committableOffset.commit()
+      m.record
     }
 
   /**

--- a/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
@@ -70,7 +70,7 @@ object Producer {
       settings: ProducerSettings[K, V]
   ): Sink[Envelope[K, V, ConsumerMessage.Committable], Future[Done]] =
     flexiFlow[K, V, ConsumerMessage.Committable](settings)
-      .mapAsync(settings.parallelism)(_.passThrough.commitScaladsl())
+      .map(_.passThrough.commit())
       .toMat(Sink.ignore)(Keep.right)
 
   /**
@@ -118,7 +118,7 @@ object Producer {
       producer: org.apache.kafka.clients.producer.Producer[K, V]
   ): Sink[Envelope[K, V, ConsumerMessage.Committable], Future[Done]] =
     flexiFlow[K, V, ConsumerMessage.Committable](settings, producer)
-      .mapAsync(settings.parallelism)(_.passThrough.commitScaladsl())
+      .map(_.passThrough.commit())
       .toMat(Sink.ignore)(Keep.right)
 
   /**

--- a/testkit/src/main/scala/akka/kafka/testkit/ConsumerResultFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/ConsumerResultFactory.scala
@@ -5,7 +5,6 @@
 
 package akka.kafka.testkit
 
-import akka.Done
 import akka.annotation.ApiMayChange
 import akka.kafka.ConsumerMessage
 import akka.kafka.ConsumerMessage.{CommittableOffset, GroupTopicPartition, PartitionOffsetCommittedMarker}
@@ -13,7 +12,6 @@ import akka.kafka.internal.{CommittableOffsetImpl, InternalCommitter}
 import org.apache.kafka.clients.consumer.ConsumerRecord
 
 import scala.collection.immutable
-import scala.concurrent.Future
 
 /**
  * Factory methods to create instances that normally are emitted by [[akka.kafka.scaladsl.Consumer]] and [[akka.kafka.javadsl.Consumer]] flows.
@@ -22,10 +20,8 @@ import scala.concurrent.Future
 object ConsumerResultFactory {
 
   val fakeCommitter = new InternalCommitter {
-    override def commit(
-        offsets: immutable.Seq[ConsumerMessage.PartitionOffsetMetadata]
-    ): Future[Done] = Future.successful(Done)
-    override def commit(batch: ConsumerMessage.CommittableOffsetBatch): Future[Done] = Future.successful(Done)
+    override def commit(offsets: immutable.Seq[ConsumerMessage.PartitionOffsetMetadata]): Unit = ()
+    override def commit(batch: ConsumerMessage.CommittableOffsetBatch): Unit = ()
   }
 
   def partitionOffset(groupId: String, topic: String, partition: Int, offset: Long): ConsumerMessage.PartitionOffset =

--- a/tests/src/test/scala/akka/kafka/internal/ConsumerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConsumerSpec.scala
@@ -261,28 +261,30 @@ class ConsumerSpec(_system: ActorSystem)
     mock.verifyClosed()
   }
 
-  it should "complete futures with failure when commit after stop" in assertAllStagesStopped {
-    val commitLog = new ConsumerMock.LogHandler()
-    val mock = new ConsumerMock[K, V](commitLog)
-    val (control, probe) = createCommittableSource(mock.mock)
-      .toMat(TestSink.probe)(Keep.both)
-      .run()
-
-    val msg = createMessage(1)
-    mock.enqueue(List(toRecord(msg)))
-
-    probe.request(100)
-    val first = probe.expectNext()
-
-    val stopped = control.shutdown()
-    probe.expectComplete()
-    Await.result(stopped, remainingOrDefault)
-
-    val done = first.committableOffset.commitScaladsl()
-    intercept[CommitTimeoutException] {
-      Await.result(done, remainingOrDefault)
-    }
-  }
+  // TODO: the new implementation will only log an error when an exception is returned to the commit callback
+  //       is this test still required?
+//  it should "complete futures with failure when commit after stop" in assertAllStagesStopped {
+//    val commitLog = new ConsumerMock.LogHandler()
+//    val mock = new ConsumerMock[K, V](commitLog)
+//    val (control, probe) = createCommittableSource(mock.mock)
+//      .toMat(TestSink.probe)(Keep.both)
+//      .run()
+//
+//    val msg = createMessage(1)
+//    mock.enqueue(List(toRecord(msg)))
+//
+//    probe.request(100)
+//    val first = probe.expectNext()
+//
+//    val stopped = control.shutdown()
+//    probe.expectComplete()
+//    Await.result(stopped, remainingOrDefault)
+//
+//    val done = first.committableOffset.commitScaladsl()
+//    intercept[CommitTimeoutException] {
+//      Await.result(done, remainingOrDefault)
+//    }
+//  }
 
   it should "keep stage running after cancellation until all futures completed" in assertAllStagesStopped {
     val commitLog = new ConsumerMock.LogHandler()

--- a/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
@@ -363,6 +363,5 @@ class CommittingSpec extends SpecBase with TestcontainersKafkaLike with Inside {
                         "Should re-process at most maxBatch elements")
       probe1.cancel()
     }
-
   }
 }


### PR DESCRIPTION
## Purpose

This PR proposes 2 major changes to the offset committing.

1. Decouple back-pressure when committing offsets (background in #845)
2. Send accumulated commit requests asynchronously during the `akka.kafka.consumer.poll-interval` (inspired by comments in #849 and #850)

## Changes

* Replace ask pattern with a fire and forget commit request to the `KafkaConsumerActor`
* Accumulate commit requests in `KafkaConsumerActor`
* At poll time (`akka.kafka.consumer.poll-interval`) merge all commit requests and perform an asynchronous commit before fetching records.
* Throw a `akka.kafka.CommitTimeoutException` from the commit callback when the round trip takes greater than `akka.kafka.consumer.commit-timeout`.  This exception was previously thrown by the ask timeout handler in the `KafkaAsyncConsumerCommitterRef`.
* Commit any outstanding commit requests during graceful shutdown
* Deprecate `Committable.commitScaladsl` and `Committable.commitJavadsl` in favour of `Committable.commit` because we no longer need to return a `Future` or `CompletableFuture`.
* Remove `parallelism` from `CommitterSettings`

## More Proposed Changes

* Should we deprecate `CommitterSettings` altogether?  We can change all `Committer` flows to `groupedWithin` using the `akka.kafka.consumer.poll-interval`.  I can't think of a good reason to commit more frequently than this interval since commits will not be sent immediately to Kafka.
* Several tests are no longer relevant if we adopt this new approach to committing.  I've commented them out for now.