### PR TITLE
Special casing single offset committing

### DIFF
--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/Benchmarks.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/Benchmarks.scala
@@ -80,15 +80,17 @@ class ApacheKafkaBatchedConsumer extends BenchmarksBase() {
 }
 
 class AlpakkaKafkaBatchedConsumer extends BenchmarksBase() {
+  val factor = 1
+
   it should "bench with small messages" in {
-    val cmd = RunTestCommand("alpakka-kafka-batched-consumer", bootstrapServers, 1000 * 1000, 100)
+    val cmd = RunTestCommand("alpakka-kafka-batched-consumer", bootstrapServers, 1000 * factor, 100)
     runPerfTest(cmd,
                 ReactiveKafkaConsumerFixtures.committableSources(cmd),
                 ReactiveKafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
   }
 
   it should "bench with normal messages" in {
-    val cmd = RunTestCommand("alpakka-kafka-batched-consumer-normal-msg", bootstrapServers, 1000 * 1000, 5 * 1000)
+    val cmd = RunTestCommand("alpakka-kafka-batched-consumer-normal-msg", bootstrapServers, 1000 * factor, 5 * 1000)
     runPerfTest(cmd,
                 ReactiveKafkaConsumerFixtures.committableSources(cmd),
                 ReactiveKafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
@@ -97,7 +99,7 @@ class AlpakkaKafkaBatchedConsumer extends BenchmarksBase() {
   it should "bench with normal messages and eight partitions" in {
     val cmd = RunTestCommand("alpakka-kafka-batched-consumer-normal-msg-8-partitions",
                              bootstrapServers,
-                             msgCount = 1000 * 1000,
+                             msgCount = 1000 * factor,
                              msgSize = 5 * 1000,
                              numberOfPartitions = 8)
     runPerfTest(cmd,
@@ -115,7 +117,7 @@ class ApacheKafkaAtMostOnceConsumer extends BenchmarksBase() {
 
 class AlpakkaKafkaAtMostOnceConsumer extends BenchmarksBase() {
   it should "bench" in {
-    val cmd = RunTestCommand("alpakka-kafka-at-most-once-consumer", bootstrapServers, 50000, 100)
+    val cmd = RunTestCommand("alpakka-kafka-at-most-once-consumer", bootstrapServers, 500, 100)
     runPerfTest(cmd,
                 ReactiveKafkaConsumerFixtures.committableSources(cmd),
                 ReactiveKafkaConsumerBenchmarks.consumeCommitAtMostOnce)

--- a/testkit/src/main/scala/akka/kafka/testkit/ConsumerResultFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/ConsumerResultFactory.scala
@@ -12,7 +12,6 @@ import akka.kafka.ConsumerMessage.{CommittableOffset, GroupTopicPartition, Parti
 import akka.kafka.internal.{CommittableOffsetImpl, KafkaAsyncConsumerCommitterRef}
 import org.apache.kafka.clients.consumer.ConsumerRecord
 
-import scala.collection.immutable
 import scala.concurrent.Future
 
 /**

--- a/testkit/src/main/scala/akka/kafka/testkit/ConsumerResultFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/ConsumerResultFactory.scala
@@ -9,7 +9,7 @@ import akka.Done
 import akka.annotation.ApiMayChange
 import akka.kafka.ConsumerMessage
 import akka.kafka.ConsumerMessage.{CommittableOffset, GroupTopicPartition, PartitionOffsetCommittedMarker}
-import akka.kafka.internal.{CommittableOffsetImpl, InternalCommitter}
+import akka.kafka.internal.{CommittableOffsetImpl, KafkaAsyncConsumerCommitterRef}
 import org.apache.kafka.clients.consumer.ConsumerRecord
 
 import scala.collection.immutable
@@ -21,10 +21,8 @@ import scala.concurrent.Future
 @ApiMayChange
 object ConsumerResultFactory {
 
-  val fakeCommitter = new InternalCommitter {
-    override def commit(
-        offsets: immutable.Seq[ConsumerMessage.PartitionOffsetMetadata]
-    ): Future[Done] = Future.successful(Done)
+  val fakeCommitter: KafkaAsyncConsumerCommitterRef = new KafkaAsyncConsumerCommitterRef(null, null)(ec = null) {
+    override def commitSingle(offset: CommittableOffsetImpl): Future[Done] = Future.successful(Done)
     override def commit(batch: ConsumerMessage.CommittableOffsetBatch): Future[Done] = Future.successful(Done)
   }
 


### PR DESCRIPTION
## Purpose

Introduce a special case for committing without batches which require the poll do be triggered so that the backpressure is lifted.

## Changes

* Special actor message for the case that just a single offset is committed
* Remove the `InternalCommitter` interface

## Background Context

The benchmarks show that the `atMostOnce` cases break when using commit aggregation, but other the adding an extra delayed poll erases some of the optimisation seen without it.