### PR TITLE
Configure autolabeler bot; update release helpers

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -1,0 +1,7 @@
+# configuration for https://github.com/probot/autolabeler
+
+benchmarks: ["/benchmarks"]
+core: ["/core"]
+documentation: ["/docs"]
+testkit: ["/testkit"]
+tests: ["/tests", "docker-compose.yml"]

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,6 +2,12 @@
 name-template: 'Alpakka Kafka $NEXT_PATCH_VERSION'
 tag-template: 'v$NEXT_PATCH_VERSION'
 categories:
+  - title: 'Benchmarks'
+    label: 'benchmarks'
+  - title: 'Alpakka Kafka core'
+    label: 'core'
+  - title: 'Tests'
+    label: 'tests'
   - title: 'Alpakka Kafka Testkit'
     label: 'testkit'
   - title: 'Documentation'

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,3 +1,28 @@
 # Releasing
 
 Create a new issue from the [Alpakka Kafka Release Train Issue Template](docs/release-train-issue-template.md) and follow the steps.
+
+```bash
+~/alpakka> scripts/create-release-issue.sh `version-to-be-released`
+```
+
+### Releasing only updated docs
+
+It is possible to release a revised documentation to the already existing release.
+
+1. Create a new branch from a release tag. If a revised documentation is for the `v1.1.1` release, then the name of the new branch should be `docs/v1.1.1`.
+1. Add and commit `version.sbt` file that pins the version to the one, that is being revised. Also set `isSnapshot` to `false` for the stable documentation links. For example:
+    ```scala
+    ThisBuild / version := "1.1.1"
+    ThisBuild / isSnapshot := false
+    ```
+1. Make all of the required changes to the documentation.
+1. Check the documentation update locally:
+    ```sh
+    sbt docs/previewSite
+    ```
+1. If the generated documentation looks good, send it to Gustav:
+    ```sh
+    sbt docs/publishRsync
+    ```
+1. Do not forget to push the new branch back to GitHub.

--- a/scripts/create-release-issue.sh
+++ b/scripts/create-release-issue.sh
@@ -6,5 +6,5 @@ then
   echo specify the version name to be released, eg. 1.0.0
 else
   sed -e 's/\$VERSION\$/'$VERSION'/g' docs/release-train-issue-template.md > /tmp/release-$VERSION.md
-  echo Created $(hub issue create -F /tmp/release-$VERSION.md -M $VERSION)
+  echo Created $(hub issue create -F /tmp/release-$VERSION.md --milestone $VERSION --browse)
 fi


### PR DESCRIPTION
Start using auto labeler bot.

Add "Update docs" section to release instructions.