### PR TITLE
Add producer benchmark with partitions

### DIFF
--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/Benchmarks.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/Benchmarks.scala
@@ -139,7 +139,7 @@ class ApacheKafkaPlainProducer extends BenchmarksBase() {
   }
 
   it should "bench with normal messages written to 8 partitions" in {
-    val cmd = RunTestCommand(prefix + "-normal-msg", bootstrapServers, 2000 * factor, 5000, numberOfPartitions = 8)
+    val cmd = RunTestCommand(prefix + "-normal-msg-8-partitions", bootstrapServers, 2000 * factor, 5000, numberOfPartitions = 8)
     runPerfTest(cmd, KafkaProducerFixtures.initializedProducer(cmd), KafkaProducerBenchmarks.plainFlow)
   }
 }
@@ -158,7 +158,7 @@ class AlpakkaKafkaPlainProducer extends BenchmarksBase() {
   }
 
   it should "bench with normal messages written to 8 partitions" in {
-    val cmd = RunTestCommand(prefix + "-normal-msg", bootstrapServers, 2000 * factor, 5000, numberOfPartitions = 8)
+    val cmd = RunTestCommand(prefix + "-normal-msg-8-partitions", bootstrapServers, 2000 * factor, 5000, numberOfPartitions = 8)
     runPerfTest(cmd, ReactiveKafkaProducerFixtures.flowFixture(cmd), ReactiveKafkaProducerBenchmarks.plainFlow)
   }
 }

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaProducerBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaProducerBenchmarks.scala
@@ -25,8 +25,9 @@ object KafkaProducerBenchmarks extends LazyLogging {
     val msg = PerfFixtureHelpers.stringOfSize(fixture.msgSize)
 
     for (i <- 1 to fixture.msgCount) {
+      val partition: Int = (i % fixture.numberOfPartitions).toInt
       producer.send(
-        new ProducerRecord[Array[Byte], String](fixture.topic, msg),
+        new ProducerRecord[Array[Byte], String](fixture.topic, partition, null, msg),
         new Callback {
           override def onCompletion(metadata: RecordMetadata, exception: Exception): Unit = meter.mark()
         }

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaProducerFixtureGen.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaProducerFixtureGen.scala
@@ -11,7 +11,8 @@ import org.apache.kafka.clients.producer.KafkaProducer
 case class KafkaProducerTestFixture(topic: String,
                                     msgCount: Int,
                                     msgSize: Int,
-                                    producer: KafkaProducer[Array[Byte], String]) {
+                                    producer: KafkaProducer[Array[Byte], String],
+                                    numberOfPartitions: Int) {
   def close(): Unit = producer.close()
 }
 
@@ -20,7 +21,7 @@ object KafkaProducerFixtures extends PerfFixtureHelpers {
   def noopFixtureGen(c: RunTestCommand) = FixtureGen[KafkaProducerTestFixture](
     c,
     msgCount => {
-      KafkaProducerTestFixture("topic", msgCount, c.msgSize, null)
+      KafkaProducerTestFixture("topic", msgCount, c.msgSize, null, c.numberOfPartitions)
     }
   )
 
@@ -29,7 +30,7 @@ object KafkaProducerFixtures extends PerfFixtureHelpers {
     msgCount => {
       val topic = randomId()
       val rawProducer = initTopicAndProducer(topic, c.copy(msgCount = 1))
-      KafkaProducerTestFixture(topic, msgCount, c.msgSize, rawProducer)
+      KafkaProducerTestFixture(topic, msgCount, c.msgSize, rawProducer, c.numberOfPartitions)
     }
   )
 }

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/PerfFixtureHelpers.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/PerfFixtureHelpers.scala
@@ -47,8 +47,9 @@ private[benchmarks] trait PerfFixtureHelpers extends LazyLogging {
     val msg = stringOfSize(cmd.msgSize)
     for (i <- 0L to cmd.msgCount.toLong) {
       if (!lastElementStoredPromise.isCompleted) {
+        val partition: Int = (i % cmd.numberOfPartitions).toInt
         producer.send(
-          new ProducerRecord[Array[Byte], String](topic, msg),
+          new ProducerRecord[Array[Byte], String](topic, partition, null, msg),
           new Callback {
             override def onCompletion(recordMetadata: RecordMetadata, e: Exception): Unit =
               if (e == null) {

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaProducerBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaProducerBenchmarks.scala
@@ -35,9 +35,10 @@ object ReactiveKafkaProducerBenchmarks extends LazyLogging {
     val msg = PerfFixtureHelpers.stringOfSize(fixture.msgSize)
 
     val future = Source(0 to fixture.msgCount)
-      .map(
-        number => ProducerMessage.single(new ProducerRecord[Array[Byte], String](fixture.topic, msg), number)
-      )
+      .map { number =>
+        val partition: Int = (number % fixture.numberOfPartitions).toInt
+        ProducerMessage.single(new ProducerRecord[Array[Byte], String](fixture.topic, partition, null, msg), number)
+      }
       .via(fixture.flow)
       .map {
         case msg: Result[Array[Byte], String, Int] =>

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaProducerFixtures.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaProducerFixtures.scala
@@ -28,7 +28,8 @@ object ReactiveKafkaProducerFixtures extends PerfFixtureHelpers {
   case class ReactiveKafkaProducerTestFixture[PassThrough](topic: String,
                                                            msgCount: Int,
                                                            msgSize: Int,
-                                                           flow: FlowType[PassThrough])
+                                                           flow: FlowType[PassThrough],
+                                                           numberOfPartitions: Int)
 
   private def createProducerSettings(kafkaHost: String)(implicit actorSystem: ActorSystem): ProducerSettings[K, V] =
     ProducerSettings(actorSystem, new ByteArraySerializer, new StringSerializer)
@@ -42,7 +43,7 @@ object ReactiveKafkaProducerFixtures extends PerfFixtureHelpers {
         val flow: FlowType[Int] = Producer.flexiFlow(createProducerSettings(c.kafkaHost))
         val topic = randomId()
         initTopicAndProducer(topic, c.copy(msgCount = 1))
-        ReactiveKafkaProducerTestFixture(topic, msgCount, c.msgSize, flow)
+        ReactiveKafkaProducerTestFixture(topic, msgCount, c.msgSize, flow, c.numberOfPartitions)
       }
     )
 


### PR DESCRIPTION
## Purpose

Add another producer benchmark that writes to 8 partitions.
Make partition use more explicit for all benchmarks.

## Background Context

Producing with Alpakka Kafka should be able to perform better.