### PR TITLE
Capture exceptions from Kafka consumer and pass to involved stages #887

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -223,7 +223,6 @@ import scala.util.control.NonFatal
   /** ActorRefs to all stages that requested messages from this actor (removed on their termination). */
   private var requestors = Set.empty[ActorRef]
   private var consumer: Consumer[K, V] = _
-  private var subscriptions = Set.empty[SubscriptionRequest]
   private var commitsInProgress = 0
   private val commitRefreshing = CommitRefreshing(settings.commitRefreshInterval)
   private var stopInProgress = false
@@ -297,7 +296,6 @@ import scala.util.control.NonFatal
       requestDelayedPoll()
 
     case s: SubscriptionRequest =>
-      subscriptions = subscriptions + s
       handleSubscription(s)
 
     case Seek(offsets) =>

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -32,7 +32,6 @@ import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
 
 import scala.jdk.CollectionConverters._
 import scala.collection.compat._
-import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.util.Try
 import scala.util.control.NonFatal
@@ -45,21 +44,19 @@ import scala.util.control.NonFatal
 @InternalApi private object KafkaConsumerActor {
 
   object Internal {
-    sealed trait SubscriptionRequest
+    sealed trait SubscriptionRequest extends NoSerializationVerificationNeeded
 
     //requests
-    final case class Assign(tps: Set[TopicPartition]) extends NoSerializationVerificationNeeded
-    final case class AssignWithOffset(tps: Map[TopicPartition, Long]) extends NoSerializationVerificationNeeded
-    final case class AssignOffsetsForTimes(timestampsToSearch: Map[TopicPartition, Long])
-        extends NoSerializationVerificationNeeded
+    final case class Assign(tps: Set[TopicPartition]) extends SubscriptionRequest
+    final case class AssignWithOffset(tps: Map[TopicPartition, Long]) extends SubscriptionRequest
+    final case class AssignOffsetsForTimes(timestampsToSearch: Map[TopicPartition, Long]) extends SubscriptionRequest
     final case class Subscribe(topics: Set[String], rebalanceHandler: PartitionAssignmentHandler)
         extends SubscriptionRequest
-        with NoSerializationVerificationNeeded
     case object RequestMetrics extends NoSerializationVerificationNeeded
     // Could be optimized to contain a Pattern as it used during reconciliation now, tho only in exceptional circumstances
     final case class SubscribePattern(pattern: String, rebalanceHandler: PartitionAssignmentHandler)
         extends SubscriptionRequest
-        with NoSerializationVerificationNeeded
+    final case object RegisterSubStage extends NoSerializationVerificationNeeded
     final case class Seek(tps: Map[TopicPartition, Long]) extends NoSerializationVerificationNeeded
     final case class RequestMessages(requestId: Int, topics: Set[TopicPartition])
         extends NoSerializationVerificationNeeded
@@ -220,8 +217,8 @@ import scala.util.control.NonFatal
 
   private var requests = Map.empty[ActorRef, RequestMessages]
 
-  /** ActorRefs to all stages that requested messages from this actor (removed on their termination). */
-  private var requestors = Set.empty[ActorRef]
+  /** ActorRefs of all stages that sent subscriptions requests or `RegisterSubStage` to this actor (removed on their termination). */
+  private var stageActors = Set.empty[ActorRef]
   private var consumer: Consumer[K, V] = _
   private var commitsInProgress = 0
   private val commitRefreshing = CommitRefreshing(settings.commitRefreshInterval)
@@ -250,41 +247,6 @@ import scala.util.control.NonFatal
   private var partitionAssignmentHandler: RebalanceListener = RebalanceListener.Empty
 
   def receive: Receive = LoggingReceive {
-    case Assign(assignedTps) =>
-      scheduleFirstPollTask()
-      checkOverlappingRequests("Assign", sender(), assignedTps)
-      val previousAssigned = consumer.assignment()
-      consumer.assign((assignedTps.toSeq ++ previousAssigned.asScala).asJava)
-      commitRefreshing.assignedPositions(assignedTps, consumer, positionTimeout)
-
-    case AssignWithOffset(assignedOffsets) =>
-      scheduleFirstPollTask()
-      checkOverlappingRequests("AssignWithOffset", sender(), assignedOffsets.keySet)
-      val previousAssigned = consumer.assignment()
-      consumer.assign((assignedOffsets.keys.toSeq ++ previousAssigned.asScala).asJava)
-      assignedOffsets.foreach {
-        case (tp, offset) =>
-          consumer.seek(tp, offset)
-      }
-      commitRefreshing.assignedPositions(assignedOffsets.keySet, assignedOffsets)
-
-    case AssignOffsetsForTimes(timestampsToSearch) =>
-      scheduleFirstPollTask()
-      checkOverlappingRequests("AssignOffsetsForTimes", sender(), timestampsToSearch.keySet)
-      val previousAssigned = consumer.assignment()
-      consumer.assign((timestampsToSearch.keys.toSeq ++ previousAssigned.asScala).asJava)
-      val topicPartitionToOffsetAndTimestamp =
-        consumer.offsetsForTimes(timestampsToSearch.view.mapValues(long2Long).toMap.asJava, offsetForTimesTimeout)
-      val assignedOffsets = topicPartitionToOffsetAndTimestamp.asScala.filter(_._2 != null).toMap.map {
-        case (tp, oat: OffsetAndTimestamp) =>
-          val offset = oat.offset()
-          val ts = oat.timestamp()
-          log.debug("Get offset {} from topic {} with timestamp {}", offset, tp, ts)
-          consumer.seek(tp, offset)
-          tp -> offset
-      }
-      commitRefreshing.assignedPositions(assignedOffsets.keySet, assignedOffsets)
-
     case Commit(offsets) =>
       // prepending, as later received offsets most likely are higher
       commitMaps = offsets :: commitMaps
@@ -298,9 +260,16 @@ import scala.util.control.NonFatal
     case s: SubscriptionRequest =>
       handleSubscription(s)
 
+    case RegisterSubStage =>
+      stageActors += sender()
+
     case Seek(offsets) =>
-      offsets.foreach { case (tp, offset) => consumer.seek(tp, offset) }
-      sender() ! Done
+      try {
+        offsets.foreach { case (tp, offset) => consumer.seek(tp, offset) }
+        sender() ! Done
+      } catch {
+        case NonFatal(e) => sendFailure(e, sender())
+      }
 
     case p: Poll[_, _] =>
       receivePoll(p)
@@ -309,8 +278,7 @@ import scala.util.control.NonFatal
       context.watch(sender())
       checkOverlappingRequests("RequestMessages", sender(), req.topics)
       requests = requests.updated(sender(), req)
-      requestors += sender()
-      if (requestors.size == 1)
+      if (stageActors.size == 1)
         poll()
       else requestDelayedPoll()
 
@@ -330,33 +298,71 @@ import scala.util.control.NonFatal
       self ! Stop
 
     case RequestMetrics =>
-      val unmodifiableYetMutableMetrics: java.util.Map[MetricName, _ <: Metric] = consumer.metrics()
-      sender() ! ConsumerMetrics(unmodifiableYetMutableMetrics.asScala.toMap)
+      try {
+        val unmodifiableYetMutableMetrics: java.util.Map[MetricName, _ <: Metric] = consumer.metrics()
+        sender() ! ConsumerMetrics(unmodifiableYetMutableMetrics.asScala.toMap)
+      } catch {
+        case NonFatal(e) => sendFailure(e, sender())
+      }
 
     case Terminated(ref) =>
       requests -= ref
-      requestors -= ref
+      stageActors -= ref
 
     case req: Metadata.Request =>
-      sender ! handleMetadataRequest(req)
+      sender() ! handleMetadataRequest(req)
   }
 
   def handleSubscription(subscription: SubscriptionRequest): Unit =
     try {
       subscription match {
+        case Assign(assignedTps) =>
+          checkOverlappingRequests("Assign", sender(), assignedTps)
+          val previousAssigned = consumer.assignment()
+          consumer.assign((assignedTps.toSeq ++ previousAssigned.asScala).asJava)
+          commitRefreshing.assignedPositions(assignedTps, consumer, positionTimeout)
+
+        case AssignWithOffset(assignedOffsets) =>
+          checkOverlappingRequests("AssignWithOffset", sender(), assignedOffsets.keySet)
+          val previousAssigned = consumer.assignment()
+          consumer.assign((assignedOffsets.keys.toSeq ++ previousAssigned.asScala).asJava)
+          assignedOffsets.foreach {
+            case (tp, offset) =>
+              consumer.seek(tp, offset)
+          }
+          commitRefreshing.assignedPositions(assignedOffsets.keySet, assignedOffsets)
+
+        case AssignOffsetsForTimes(timestampsToSearch) =>
+          checkOverlappingRequests("AssignOffsetsForTimes", sender(), timestampsToSearch.keySet)
+          val previousAssigned = consumer.assignment()
+          consumer.assign((timestampsToSearch.keys.toSeq ++ previousAssigned.asScala).asJava)
+          val topicPartitionToOffsetAndTimestamp =
+            consumer.offsetsForTimes(timestampsToSearch.view.mapValues(long2Long).toMap.asJava, offsetForTimesTimeout)
+          val assignedOffsets = topicPartitionToOffsetAndTimestamp.asScala.filter(_._2 != null).toMap.map {
+            case (tp, oat: OffsetAndTimestamp) =>
+              val offset = oat.offset()
+              val ts = oat.timestamp()
+              log.debug("Get offset {} from topic {} with timestamp {}", offset, tp, ts)
+              consumer.seek(tp, offset)
+              tp -> offset
+          }
+          commitRefreshing.assignedPositions(assignedOffsets.keySet, assignedOffsets)
+
         case Subscribe(topics, rebalanceHandler) =>
           val callback = new RebalanceListenerImpl(rebalanceHandler)
           partitionAssignmentHandler = callback
           consumer.subscribe(topics.toList.asJava, callback)
+
         case SubscribePattern(pattern, rebalanceHandler) =>
           val callback = new RebalanceListenerImpl(rebalanceHandler)
           partitionAssignmentHandler = callback
           consumer.subscribe(Pattern.compile(pattern), callback)
-      }
 
+      }
       scheduleFirstPollTask()
+      stageActors += sender()
     } catch {
-      case NonFatal(ex) => processErrors(ex)
+      case NonFatal(ex) => sendFailure(ex, sender())
     }
 
   def checkOverlappingRequests(updateType: String, fromStage: ActorRef, topics: Set[TopicPartition]): Unit =
@@ -375,7 +381,8 @@ import scala.util.control.NonFatal
     case p: Poll[_, _] =>
       receivePoll(p)
     case Stop =>
-    case _: Terminated =>
+    case Terminated(ref) =>
+      stageActors -= ref
     case _ @(_: Commit | _: RequestMessages) =>
       sender() ! Status.Failure(StoppingException())
     case msg @ (_: Assign | _: AssignWithOffset | _: Subscribe | _: SubscribePattern) =>
@@ -443,8 +450,8 @@ import scala.util.control.NonFatal
     }
 
   def poll(): Unit = {
-    val currentAssignmentsJava = consumer.assignment()
     try {
+      val currentAssignmentsJava = consumer.assignment()
       commitAggregatedOffsets()
       if (requests.isEmpty) {
         // no outstanding requests so we don't expect any messages back, but we should anyway
@@ -549,12 +556,17 @@ import scala.util.control.NonFatal
       }
     }
 
+  private def sendFailure(exception: Throwable, stageActorRef: ActorRef): Unit = {
+    stageActorRef ! Failure(exception)
+    requests -= stageActorRef
+    stageActors -= stageActorRef
+  }
+
   private def processErrors(exception: Throwable): Unit = {
-    val involvedStageActors = (requests.keys ++ owner).toSet
-    log.debug("sending failure to {}", involvedStageActors.mkString(","))
-    involvedStageActors.foreach { stageActorRef =>
-      stageActorRef ! Failure(exception)
-      requests -= stageActorRef
+    val sendTo = (stageActors ++ owner).toSet
+    log.debug(s"sending failure {} to {}", exception.getClass, sendTo.mkString(","))
+    stageActors.foreach { stageActorRef =>
+      sendFailure(exception, stageActorRef)
     }
   }
 

--- a/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
@@ -10,6 +10,7 @@ import akka.actor.Status
 import akka.actor.{ActorRef, ExtendedActorSystem, Terminated}
 import akka.annotation.InternalApi
 import akka.kafka.Subscriptions.{TopicSubscription, TopicSubscriptionPattern}
+import akka.kafka.internal.KafkaConsumerActor.Internal.RegisterSubStage
 import akka.kafka.{AutoSubscription, ConsumerFailed, ConsumerSettings}
 import akka.kafka.scaladsl.Consumer.Control
 import akka.pattern.{ask, AskTimeoutException}
@@ -318,6 +319,7 @@ private final class SubSourceStage[K, V, Msg](
             failStage(new ConsumerFailed)
         }
         subSourceActor.watch(consumerActor)
+        consumerActor.tell(RegisterSubStage, subSourceActor.ref)
       }
 
       override def postStop(): Unit = {

--- a/core/src/main/scala/akka/kafka/internal/TransactionalSource.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalSource.scala
@@ -121,10 +121,13 @@ private[internal] abstract class TransactionalSourceLogic[K, V, Msg](shape: Sour
         ack.getOrElse(sender).tell(msg, sourceActor.ref)
       } else {
         log.debug(s"Draining partitions {}", partitions)
-        materializer.scheduleOnce(consumerSettings.drainingCheckInterval, new Runnable {
-          override def run(): Unit =
-            sourceActor.ref.tell(Drain(partitions, ack.orElse(Some(sender)), msg), sourceActor.ref)
-        })
+        materializer.scheduleOnce(
+          consumerSettings.drainingCheckInterval,
+          new Runnable {
+            override def run(): Unit =
+              sourceActor.ref.tell(Drain(partitions, ack.orElse(Some(sender)), msg), sourceActor.ref)
+          }
+        )
       }
   }
 

--- a/core/src/main/scala/akka/kafka/internal/TransactionalSource.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalSource.scala
@@ -110,7 +110,7 @@ private[internal] abstract class TransactionalSourceLogic[K, V, Msg](shape: Sour
   private def drainHandling: PartialFunction[(ActorRef, Any), Unit] = {
     case (sender, Committed(offsets)) =>
       inFlightRecords.committed(offsets.view.mapValues(_.offset() - 1).toMap)
-      sender ! Done
+      sender.tell(Done, sourceActor.ref)
     case (sender, CommittingFailure) => {
       log.info("Committing failed, resetting in flight offsets")
       inFlightRecords.reset()
@@ -118,12 +118,12 @@ private[internal] abstract class TransactionalSourceLogic[K, V, Msg](shape: Sour
     case (sender, Drain(partitions, ack, msg)) =>
       if (inFlightRecords.empty(partitions)) {
         log.debug(s"Partitions drained ${partitions.mkString(",")}")
-        ack.getOrElse(sender) ! msg
+        ack.getOrElse(sender).tell(msg, sourceActor.ref)
       } else {
         log.debug(s"Draining partitions {}", partitions)
         materializer.scheduleOnce(consumerSettings.drainingCheckInterval, new Runnable {
           override def run(): Unit =
-            sourceActor.ref ! Drain(partitions, ack.orElse(Some(sender)), msg)
+            sourceActor.ref.tell(Drain(partitions, ack.orElse(Some(sender)), msg), sourceActor.ref)
         })
       }
   }
@@ -151,10 +151,10 @@ private[internal] abstract class TransactionalSourceLogic[K, V, Msg](shape: Sour
       // This is invoked in the KafkaConsumerActor thread when doing poll.
       override def onRevoke(revokedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit =
         if (waitForDraining(revokedTps)) {
-          sourceActor.ref ! Revoked(revokedTps.toList)
+          sourceActor.ref.tell(Revoked(revokedTps.toList), consumerActor)
         } else {
-          sourceActor.ref ! Failure(new Error("Timeout while draining"))
-          consumerActor ! KafkaConsumerActor.Internal.Stop
+          sourceActor.ref.tell(Failure(new Error("Timeout while draining")), consumerActor)
+          consumerActor.tell(KafkaConsumerActor.Internal.Stop, consumerActor)
         }
 
       override def onStop(revokedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = ()

--- a/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala
@@ -7,10 +7,9 @@ package docs.scaladsl
 
 import akka.Done
 import akka.kafka.Subscriptions
-import akka.kafka.scaladsl.Consumer.DrainingControl
 import akka.kafka.scaladsl.{Consumer, Producer, SpecBase}
 import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
-import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
+import akka.stream.scaladsl.{Flow, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.producer.ProducerRecord

--- a/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala
@@ -7,9 +7,10 @@ package docs.scaladsl
 
 import akka.Done
 import akka.kafka.Subscriptions
+import akka.kafka.scaladsl.Consumer.DrainingControl
 import akka.kafka.scaladsl.{Consumer, Producer, SpecBase}
 import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
-import akka.stream.scaladsl.{Flow, Sink, Source}
+import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.producer.ProducerRecord
@@ -156,6 +157,56 @@ class AssignmentSpec extends SpecBase with TestcontainersKafkaLike {
       messages.futureValue.map(_ - now).count(_ > 5000) shouldBe 0
     }
   }
+
+  "illegal subscriptions" should {
+    "fail the stream with invalid topic" in {
+      val streamCompletion = Consumer
+        .plainSource(consumerDefaults.withGroupId(createGroupId()), Subscriptions.topics("illegal topic name"))
+        .runWith(Sink.ignore)
+      streamCompletion.failed.futureValue shouldBe a[org.apache.kafka.common.errors.InvalidTopicException]
+    }
+
+    "fail the stream for empty subscriptions list" in {
+      val streamCompletion = Consumer
+        .plainSource(consumerDefaults.withGroupId(createGroupId()), Subscriptions.topics())
+        .runWith(Sink.ignore)
+      streamCompletion.failed.futureValue shouldBe a[java.lang.IllegalStateException]
+    }
+
+    "fail the stream for `null` topic name" in {
+      val streamCompletion = Consumer
+        .plainSource(consumerDefaults.withGroupId(createGroupId()), Subscriptions.topics(Set(null: String)))
+        .runWith(Sink.ignore)
+      streamCompletion.failed.futureValue shouldBe a[java.lang.IllegalArgumentException]
+    }
+
+    "fail the stream with invalid topic for assignments" in {
+      val streamCompletion = Consumer
+        .plainSource(consumerDefaults.withGroupId(createGroupId()),
+                     Subscriptions.assignment(new TopicPartition("illegal topic name", 2)))
+        .runWith(Sink.ignore)
+      streamCompletion.failed.futureValue shouldBe a[org.apache.kafka.common.errors.InvalidTopicException]
+    }
+
+    "fail the stream for illegal topic pattern" in {
+      val streamCompletion = Consumer
+        .plainSource(consumerDefaults.withGroupId(createGroupId()), Subscriptions.topicPattern("illegal regex (*"))
+        .runWith(Sink.ignore)
+      streamCompletion.failed.futureValue shouldBe a[java.util.regex.PatternSyntaxException]
+    }
+
+    "fail the stream for illegal offsets for times" in {
+      val streamCompletion = Consumer
+        .plainSource(
+          consumerDefaults.withGroupId(createGroupId()),
+          Subscriptions.assignmentOffsetsForTimes(new TopicPartition("topic", 0) -> 232L,
+                                                  new TopicPartition("topic", 1) -> -232L)
+        )
+        .runWith(Sink.ignore)
+      streamCompletion.failed.futureValue shouldBe a[java.lang.IllegalArgumentException]
+    }
+  }
+
   // #testkit
 
 }


### PR DESCRIPTION
## Purpose

Some calls to the Kafka consumer may throw exceptions. These are captured now and sent to the stage which sent the command that triggered the error.

## References

Implements #796 and #814

## Changes

* `KafkaConsumerActor` maintains a set of stage actors that it interacts with (replaces `requestors` which required to receive demand from the stages)
* All subscriptions and assignments are passed to `handleSubscription`
* Illegal subscribe commands fail the sending stage/stream only

## TODO

- [ ] Producer stage

