### PR TITLE
Aggregate offsets and commit before poll

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -140,7 +140,7 @@ akka.kafka.committer {
   max-interval = 10s
 
   # Parallelsim for async committing
-  parallelism = 1
+  parallelism = 100
 }
 # // #committer-settings
 

--- a/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
@@ -29,7 +29,7 @@ object Committer {
     Flow[Committable]
       .groupedWeightedWithin(settings.maxBatch, settings.maxInterval)(_.batchSize)
       .map(CommittableOffsetBatch.apply)
-      .mapAsync(settings.parallelism) { b =>
+      .mapAsyncUnordered(settings.parallelism) { b =>
         b.commitScaladsl().map(_ => b)(ExecutionContexts.sameThreadExecutionContext)
       }
 

--- a/tests/src/test/scala/akka/kafka/internal/CommittingWithMockSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingWithMockSpec.scala
@@ -199,7 +199,7 @@ class CommittingWithMockSpec(_system: ActorSystem)
     Await.result(control.shutdown(), remainingOrDefault)
   }
 
-  it should "call commitAsync for every commit message (no commit batching)" in assertAllStagesStopped {
+  it should "collect commits to be sent in one commitAsync" in assertAllStagesStopped {
     val commitLog = new ConsumerMock.LogHandler()
     val mock = new ConsumerMock[K, V](commitLog)
     val (control, probe) = createCommittableSource(mock.mock)
@@ -213,7 +213,7 @@ class CommittingWithMockSpec(_system: ActorSystem)
     val done = Future.sequence(probe.expectNextN(100).map(_.committableOffset.commitScaladsl()))
 
     awaitAssert {
-      commitLog.calls should have size (100)
+      commitLog.calls should have size (1)
     }
 
     //emulate commit

--- a/tests/src/test/scala/akka/kafka/internal/OffsetAggregationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/OffsetAggregationSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.internal
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.requests.OffsetFetchResponse
+import org.scalatest.{Matchers, WordSpecLike}
+
+class OffsetAggregationSpec extends WordSpecLike with Matchers {
+
+  val topicA = "topicA"
+  val topicB = "topicB"
+
+  "aggregateOffsets" should {
+    "give all offsets for one element" in {
+      val in = Map(new TopicPartition(topicA, 1) -> new OffsetAndMetadata(12, OffsetFetchResponse.NO_METADATA))
+      KafkaConsumerActor.aggregateOffsets(List(in)) shouldBe in
+    }
+
+    "give the highest offsets" in {
+      val in1 = Map(new TopicPartition(topicA, 1) -> new OffsetAndMetadata(42, OffsetFetchResponse.NO_METADATA))
+      val in2 = Map(new TopicPartition(topicA, 1) -> new OffsetAndMetadata(12, OffsetFetchResponse.NO_METADATA))
+      KafkaConsumerActor.aggregateOffsets(List(in1, in2)) shouldBe in1
+    }
+
+    "give the highest offsets (other order)" in {
+      val in1 = Map(new TopicPartition(topicA, 1) -> new OffsetAndMetadata(42, OffsetFetchResponse.NO_METADATA))
+      val in2 = Map(new TopicPartition(topicA, 1) -> new OffsetAndMetadata(12, OffsetFetchResponse.NO_METADATA))
+      KafkaConsumerActor.aggregateOffsets(List(in2, in1)) shouldBe in1
+    }
+
+    "give the highest offsets (when mixed)" in {
+      val in1 = Map(
+        new TopicPartition(topicA, 1) -> new OffsetAndMetadata(42, OffsetFetchResponse.NO_METADATA),
+        new TopicPartition(topicB, 1) -> new OffsetAndMetadata(11, OffsetFetchResponse.NO_METADATA)
+      )
+      val in2 = Map(
+        new TopicPartition(topicA, 1) -> new OffsetAndMetadata(12, OffsetFetchResponse.NO_METADATA),
+        new TopicPartition(topicB, 1) -> new OffsetAndMetadata(43, OffsetFetchResponse.NO_METADATA)
+      )
+      KafkaConsumerActor.aggregateOffsets(List(in1, in2)) shouldBe Map(
+        new TopicPartition(topicA, 1) -> new OffsetAndMetadata(42, OffsetFetchResponse.NO_METADATA),
+        new TopicPartition(topicB, 1) -> new OffsetAndMetadata(43, OffsetFetchResponse.NO_METADATA)
+      )
+    }
+  }
+
+}

--- a/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
@@ -49,7 +49,7 @@ class CommittingSpec extends SpecBase with TestcontainersKafkaLike with Inside {
         .committableSource(consumerSettings, Subscriptions.topics(topic1))
         .mapAsync(10) { elem =>
           elem.committableOffset.commitScaladsl().map { _ =>
-            committedElements.set(elem.record.value.toInt)
+            committedElements.updateAndGet(v => Math.max(v, elem.record.value.toInt))
             elem.record.value
           }
         }

--- a/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
@@ -6,6 +6,7 @@
 package akka.kafka.scaladsl
 
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.function.IntUnaryOperator
 
 import akka.kafka.ConsumerMessage.CommittableOffsetBatch
 import akka.kafka.ProducerMessage.MultiMessage
@@ -49,7 +50,9 @@ class CommittingSpec extends SpecBase with TestcontainersKafkaLike with Inside {
         .committableSource(consumerSettings, Subscriptions.topics(topic1))
         .mapAsync(10) { elem =>
           elem.committableOffset.commitScaladsl().map { _ =>
-            committedElements.updateAndGet(v => Math.max(v, elem.record.value.toInt))
+            committedElements.updateAndGet(new IntUnaryOperator {
+              override def applyAsInt(operand: Int): Int = Math.max(operand, elem.record.value.toInt)
+            })
             elem.record.value
           }
         }


### PR DESCRIPTION
## Purpose

Reduce calls to `consumer.commitAsync` by aggregating commits in the actor and sending them just before polling.

## References

Idea explained in #849
Implementation partly stolen from #851 

## Changes

The almost unchanged tests indicate that this doesn't change the behaviour a lot.

This change may make a commit wait until the next poll (default 50 ms). To fully make use of this, the committer defaults should be changed.
