### PR TITLE
Split testing with different Scala version to separate Travis jo…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,14 +39,28 @@ jobs:
       name: "Check binary compatibility. Run locally with: sbt mimaReportBinaryIssues"
 
     - stage: test
-      env: CMD="+test"
-      name: "Run tests (AdoptOpenJDK 8)"
+      env: CMD="++2.11.12 test"
+      name: "Run tests with Scala 2.11 and AdoptOpenJDK 8"
+    - env: CMD="++2.12.9 test"
+      name: "Run tests with Scala 2.12 and AdoptOpenJDK 8"
+    - env: CMD="++2.13.0 test"
+      name: "Run tests with Scala 2.13 and AdoptOpenJDK 8"
 
     - env:
       - JDK="adopt@~1.11.0-2"
       - _JAVA_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
-      - CMD="+test"
-      name: "Run tests (AdoptOpenJDK 11)"
+      - CMD="++2.11.12 test"
+      name: "Run tests with Scala 2.11 and AdoptOpenJDK 11"
+    - env:
+      - JDK="adopt@~1.11.0-2"
+      - _JAVA_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+      - CMD="++2.12.9 test"
+      name: "Run tests with Scala 2.12 and AdoptOpenJDK 11"
+    - env:
+      - JDK="adopt@~1.11.0-2"
+      - _JAVA_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
+      - CMD="++2.13.0 test"
+      name: "Run tests with Scala 2.13 and AdoptOpenJDK 11"
 
     - stage: integration
       env: CMD="dockerComposeTestAll"
@@ -69,7 +83,7 @@ stages:
   # runs on master commits and PRs
   - name: test
     if: NOT tag =~ ^v
-    
+
   # runs on master commits and PRs
   - name: integration
     if: NOT tag =~ ^v

--- a/build.sbt
+++ b/build.sbt
@@ -64,8 +64,8 @@ val commonSettings = Def.settings(
   startYear := Some(2014),
   licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")),
   description := "Alpakka is a Reactive Enterprise Integration library for Java and Scala, based on Reactive Streams and Akka.",
-  crossScalaVersions := Seq("2.12.8", Scala211, Scala213).filterNot(_ == Scala211 && Nightly),
-  scalaVersion := "2.12.8",
+  crossScalaVersions := Seq("2.12.9", Scala211, Scala213).filterNot(_ == Scala211 && Nightly),
+  scalaVersion := "2.12.9",
   crossVersion := CrossVersion.binary,
   javacOptions ++= Seq(
       "-Xlint:deprecation"


### PR DESCRIPTION
## Purpose

Current test running Travis jobs takes >40minutes, as they cross-test with all Scala version in one Travis job.

This PR creates separate Travis jobs for different Scala versions.