### PR TITLE
Offset batch: remove intermediary structure 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -100,7 +100,7 @@ val commonSettings = Def.settings(
         Seq(
           "-doc-source-url", {
             val branch = if (isSnapshot.value) "master" else s"v${version.value}"
-            s"https://github.com/akka/alpakka-kafka/tree/${branch}€{FILE_PATH_EXT}#€{FILE_LINE}"
+            s"https://github.com/akka/alpakka-kafka/tree/${branch}€{FILE_PATH_EXT}#L€{FILE_LINE}"
           },
           "-doc-canonical-base-url",
           "https://doc.akka.io/api/alpakka-kafka/current/"

--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -12,6 +12,7 @@ import akka.Done
 import akka.annotation.{DoNotInherit, InternalApi}
 import akka.kafka.internal.{CommittableOffsetBatchImpl, CommittedMarker}
 import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.common.TopicPartition
 
 import scala.concurrent.Future
 import scala.runtime.AbstractFunction2
@@ -137,7 +138,9 @@ object ConsumerMessage {
       groupId: String,
       topic: String,
       partition: Int
-  )
+  ) {
+    def topicPartition: TopicPartition = new TopicPartition(topic, partition)
+  }
 
   object CommittableOffsetBatch {
     val empty: CommittableOffsetBatch = new CommittableOffsetBatchImpl(Map.empty, Map.empty, 0)

--- a/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
+++ b/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
@@ -162,7 +162,7 @@ private[kafka] final class CommittableOffsetBatchImpl(
     val committers: Map[String, KafkaAsyncConsumerCommitterRef],
     override val batchSize: Long
 ) extends CommittableOffsetBatch {
-  def offsets: Map[GroupTopicPartition, Long] = offsetsAndMetadata.view.mapValues(_.offset()).toMap
+  def offsets: Map[GroupTopicPartition, Long] = offsetsAndMetadata.view.mapValues(_.offset() - 1L).toMap
 
   def updated(committable: Committable): CommittableOffsetBatch = committable match {
     case offset: CommittableOffset => updatedWithOffset(offset)
@@ -180,7 +180,7 @@ private[kafka] final class CommittableOffsetBatchImpl(
     }
 
     val newOffsets =
-      offsetsAndMetadata.updated(key, new OffsetAndMetadata(committableOffset.partitionOffset.offset, metadata))
+      offsetsAndMetadata.updated(key, new OffsetAndMetadata(committableOffset.partitionOffset.offset + 1L, metadata))
 
     val committer = committableOffset match {
       case c: CommittableOffsetImpl => c.committer
@@ -238,7 +238,7 @@ private[kafka] final class CommittableOffsetBatchImpl(
     offsets.asJava
 
   override def toString(): String =
-    s"CommittableOffsetBatch(batchSize=$batchSize, ${offsetsAndMetadata.mkString("->")})"
+    s"CommittableOffsetBatch(batchSize=$batchSize, ${offsets.mkString(", ")})"
 
   override def commitScaladsl(): Future[Done] =
     if (batchSize == 0L)


### PR DESCRIPTION
## Purpose

Convert the `Map[GroupTopicPartition, OffsetAndMetadata]` directly into a `Map[TopicPartition, OffsetAndMetadata]` to be sent to the consumer actor.

## Changes

* Move the location where the `offset + 1` is applied
* Change `toString` back to just show the offsets

## Background Context

Before sending offsets in `KafkaAsyncConsumerCommitterRef` the map was first transformed to a `Seq[PartitionOffsetMetadata]` (unpacking the `OffsetWithMetaData`) and than back to a `Map[TopicPartition, OffsetAndMetadata]` in the `commit` method.
By mapping directly less intermediary objects are created. The `OffsetAndMetadata` can be kept, but the `offset + 1` needed to be applied when building the batch in `CommittableOffsetBatchImpl` instead. The public `offsets` method compensates for that.