### PR TITLE
Add page descriptions for HTML meta tags

### DIFF
--- a/docs/src/main/paradox/atleastonce.md
+++ b/docs/src/main/paradox/atleastonce.md
@@ -1,3 +1,6 @@
+---
+project.description: Achieve at-least-once semantics with offset committing in Alpakka Kafka.
+---
 # At-Least-Once Delivery
 
 At-least-once delivery semantics, the requirement to process every message, is a basic requirement of most applications. 

--- a/docs/src/main/paradox/consumer-metadata.md
+++ b/docs/src/main/paradox/consumer-metadata.md
@@ -1,3 +1,6 @@
+---
+project.description: Access Kafka consumer metadata by sending messages to the actor provided by Alpakka Kafka.
+---
 # Consumer Metadata
 
 To access the Kafka consumer metadata you need to create the `KafkaConsumerActor` as described in the @ref[Consumer documentation](consumer.md#sharing-the-kafkaconsumer-instance) and send messages from `Metadata` (@scaladoc[API](akka.kafka.Metadata$)) to it.

--- a/docs/src/main/paradox/consumer.md
+++ b/docs/src/main/paradox/consumer.md
@@ -1,3 +1,6 @@
+---
+project.description: Consume messages from Apache Kafka in Akka Streams sources and their commit offsets to Kafka.
+---
 # Consumer
 
 A consumer subscribes to Kafka topics and passes the messages into an Akka Stream.

--- a/docs/src/main/paradox/errorhandling.md
+++ b/docs/src/main/paradox/errorhandling.md
@@ -1,9 +1,16 @@
+---
+project.description: Handle errors from the Kafka API in Alpakka Kafka.
+---
 # Error handling
 
 ## Failing consumer
 
-When a consumer fails to read from Kafka due to connection problems, it throws a @javadoc[WakeupException](org.apache.kafka.common.errors.WakeupException) which is handled internally with retries. Refer to consumer configuration @ref[settings](consumer.md#settings) for details on `wakeup-timeout` and `max-wakeups` if you're interested in tweaking the retry handling parameters.
-When the currently configured number of `max-wakeups` is reached, the source stage will fail with an exception and stop.
+Errors from the Kafka consumer will be forwarded to the Alpakka sources that use it, the sources will fail their streams.
+
+### Lost connection to the Kafka broker
+
+To fail a Alpakka Kafka consumer in case the Kafka broker is not available, configure a **Connection Checker** via `ConsumerSettings`. If not **Connection Checker** is configured, Alpakka will continue to poll the broker indefinitely.
+
 
 ## Failing producer
 

--- a/docs/src/main/paradox/producer.md
+++ b/docs/src/main/paradox/producer.md
@@ -1,3 +1,6 @@
+---
+project.description: Produce messages to Apache Kafka topics from Akka Streams with Alpakka Kafka.
+---
 # Producer
 
 A producer publishes messages to Kafka topics. The message itself contains information about what topic and partition to publish to so you can publish to different topics with the same producer.

--- a/docs/src/main/paradox/production.md
+++ b/docs/src/main/paradox/production.md
@@ -1,10 +1,13 @@
+---
+project.description: Consider these areas when using Alpakka Kafka in production.
+---
 # Production considerations
 
 
 ## Alpakka Kafka API
 
 1. Do not use `Consumer.atMostOnceSource` in production as it internally commits the offset after every element.
-1. If you create `Producer` sinks in "inner flows", be sure to [share the `Producer` instance](https://doc.akka.io/docs/akka-stream-kafka/current/producer.html#sharing-the-kafkaproducer-instance). This avoids the expensive creation of `KafkaProducer` instances. 
+1. If you create `Producer` sinks in "inner flows", be sure to @ref:[share the `Producer` instance](producer.md#sharing-the-kafkaproducer-instance). This avoids the expensive creation of `KafkaProducer` instances.
 
 @@@ note
 

--- a/docs/src/main/paradox/release-notes/1.0.x.md
+++ b/docs/src/main/paradox/release-notes/1.0.x.md
@@ -1,3 +1,6 @@
+---
+project.description: Release notes for all Alpakka Kafka 1.0.x releases.
+---
 # Alpakka Kafka 1.0.x
 
 @@@ note

--- a/docs/src/main/paradox/snapshots.md
+++ b/docs/src/main/paradox/snapshots.md
@@ -1,3 +1,6 @@
+---
+project.description: Snapshot builds of Alpakka Kafka are provided via a Bintray repository.
+---
 # Snapshots
 
 [snapshots-badge]:  https://api.bintray.com/packages/akka/snapshots/alpakka-kafka/images/download.svg

--- a/docs/src/main/paradox/subscription.md
+++ b/docs/src/main/paradox/subscription.md
@@ -1,3 +1,6 @@
+---
+project.description: An Alpakka Kafka consumer source can subscribe to Kafka topics within a consumer group, or to specific partitions.
+---
 # Subscription
 
 Consumer Sources are created with different types of subscriptions, which control from which topics, partitions and offsets data is to be consumed.

--- a/docs/src/main/paradox/testing.md
+++ b/docs/src/main/paradox/testing.md
@@ -1,3 +1,6 @@
+---
+project.description: Alpakka Kafka provides a Testkit with support for running local Kafka brokers for integration tests.
+---
 # Testing
 
 To simplify testing of streaming integrations with Alpakka Kafka, it provides the **Alpakka Kafka testkit**. It provides help for

--- a/docs/src/main/paradox/transactions.md
+++ b/docs/src/main/paradox/transactions.md
@@ -1,3 +1,6 @@
+---
+project.description: Alpakka has support for Kafka Transactions which provide guarantees that messages processed in a consume-transform-produce workflow are processed exactly once or not at all.
+---
 # Transactions
 
 Kafka Transactions provide guarantees that messages processed in a consume-transform-produce workflow (consumed from a source topic, transformed, and produced to a destination topic) are processed exactly once or not at all.  This is achieved through coordination between the Kafka consumer group coordinator, transaction coordinator, and the consumer and producer clients used in the user application.  The Kafka producer marks messages that are consumed from the source topic as "committed" only once the transformed messages are successfully produced to the sink.  


### PR DESCRIPTION
## Purpose

Add page descriptions for HTML meta tags.

## Changes

* Remove references to `WakeupExceptions`
* Refer to "Connection Checker" in error handling docs