### PR TITLE
Introduce API for committing without backpressure

### DIFF
--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/Benchmarks.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/Benchmarks.scala
@@ -11,6 +11,8 @@ import org.scalatest.FlatSpecLike
 import scala.concurrent.duration._
 
 abstract class BenchmarksBase() extends ScalatestKafkaSpec(0) with FlatSpecLike {
+
+  // Message count multiplier to adapt for shorter local testing
   val factor = 1000
 
   override def bootstrapServers: String =
@@ -56,14 +58,14 @@ class AlpakkaKafkaPlainConsumer extends BenchmarksBase() {
 
 class ApacheKafkaBatchedConsumer extends BenchmarksBase() {
   it should "bench with small messages" in {
-    val cmd = RunTestCommand("apache-kafka-batched-consumer", bootstrapServers, 1000 * 1000, 100)
+    val cmd = RunTestCommand("apache-kafka-batched-consumer", bootstrapServers, 1000 * factor, 100)
     runPerfTest(cmd,
                 KafkaConsumerFixtures.filledTopics(cmd),
                 KafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
   }
 
   it should "bench with normal messages" in {
-    val cmd = RunTestCommand("apache-kafka-batched-consumer-normal-msg", bootstrapServers, 1000 * 1000, 5 * 1000)
+    val cmd = RunTestCommand("apache-kafka-batched-consumer-normal-msg", bootstrapServers, 1000 * factor, 5 * 1000)
     runPerfTest(cmd,
                 KafkaConsumerFixtures.filledTopics(cmd),
                 KafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
@@ -72,7 +74,7 @@ class ApacheKafkaBatchedConsumer extends BenchmarksBase() {
   it should "bench with normal messages and eight partitions" in {
     val cmd = RunTestCommand("apache-kafka-batched-consumer-normal-msg-8-partitions",
                              bootstrapServers,
-                             msgCount = 1000 * 1000,
+                             msgCount = 1000 * factor,
                              msgSize = 5 * 1000,
                              numberOfPartitions = 8)
     runPerfTest(cmd,
@@ -165,14 +167,14 @@ class AlpakkaKafkaPlainProducer extends BenchmarksBase() {
 
 class ApacheKafkaTransactions extends BenchmarksBase() {
   it should "bench with small messages" in {
-    val cmd = RunTestCommand("apache-kafka-transactions", bootstrapServers, 100 * 1000, 100)
+    val cmd = RunTestCommand("apache-kafka-transactions", bootstrapServers, 100 * factor, 100)
     runPerfTest(cmd,
                 KafkaTransactionFixtures.initialize(cmd),
                 KafkaTransactionBenchmarks.consumeTransformProduceTransaction(commitInterval = 100.milliseconds))
   }
 
   it should "bench with normal messages" in {
-    val cmd = RunTestCommand("apache-kafka-transactions-normal-msg", bootstrapServers, 100 * 1000, 5000)
+    val cmd = RunTestCommand("apache-kafka-transactions-normal-msg", bootstrapServers, 100 * factor, 5000)
     runPerfTest(cmd,
                 KafkaTransactionFixtures.initialize(cmd),
                 KafkaTransactionBenchmarks.consumeTransformProduceTransaction(commitInterval = 100.milliseconds))
@@ -181,7 +183,7 @@ class ApacheKafkaTransactions extends BenchmarksBase() {
 
 class AlpakkaKafkaTransactions extends BenchmarksBase() {
   it should "bench with small messages" in {
-    val cmd = RunTestCommand("alpakka-kafka-transactions", bootstrapServers, 100 * 1000, 100)
+    val cmd = RunTestCommand("alpakka-kafka-transactions", bootstrapServers, 100 * factor, 100)
     runPerfTest(
       cmd,
       ReactiveKafkaTransactionFixtures.transactionalSourceAndSink(cmd, commitInterval = 100.milliseconds),
@@ -190,7 +192,7 @@ class AlpakkaKafkaTransactions extends BenchmarksBase() {
   }
 
   it should "bench with normal messages" in {
-    val cmd = RunTestCommand("alpakka-kafka-transactions-normal-msg", bootstrapServers, 100 * 1000, 5000)
+    val cmd = RunTestCommand("alpakka-kafka-transactions-normal-msg", bootstrapServers, 100 * factor, 5000)
     runPerfTest(
       cmd,
       ReactiveKafkaTransactionFixtures.transactionalSourceAndSink(cmd, commitInterval = 100.milliseconds),

--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/NoCommitBackpressure.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/NoCommitBackpressure.scala
@@ -3,21 +3,21 @@ package akka.kafka.benchmarks
 import akka.kafka.benchmarks.Timed.runPerfTest
 import akka.kafka.benchmarks.app.RunTestCommand
 
-class ApacheKafkaBatchedNoPausingConsumer extends BenchmarksBase() {
+class RawKafkaCommitEveryPollConsumer extends BenchmarksBase() {
   private val prefix = "apache-kafka-batched-no-pausing-"
 
   it should "bench with small messages" in {
     val cmd = RunTestCommand(prefix + "consumer", bootstrapServers, 1000 * factor, 100)
     runPerfTest(cmd,
       KafkaConsumerFixtures.filledTopics(cmd),
-      KafkaConsumerBenchmarks.consumerAtLeastOnceBatchedNoPausing(batchSize = 1000))
+      KafkaConsumerBenchmarks.consumerAtLeastOnceCommitEveryPoll())
   }
 
   it should "bench with normal messages" in {
     val cmd = RunTestCommand(prefix + "consumer-normal-msg", bootstrapServers, 1000 * factor, 5 * 1000)
     runPerfTest(cmd,
       KafkaConsumerFixtures.filledTopics(cmd),
-      KafkaConsumerBenchmarks.consumerAtLeastOnceBatchedNoPausing(batchSize = 1000))
+      KafkaConsumerBenchmarks.consumerAtLeastOnceCommitEveryPoll())
   }
 
   it should "bench with normal messages and eight partitions" in {
@@ -28,11 +28,11 @@ class ApacheKafkaBatchedNoPausingConsumer extends BenchmarksBase() {
       numberOfPartitions = 8)
     runPerfTest(cmd,
       KafkaConsumerFixtures.filledTopics(cmd),
-      KafkaConsumerBenchmarks.consumerAtLeastOnceBatchedNoPausing(batchSize = 1000))
+      KafkaConsumerBenchmarks.consumerAtLeastOnceCommitEveryPoll())
   }
 }
 
-class AlpakkaKafkaCommitAndForgetConsumer extends BenchmarksBase() {
+class AlpakkaCommitAndForgetConsumer extends BenchmarksBase() {
   val prefix = "alpakka-kafka-commit-and-forget-"
 
   it should "bench with small messages" in {

--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/NoCommitBackpressure.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/NoCommitBackpressure.scala
@@ -1,0 +1,63 @@
+package akka.kafka.benchmarks
+
+import akka.kafka.benchmarks.Timed.runPerfTest
+import akka.kafka.benchmarks.app.RunTestCommand
+
+class ApacheKafkaBatchedNoPausingConsumer extends BenchmarksBase() {
+  private val prefix = "apache-kafka-batched-no-pausing-"
+
+  it should "bench with small messages" in {
+    val cmd = RunTestCommand(prefix + "consumer", bootstrapServers, 1000 * factor, 100)
+    runPerfTest(cmd,
+      KafkaConsumerFixtures.filledTopics(cmd),
+      KafkaConsumerBenchmarks.consumerAtLeastOnceBatchedNoPausing(batchSize = 1000))
+  }
+
+  it should "bench with normal messages" in {
+    val cmd = RunTestCommand(prefix + "consumer-normal-msg", bootstrapServers, 1000 * factor, 5 * 1000)
+    runPerfTest(cmd,
+      KafkaConsumerFixtures.filledTopics(cmd),
+      KafkaConsumerBenchmarks.consumerAtLeastOnceBatchedNoPausing(batchSize = 1000))
+  }
+
+  it should "bench with normal messages and eight partitions" in {
+    val cmd = RunTestCommand(prefix + "consumer-normal-msg-8-partitions",
+      bootstrapServers,
+      msgCount = 1000 * factor,
+      msgSize = 5 * 1000,
+      numberOfPartitions = 8)
+    runPerfTest(cmd,
+      KafkaConsumerFixtures.filledTopics(cmd),
+      KafkaConsumerBenchmarks.consumerAtLeastOnceBatchedNoPausing(batchSize = 1000))
+  }
+}
+
+class AlpakkaKafkaCommitAndForgetConsumer extends BenchmarksBase() {
+  val prefix = "alpakka-kafka-commit-and-forget-"
+
+  it should "bench with small messages" in {
+    val cmd = RunTestCommand(prefix + "consumer", bootstrapServers, 1000 * factor, 100)
+    runPerfTest(cmd,
+      ReactiveKafkaConsumerFixtures.committableSources(cmd),
+      ReactiveKafkaConsumerBenchmarks.consumerCommitAndForget(commitBatchSize = 1000))
+  }
+
+  it should "bench with normal messages" in {
+    val cmd = RunTestCommand(prefix + "normal-msg", bootstrapServers, 1000 * factor, 5 * 1000)
+    runPerfTest(cmd,
+      ReactiveKafkaConsumerFixtures.committableSources(cmd),
+      ReactiveKafkaConsumerBenchmarks.consumerCommitAndForget(commitBatchSize = 1000))
+  }
+
+  it should "bench with normal messages and eight partitions" in {
+    val cmd = RunTestCommand(prefix + "normal-msg-8-partitions",
+      bootstrapServers,
+      msgCount = 1000 * factor,
+      msgSize = 5 * 1000,
+      numberOfPartitions = 8)
+    runPerfTest(cmd,
+      ReactiveKafkaConsumerFixtures.committableSources(cmd),
+      ReactiveKafkaConsumerBenchmarks.consumerCommitAndForget(commitBatchSize = 1000))
+  }
+}
+

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaConsumerBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaConsumerBenchmarks.scala
@@ -68,14 +68,17 @@ object KafkaConsumerBenchmarks extends LazyLogging {
   def consumerAtLeastOnceBatched(batchSize: Int)(fixture: KafkaConsumerTestFixture, meter: Meter): Unit = {
     val consumer = fixture.consumer
 
-    var lastProcessedOffset = 0L
+    var lastProcessedOffset = Map.empty[Int, Long]
     var accumulatedMsgCount = 0L
     var commitInProgress = false
     val assignment = consumer.assignment()
 
     def doCommit(): Unit = {
       accumulatedMsgCount = 0
-      val offsetMap = Map(new TopicPartition(fixture.topic, 0) -> new OffsetAndMetadata(lastProcessedOffset))
+      val offsetMap = lastProcessedOffset.map {
+        case (partition, offset) =>
+          new TopicPartition(fixture.topic, partition) -> new OffsetAndMetadata(offset)
+      }
       logger.debug("Committing offset " + offsetMap.head._2.offset())
       consumer.commitAsync(
         offsetMap.asJava,
@@ -84,6 +87,7 @@ object KafkaConsumerBenchmarks extends LazyLogging {
             commitInProgress = false
         }
       )
+      lastProcessedOffset = Map.empty[Int, Long]
     }
 
     @tailrec
@@ -98,7 +102,7 @@ object KafkaConsumerBenchmarks extends LazyLogging {
         for (record <- records.iterator().asScala) {
           accumulatedMsgCount = accumulatedMsgCount + 1
           meter.mark()
-          lastProcessedOffset = record.offset()
+          lastProcessedOffset += record.partition() -> record.offset()
           if (accumulatedMsgCount >= batchSize) {
             if (!commitInProgress) {
               commitInProgress = true
@@ -117,27 +121,26 @@ object KafkaConsumerBenchmarks extends LazyLogging {
   }
 
   /**
-   * Reads messages from topic in a loop and groups in batches of given max size. Once a batch is completed,
-   * batches the next part.
+   * Reads messages from topic in a loop and commits all read offsets.
    */
-  def consumerAtLeastOnceBatchedNoPausing(batchSize: Int)(fixture: KafkaConsumerTestFixture, meter: Meter): Unit = {
+  def consumerAtLeastOnceCommitEveryPoll()(fixture: KafkaConsumerTestFixture, meter: Meter): Unit = {
     val consumer = fixture.consumer
 
-    var lastProcessedOffset = 0L
-    var accumulatedMsgCount = 0L
-    var commitInProgress = false
+    var lastProcessedOffset = Map.empty[Int, Long]
 
     def doCommit(): Unit = {
-      accumulatedMsgCount = 0
-      val offsetMap = Map(new TopicPartition(fixture.topic, 0) -> new OffsetAndMetadata(lastProcessedOffset))
+      val offsetMap = lastProcessedOffset.map {
+        case (partition, offset) =>
+          new TopicPartition(fixture.topic, partition) -> new OffsetAndMetadata(offset)
+      }
       logger.debug("Committing offset " + offsetMap.head._2.offset())
       consumer.commitAsync(
         offsetMap.asJava,
         new OffsetCommitCallback {
-          override def onComplete(map: util.Map[TopicPartition, OffsetAndMetadata], e: Exception): Unit =
-            commitInProgress = false
+          override def onComplete(map: util.Map[TopicPartition, OffsetAndMetadata], e: Exception): Unit = ()
         }
       )
+      lastProcessedOffset = Map.empty[Int, Long]
     }
 
     @tailrec
@@ -148,16 +151,10 @@ object KafkaConsumerBenchmarks extends LazyLogging {
         logger.debug("Polling")
         val records = consumer.poll(pollTimeoutMs)
         for (record <- records.iterator().asScala) {
-          accumulatedMsgCount = accumulatedMsgCount + 1
           meter.mark()
-          lastProcessedOffset = record.offset()
-          if (accumulatedMsgCount >= batchSize) {
-            if (!commitInProgress) {
-              commitInProgress = true
-              doCommit()
-            }
-          }
+          lastProcessedOffset += record.partition() -> record.offset()
         }
+        doCommit()
         val recordCount = records.count()
         logger.debug(s"${readSoFar + recordCount} records read. Limit = $readLimit")
         pollInLoop(readLimit, readSoFar + recordCount)

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaConsumerBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaConsumerBenchmarks.scala
@@ -126,7 +126,6 @@ object KafkaConsumerBenchmarks extends LazyLogging {
     var lastProcessedOffset = 0L
     var accumulatedMsgCount = 0L
     var commitInProgress = false
-    val assignment = consumer.assignment()
 
     def doCommit(): Unit = {
       accumulatedMsgCount = 0

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/PerfFixtureHelpers.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/PerfFixtureHelpers.scala
@@ -27,7 +27,7 @@ private[benchmarks] trait PerfFixtureHelpers extends LazyLogging {
   import PerfFixtureHelpers._
 
   val producerTimeout = 6 minutes
-  val logPercentStep = 1
+  val logPercentStep = 25
 
   def randomId() = UUID.randomUUID().toString
 

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaConsumerBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaConsumerBenchmarks.scala
@@ -90,8 +90,9 @@ object ReactiveKafkaConsumerBenchmarks extends LazyLogging {
   /**
    * Reads elements from Kafka source and commits in batches with no backpressure on committing.
    */
-  def consumerCommitAndForget(commitBatchSize: Int)(fixture: CommittableFixture, meter: Meter)(implicit sys: ActorSystem,
-                                                                                               mat: Materializer): Unit = {
+  def consumerCommitAndForget(
+      commitBatchSize: Int
+  )(fixture: CommittableFixture, meter: Meter)(implicit sys: ActorSystem, mat: Materializer): Unit = {
     logger.debug("Creating and starting a stream")
     val committerDefaults = CommitterSettings(sys)
     val promise = Promise[Unit]

--- a/core/src/main/mima-filters/1.0.x.backwards.excludes
+++ b/core/src/main/mima-filters/1.0.x.backwards.excludes
@@ -1,2 +1,5 @@
 # always exclude changes to the internal APIs
 ProblemFilters.exclude[Problem]("akka.kafka.internal.*")
+
+# PR #874 committing without backpressure
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.kafka.ConsumerMessage#CommittableOffsetBatch.tellCommit")

--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -200,6 +200,11 @@ object ConsumerMessage {
      */
     def getOffsets(): java.util.Map[GroupTopicPartition, Long]
 
+    /**
+     * Internal API.
+     */
+    @InternalApi
+    private[kafka] def commitAndForget(): CommittableOffsetBatch
   }
 
 }

--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -202,9 +202,11 @@ object ConsumerMessage {
 
     /**
      * Internal API.
+     *
+     * Sends this offset batch to the consumer actor without expecting an answer.
      */
     @InternalApi
-    private[kafka] def commitAndForget(): CommittableOffsetBatch
+    private[kafka] def tellCommit(): CommittableOffsetBatch
   }
 
 }

--- a/core/src/main/scala/akka/kafka/internal/CommittableSources.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommittableSources.scala
@@ -121,6 +121,7 @@ private[kafka] final class CommittableSubSource[K, V](settings: ConsumerSettings
  *
  * This should be case class to be comparable based on consumerActor and commitTimeout. This comparison is used in [[CommittableOffsetBatchImpl]].
  */
+@InternalApi
 private[kafka] class KafkaAsyncConsumerCommitterRef(consumerActor: ActorRef, commitTimeout: FiniteDuration)(
     implicit ec: ExecutionContext
 ) {
@@ -144,7 +145,7 @@ private[kafka] class KafkaAsyncConsumerCommitterRef(consumerActor: ActorRef, com
     case _ => failForUnexpectedImplementation(batch)
   }
 
-  def commitAndForget(batch: CommittableOffsetBatch): Unit = batch match {
+  def tellCommit(batch: CommittableOffsetBatch): Unit = batch match {
     case b: CommittableOffsetBatchImpl =>
       b.groupIdOffsetMaps.foreach {
         case (groupId, offsets) =>

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -65,6 +65,8 @@ import scala.util.control.NonFatal
         extends NoSerializationVerificationNeeded
     val Stop = akka.kafka.KafkaConsumerActor.Stop
     final case class Commit(offsets: Map[TopicPartition, OffsetAndMetadata]) extends NoSerializationVerificationNeeded
+    final case class CommitWithoutReply(offsets: Map[TopicPartition, OffsetAndMetadata])
+        extends NoSerializationVerificationNeeded
 
     /** Special case commit for non-batched committing. */
     final case class CommitSingle(tp: TopicPartition, offsetAndMetadata: OffsetAndMetadata)
@@ -290,6 +292,10 @@ import scala.util.control.NonFatal
       // prepending, as later received offsets most likely are higher
       commitMaps = offsets :: commitMaps
       commitSenders = commitSenders :+ sender()
+
+    case CommitWithoutReply(offsets) =>
+      // prepending, as later received offsets most likely are higher
+      commitMaps = offsets :: commitMaps
 
     case CommitSingle(tp, offset) =>
       commitMaps = Map(tp -> offset) :: commitMaps

--- a/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
+++ b/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
@@ -22,7 +22,6 @@ import org.apache.kafka.common.requests.OffsetFetchResponse
 
 import scala.jdk.CollectionConverters._
 import scala.collection.compat._
-import scala.collection.immutable
 import scala.compat.java8.FutureConverters.FutureOps
 import scala.concurrent.Future
 
@@ -260,6 +259,13 @@ private[kafka] final class CommittableOffsetBatchImpl(
     else {
       committers.head._2.commit(this)
     }
+
+  override def commitAndForget(): CommittableOffsetBatch = {
+    if (batchSize != 0L) {
+      committers.head._2.commitAndForget(this)
+    }
+    this
+  }
 
   override def commitJavadsl(): CompletionStage[Done] = commitScaladsl().toJava
 

--- a/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
+++ b/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
@@ -260,9 +260,9 @@ private[kafka] final class CommittableOffsetBatchImpl(
       committers.head._2.commit(this)
     }
 
-  override def commitAndForget(): CommittableOffsetBatch = {
+  override def tellCommit(): CommittableOffsetBatch = {
     if (batchSize != 0L) {
-      committers.head._2.commitAndForget(this)
+      committers.head._2.tellCommit(this)
     }
     this
   }

--- a/core/src/main/scala/akka/kafka/javadsl/Committer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Committer.scala
@@ -30,6 +30,16 @@ object Committer {
     scaladsl.Committer.batchFlow(settings).asJava
 
   /**
+   * API may change - this is an experimental feature.
+   *
+   * Batches offsets and commits them to Kafka, emits `CommittableOffsetBatch` for every batch sent for
+   * committing without expecting replies (no backpressure on committing).
+   */
+  @ApiMayChange
+  def tellFlow[C <: CommittableOffset](settings: CommitterSettings): Flow[C, CommittableOffsetBatch, NotUsed] =
+    scaladsl.Committer.tellFlow(settings).asJava
+
+  /**
    * API MAY CHANGE
    *
    * Batches offsets from context and commits them to Kafka, emits no useful value, but keeps the committed
@@ -40,6 +50,18 @@ object Committer {
       settings: CommitterSettings
   ): FlowWithContext[E, C, NotUsed, CommittableOffsetBatch, NotUsed] =
     scaladsl.Committer.flowWithOffsetContext[E](settings).asJava
+
+  /**
+   * API may change - this is an experimental feature.
+   *
+   * Batches offsets from context and commits them to Kafka without expecting replies (no backpressure on committing).
+   * Emits no useful value, but keeps the committed
+   * `CommittableOffsetBatch` as context.
+   */
+  def tellFlowWithOffsetContext[E, C <: CommittableOffset](
+      settings: CommitterSettings
+  ): FlowWithContext[E, C, NotUsed, CommittableOffsetBatch, NotUsed] =
+    scaladsl.Committer.tellFlowWithOffsetContext[E](settings).asJava
 
   /**
    * Batches offsets and commits them to Kafka.

--- a/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
@@ -34,7 +34,7 @@ object Committer {
       }
 
   /**
-   * API may change!
+   * API may change - this is an experimental feature.
    *
    * Batches offsets and commits them to Kafka, emits `CommittableOffsetBatch` for every batch sent for
    * committing without expecting replies (no backpressure).
@@ -59,6 +59,24 @@ object Committer {
     val value = Flow[(E, CommittableOffset)]
       .map(_._2)
       .via(batchFlow(settings))
+      .map(b => (NotUsed, b))
+    new FlowWithContext(value)
+  }
+
+  /**
+   * API may change - this is an experimental feature.
+   *
+   * Batches offsets from context and commits them to Kafka without expecting replies (no backpressure on committing).
+   * Emits no useful value, but keeps the committed
+   * `CommittableOffsetBatch` as context.
+   */
+  @ApiMayChange
+  def tellFlowWithOffsetContext[E](
+      settings: CommitterSettings
+  ): FlowWithContext[E, CommittableOffset, NotUsed, CommittableOffsetBatch, NotUsed] = {
+    val value = Flow[(E, CommittableOffset)]
+      .map(_._2)
+      .via(tellFlow(settings))
       .map(b => (NotUsed, b))
     new FlowWithContext(value)
   }

--- a/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
@@ -34,6 +34,19 @@ object Committer {
       }
 
   /**
+   * API may change!
+   *
+   * Batches offsets and commits them to Kafka, emits `CommittableOffsetBatch` for every batch sent for
+   * committing.
+   */
+  @ApiMayChange
+  def batchSender(settings: CommitterSettings): Flow[Committable, CommittableOffsetBatch, NotUsed] =
+    Flow[Committable]
+      .groupedWeightedWithin(settings.maxBatch, settings.maxInterval)(_.batchSize)
+      .map(CommittableOffsetBatch.apply)
+      .map(_.commitAndForget())
+
+  /**
    * API MAY CHANGE
    *
    * Batches offsets from context and commits them to Kafka, emits no useful value, but keeps the committed

--- a/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
@@ -37,14 +37,14 @@ object Committer {
    * API may change!
    *
    * Batches offsets and commits them to Kafka, emits `CommittableOffsetBatch` for every batch sent for
-   * committing.
+   * committing without expecting replies (no backpressure).
    */
   @ApiMayChange
-  def batchSender(settings: CommitterSettings): Flow[Committable, CommittableOffsetBatch, NotUsed] =
-    Flow[Committable]
+  def tellFlow(settings: CommitterSettings): Flow[CommittableOffset, CommittableOffsetBatch, NotUsed] =
+    Flow[CommittableOffset]
       .groupedWeightedWithin(settings.maxBatch, settings.maxInterval)(_.batchSize)
       .map(CommittableOffsetBatch.apply)
-      .map(_.commitAndForget())
+      .map(_.tellCommit())
 
   /**
    * API MAY CHANGE

--- a/docs/src/main/paradox/consumer.md
+++ b/docs/src/main/paradox/consumer.md
@@ -136,7 +136,7 @@ Table
 |-------------|----------------------------------------------|-----|
 | maxBatch    | maximum number of messages to commit at once | 1000 |
 | maxInterval | maximum interval between commits             | 10 seconds |
-| parallelism | parallelsim for async committing             | 1 |
+| parallelism | parallelsim for async committing             | 100 |
 
 reference.conf
 : @@snip [snip](/core/src/main/resources/reference.conf) { #committer-settings }
@@ -150,14 +150,21 @@ If you use Kafka older than version 2.1.0 and consume from a topic with low acti
 
 These factory methods are part of the @scala[@scaladoc[Committer API](akka.kafka.scaladsl.Committer$)]@java[@scaladoc[Committer API](akka.kafka.javadsl.Committer$)].
 
-| Factory method          | Stream element type                  | Emits |
-|-------------------------|--------------------------------------|--------------|
-| `sink`                  | `Committable`                        | N/A       |
-| `sinkWithOffsetContext` | Any (`CommittableOffset` in context) | N/A       |
-| `flow`                  | `Committable`                        | `Done`    |
-| `batchFlow`             | `Committable`                        | `CommittableOffsetBatch`  |
-| `flowWithOffsetContext` | Any (`CommittableOffset` in context) | `NotUsed` (`CommittableOffsetBatch` in context) |
+| Factory method              | Stream element type                  | Emits        | Backpressures |
+|-----------------------------|--------------------------------------|--------------|---------------|
+| `sink`                      | `Committable`                        | N/A          | Yes |
+| `sinkWithOffsetContext`     | Any (`CommittableOffset` in context) | N/A          | Yes |
+| `flow`                      | `Committable`                        | `Done`       | Yes |
+| `batchFlow`                 | `Committable`                        | `CommittableOffsetBatch`  | Yes |
+| `flowWithOffsetContext`     | Any (`CommittableOffset` in context) | `NotUsed` (`CommittableOffsetBatch` in context) | Yes |
+| `tellFlow`                  | `CommittableOffset`                  | `CommittableOffsetBatch`                            | No |
+| `tellFlowWithOffsetContext` | Any (`CommittableOffset` in context) | `NotUsed` (`CommittableOffsetBatch` in context) | No |
 
+@@@ note { title="Committing without backpressure" }
+
+Committing without waiting for commit acknowledgement from the Kafka Broker is a new experimental feature since Alpakka Kafka 1.1.0. `tellFlow` and `tellFlowWithOffsetContext` may change or even be dropped in future releases.
+
+@@@
 
 ### Commit with meta-data
 

--- a/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
@@ -296,6 +296,7 @@ class CommittingSpec extends SpecBase with TestcontainersKafkaLike with Inside {
       control.isShutdown.futureValue shouldBe Done
     }
 
+    // See equal test "Backpressure-free committing" must "allow commit batches"
     "work in batches" in assertAllStagesStopped {
       val topic = createTopic()
       val group = createGroupId()
@@ -323,13 +324,8 @@ class CommittingSpec extends SpecBase with TestcontainersKafkaLike with Inside {
       probe.cancel()
       control.isShutdown.futureValue shouldBe Done
 
-      // Resume consumption
-      val (_, probe2) = createProbe(consumerSettings, topic)
-
-      val element = probe2.request(1).expectNext(60.seconds)
-
-      Assertions.assert(element.toInt > 1, "Should start after first element")
-      probe2.cancel()
+      val element = consumeFirstElement(topic, consumerSettings)
+      assert(element.toInt > 1, "Should start after first element")
     }
 
     "work with a committer sink" in assertAllStagesStopped {
@@ -358,14 +354,51 @@ class CommittingSpec extends SpecBase with TestcontainersKafkaLike with Inside {
       val failAt = 32
       consumeAndCommitUntil(topic, failAt.toString).failed.futureValue shouldBe an[Exception]
 
-      // Check offset
-      val (_, probe1) = createProbe(consumerSettings, topic)
-      val element1 = probe1.request(1).expectNext(60.seconds)
-
-      Assertions.assert(element1.toInt >= failAt - committerSettings.maxBatch,
-                        "Should re-process at most maxBatch elements")
-      probe1.cancel()
+      val element1 = consumeFirstElement(topic, consumerSettings)
+      assert(element1.toInt >= failAt - committerSettings.maxBatch, "Should re-process at most maxBatch elements")
     }
 
+  }
+
+  "Backpressure-free committing" must {
+    "allow commit batches" in assertAllStagesStopped {
+      val topic = createTopic()
+      val group = createGroupId()
+      val commitBatchSize = 10L
+
+      produce(topic, 1 to 100).futureValue shouldBe Done
+      val consumerSettings = consumerDefaults.withGroupId(group)
+
+      def consumeAndBatchCommit(topic: String) =
+        Consumer
+          .committableSource(
+            consumerSettings,
+            Subscriptions.topics(topic)
+          )
+          .map(_.committableOffset)
+          .via(Committer.tellFlow(committerDefaults.withMaxBatch(commitBatchSize)))
+          .toMat(TestSink.probe)(Keep.both)
+          .run()
+
+      val (control, probe) = consumeAndBatchCommit(topic)
+
+      // Request two commit batches
+      val committableOffsetBatches = probe.request(2).expectNextN(2)
+      committableOffsetBatches(0).batchSize shouldBe commitBatchSize
+      committableOffsetBatches(1).batchSize shouldBe commitBatchSize
+
+      probe.cancel()
+      control.isShutdown.futureValue shouldBe Done
+
+      val element = consumeFirstElement(topic, consumerSettings)
+      assert(element.toInt > (commitBatchSize * 2) - 1, "Should start after the already committed messages")
+    }
+  }
+
+  private def consumeFirstElement(topic: String, consumerSettings: ConsumerSettings[String, String]): String = {
+    val (_, probe2) = createProbe(consumerSettings, topic)
+    val element = probe2.request(1).expectNext(60.seconds)
+    probe2.cancel()
+    element
   }
 }


### PR DESCRIPTION
## Purpose

Explore an API to send commits to Kafka without waiting for an acknowledgement.

## References

See #845 

## Changes

* Add `Committer.tellFlow`
* Add internal `CommitWithoutReply` message
* Add internal `CommittableBatch.commitAndForget`

Unrelated:
* The Raw Kafka benchmarks now commit to the correct partition. 

## TODO

- [x] Test cases
- [x] Java API
- [x] Documentation

## Background Context

It is not obvious why one would backpressure reading from a consumer when commits are not acknowledged by Kafka at the same rate. This new API opens for a new way of committing without waiting for the commit to get a reply from the Kafka broker.