### PR TITLE
Extra poll after receiving commit data

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -286,6 +286,7 @@ import scala.util.control.NonFatal
       // prepending, as later received offsets most likely are higher
       commitMaps = offsets :: commitMaps
       commitSenders = commitSenders :+ sender()
+      requestExtraPoll()
 
     case s: SubscriptionRequest =>
       subscriptions = subscriptions + s
@@ -303,15 +304,9 @@ import scala.util.control.NonFatal
       checkOverlappingRequests("RequestMessages", sender(), req.topics)
       requests = requests.updated(sender(), req)
       requestors += sender()
-      // When many requestors, e.g. many partitions with committablePartitionedSource the
-      // performance is much improved by collecting more requests/commits before performing the poll.
-      // That is done by sending a message to self, and thereby collect pending messages in mailbox.
       if (requestors.size == 1)
         poll()
-      else if (!delayedPollInFlight) {
-        delayedPollInFlight = true
-        self ! delayedPollMsg
-      }
+      else requestExtraPoll()
 
     case Stop =>
       commitAggregatedOffsets()
@@ -410,6 +405,19 @@ import scala.util.control.NonFatal
 
   def schedulePollTask(): Unit =
     timers.startSingleTimer(PollTask, pollMsg, settings.pollInterval)
+
+  /**
+   * Sends an extra `Poll` request to self.
+   * Enqueing an extra poll via the actor mailbox allows other requests to be handled
+   * before the actual poll is executed.
+   *  When many requestors, e.g. many partitions with committablePartitionedSource the
+   * performance is much improved by collecting more requests/commits before performing the poll.
+   */
+  private def requestExtraPoll(): Unit =
+    if (!delayedPollInFlight) {
+      delayedPollInFlight = true
+      self ! delayedPollMsg
+    }
 
   private def receivePoll(p: Poll[_, _]): Unit =
     if (p.target == this) {

--- a/tests/src/test/scala/akka/kafka/internal/CommittingWithMockSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingWithMockSpec.scala
@@ -199,21 +199,26 @@ class CommittingWithMockSpec(_system: ActorSystem)
     Await.result(control.shutdown(), remainingOrDefault)
   }
 
-  it should "collect commits to be sent in one commitAsync" in assertAllStagesStopped {
+  it should "collect commits to be sent to commitAsync" in assertAllStagesStopped {
     val commitLog = new ConsumerMock.LogHandler()
     val mock = new ConsumerMock[K, V](commitLog)
     val (control, probe) = createCommittableSource(mock.mock)
       .toMat(TestSink.probe)(Keep.both)
       .run()
 
-    val msgs = (1 to 100).map(createMessage)
+    val count = 100
+    val msgs = (1 to count).map(createMessage)
     mock.enqueue(msgs.map(toRecord))
 
-    probe.request(100)
-    val done = Future.sequence(probe.expectNextN(100).map(_.committableOffset.commitScaladsl()))
+    probe.request(count.toLong)
+    val done = Future.sequence(probe.expectNextN(count.toLong).map(_.committableOffset.commitScaladsl()))
 
-    awaitAssert {
-      commitLog.calls should have size (1)
+    withClue("the commits are aggregated to a low number of calls to commitAsync:") {
+      awaitAssert {
+        val callsToCommitAsync = commitLog.calls.size
+        callsToCommitAsync should be > 1
+        callsToCommitAsync should be < count / 10
+      }
     }
 
     //emulate commit

--- a/tests/src/test/scala/akka/kafka/internal/CommittingWithMockSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingWithMockSpec.scala
@@ -216,7 +216,7 @@ class CommittingWithMockSpec(_system: ActorSystem)
     withClue("the commits are aggregated to a low number of calls to commitAsync:") {
       awaitAssert {
         val callsToCommitAsync = commitLog.calls.size
-        callsToCommitAsync should be > 1
+        callsToCommitAsync should be >= 1
         callsToCommitAsync should be < count / 10
       }
     }


### PR DESCRIPTION
## Purpose

Trigger a poll after receiving commit data so that the commit will be executed earlier than the scheduled poll, but still allowing more commits to arrive before the poll is made.

## References

Follow-up on #862 as the "at-most-once" benchmarks showed very slow consumption when committing one message at a time.