### PR TITLE
ConsumerSetting: Add group instance id setter

### DIFF
--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -234,6 +234,12 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
     withProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId)
 
   /**
+    * An id string that marks consumer as a unique static member of the consumer group.
+    */
+  def withGroupInstanceId(groupInstanceId: String): ConsumerSettings[K, V] =
+    withProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, groupInstanceId)
+
+  /**
    * Scala API:
    * The raw properties of the kafka-clients driver, see constants in
    * [[org.apache.kafka.clients.consumer.ConsumerConfig]].

--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -234,8 +234,8 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
     withProperty(ConsumerConfig.GROUP_ID_CONFIG, groupId)
 
   /**
-    * An id string that marks consumer as a unique static member of the consumer group.
-    */
+   * An id string that marks consumer as a unique static member of the consumer group.
+   */
   def withGroupInstanceId(groupInstanceId: String): ConsumerSettings[K, V] =
     withProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, groupInstanceId)
 


### PR DESCRIPTION
## Purpose

Update Kafka dependency and add method `withGroupInstanceId` to `ConsumerSettings`.

## References

References #859
