### PR TITLE
No Scala 2.11 for nightly builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ jobs:
     - stage: test
       env: CMD="++2.11.12 test"
       name: "Run tests with Scala 2.11 and AdoptOpenJDK 8"
+      if: type != cron
     - env: CMD="++2.12.9 test"
       name: "Run tests with Scala 2.12 and AdoptOpenJDK 8"
     - env: CMD="++2.13.0 test"
@@ -51,6 +52,7 @@ jobs:
       - _JAVA_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
       - CMD="++2.11.12 test"
       name: "Run tests with Scala 2.11 and AdoptOpenJDK 11"
+      if: type != cron
     - env:
       - JDK="adopt@~1.11.0-2"
       - _JAVA_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"


### PR DESCRIPTION
## Purpose

No Scala 2.11 for nightly builds

## References

Fixes https://travis-ci.org/akka/alpakka-kafka/jobs/579767628#L578
