### PR TITLE
Commit refreshing not required after Kafka 2.1

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -64,6 +64,7 @@ akka.kafka.consumer {
   # Not used anymore (since 1.0-RC1)
   # max-wakeups = 10
 
+  # Not relevant for Kafka after version 2.1.0.
   # If set to a finite duration, the consumer will re-send the last committed offsets periodically
   # for all assigned partitions. See https://issues.apache.org/jira/browse/KAFKA-4682.
   commit-refresh-interval = infinite

--- a/docs/src/main/paradox/consumer.md
+++ b/docs/src/main/paradox/consumer.md
@@ -144,7 +144,7 @@ reference.conf
 
 The bigger the values are, the less load you put on Kafka and the smaller are chances that committing offsets will become a bottleneck. However, increasing these values also means that in case of a failure you will have to re-process more messages. 
 
-If you consume from a topic with low activity, and possibly no messages arrive for more than 24 hours, consider enabling periodical commit refresh (`akka.kafka.consumer.commit-refresh-interval` configuration parameters), otherwise offsets might expire in the Kafka storage.
+If you use Kafka older than version 2.1.0 and consume from a topic with low activity, and possibly no messages arrive for more than 24 hours, consider enabling periodical commit refresh (`akka.kafka.consumer.commit-refresh-interval` configuration parameters), otherwise offsets might expire in the Kafka storage. This has been fixed in Kafka 2.1.0 (See [KAFKA-4682](https://issues.apache.org/jira/browse/KAFKA-4682)).
 
 #### Committer variants
 

--- a/docs/src/main/paradox/home.md
+++ b/docs/src/main/paradox/home.md
@@ -14,7 +14,7 @@ This **Alpakka Kafka connector** lets you connect [Apache Kafka](https://kafka.a
 |-------------|----------------|--------------|-------------------------
 |[2.1.1](https://dist.apache.org/repos/dist/release/kafka/2.1.1/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.x        | @ref:[release 1.0.4](release-notes/1.0.x.md#1-0-4)
 |[2.1.1](https://dist.apache.org/repos/dist/release/kafka/2.1.1/RELEASE_NOTES.html) | 2.12, 2.11       | 2.5.x        | @ref:[release 1.0.1](release-notes/1.0.x.md#1-0-1)
-|[2.1.0](https://dist.apache.org/repos/dist/release/kafka/2.1.0/RELEASE_NOTES.html) | 2.12, 2.11       | 2.5.x        | @ref:[release 1.0](release-notes/1.0.x.md#1-0)
+|[2.1.0](https://archive.apache.org/dist/kafka/2.1.0/RELEASE_NOTES.html) | 2.12, 2.11       | 2.5.x        | @ref:[release 1.0](release-notes/1.0.x.md#1-0)
 |2.0.x        | 2.12, 2.11 | 2.5.x        | @ref:[release 1.0-M1](release-notes/1.0-M1.md)
 |1.1.x        | 2.12, 2.11 | 2.5.x        | [release 0.20+](https://github.com/akka/reactive-kafka/releases)
 |1.0.x        | 2.12, 2.11 | 2.5.x        | [release 0.20+](https://github.com/akka/reactive-kafka/releases)
@@ -22,7 +22,7 @@ This **Alpakka Kafka connector** lets you connect [Apache Kafka](https://kafka.a
 
 @@@ note
 
-As Kakfka's client protocol negotiates the version to use with the Kafka broker, you may use a Kafka client version that is different than the Kafka broker's version.
+As Kafka's client protocol negotiates the version to use with the Kafka broker, you may use a Kafka client version that is different than the Kafka broker's version.
 
 These client can communicate with brokers that are version 0.10.0 or newer. Older or newer brokers may not support certain features. For example, 0.10.0 brokers do not support offsetsForTimes, because this feature was added in version 0.10.1. You will receive an UnsupportedVersionException when invoking an API that is not available on the running broker version.
 


### PR DESCRIPTION
## Purpose

Let users know that commit refreshing is not required after Kafka 2.1.0.

## References

https://github.com/akka/alpakka-kafka/pull/375
https://github.com/akka/alpakka-kafka/pull/701
