### PR TITLE
Micro optimisation: Check batchSize to avoid map transformation

### DIFF
--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -5,7 +5,7 @@
 
 package akka.kafka
 
-import java.util.{Objects, Map => JMap}
+import java.util.Objects
 import java.util.concurrent.CompletionStage
 
 import akka.Done
@@ -195,7 +195,7 @@ object ConsumerMessage {
     /**
      * Java API: Get current offset positions
      */
-    def getOffsets(): JMap[GroupTopicPartition, Long]
+    def getOffsets(): java.util.Map[GroupTopicPartition, Long]
 
   }
 

--- a/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
+++ b/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
@@ -5,7 +5,6 @@
 
 package akka.kafka.internal
 import java.util.concurrent.CompletionStage
-import java.util.{Map => JMap}
 
 import akka.Done
 import akka.annotation.InternalApi
@@ -172,7 +171,7 @@ private[kafka] final class CommittableOffsetBatchImpl(
     val committers: Map[String, InternalCommitter],
     override val batchSize: Long
 ) extends CommittableOffsetBatch {
-  def offsets = offsetsAndMetadata.view.mapValues(_.offset()).toMap
+  def offsets: Map[GroupTopicPartition, Long] = offsetsAndMetadata.view.mapValues(_.offset()).toMap
 
   def updated(committable: Committable): CommittableOffsetBatch = committable match {
     case offset: CommittableOffset => updatedWithOffset(offset)
@@ -244,14 +243,14 @@ private[kafka] final class CommittableOffsetBatchImpl(
         )
     }
 
-  override def getOffsets(): JMap[GroupTopicPartition, Long] =
+  override def getOffsets(): java.util.Map[GroupTopicPartition, Long] =
     offsets.asJava
 
   override def toString(): String =
-    s"CommittableOffsetBatch(${offsets.mkString("->")})"
+    s"CommittableOffsetBatch(batchSize=$batchSize, ${offsetsAndMetadata.mkString("->")})"
 
   override def commitScaladsl(): Future[Done] =
-    if (offsets.isEmpty)
+    if (batchSize == 0L)
       Future.successful(Done)
     else {
       committers.head._2.commit(this)


### PR DESCRIPTION
## Purpose

Optimising `CommittableOffsetBatchImpl.commitScalaDsl` by checking the number of collected offsets instead of the map.

## Changes

* Some better type annotations
* Add batch size, and use offset and metadata in `toString`