### PR TITLE
Benchmarks: Create topics with data only once per run

### DIFF
--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/Benchmarks.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/Benchmarks.scala
@@ -26,16 +26,20 @@ abstract class BenchmarksBase() extends ScalatestKafkaSpec(0) with FlatSpecLike 
   }
 }
 
+case class MsgConf(msgCount: Int,
+                   msgSize: Int,
+                   numberOfPartitions: Int = 1)
+
 class ApacheKafkaConsumerNokafka extends BenchmarksBase() {
   it should "bench" in {
-    val cmd = RunTestCommand("apache-kafka-plain-consumer-nokafka", bootstrapServers, 2000000, 100)
+    val cmd = RunTestCommand("apache-kafka-plain-consumer-nokafka", bootstrapServers, 2000 * factor, 100)
     runPerfTest(cmd, KafkaConsumerFixtures.noopFixtureGen(cmd), KafkaConsumerBenchmarks.consumePlainNoKafka)
   }
 }
 
 class AlpakkaKafkaConsumerNokafka extends BenchmarksBase() {
   it should "bench" in {
-    val cmd = RunTestCommand("alpakka-kafka-plain-consumer-nokafka", bootstrapServers, 2000000, 100)
+    val cmd = RunTestCommand("alpakka-kafka-plain-consumer-nokafka", bootstrapServers, 2000 * factor, 100)
     runPerfTest(cmd,
                 ReactiveKafkaConsumerFixtures.noopFixtureGen(cmd),
                 ReactiveKafkaConsumerBenchmarks.consumePlainNoKafka)
@@ -44,14 +48,14 @@ class AlpakkaKafkaConsumerNokafka extends BenchmarksBase() {
 
 class ApacheKafkaPlainConsumer extends BenchmarksBase() {
   it should "bench" in {
-    val cmd = RunTestCommand("apache-kafka-plain-consumer", bootstrapServers, 2000000, 100)
+    val cmd = RunTestCommand("apache-kafka-plain-consumer", bootstrapServers, 2000 * factor, 100)
     runPerfTest(cmd, KafkaConsumerFixtures.filledTopics(cmd), KafkaConsumerBenchmarks.consumePlain)
   }
 }
 
 class AlpakkaKafkaPlainConsumer extends BenchmarksBase() {
   it should "bench" in {
-    val cmd = RunTestCommand("alpakka-kafka-plain-consumer", bootstrapServers, 2000000, 100)
+    val cmd = RunTestCommand("alpakka-kafka-plain-consumer", bootstrapServers, 2000 * factor, 100)
     runPerfTest(cmd, ReactiveKafkaConsumerFixtures.plainSources(cmd), ReactiveKafkaConsumerBenchmarks.consumePlain)
   }
 }

--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/Benchmarks.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/Benchmarks.scala
@@ -4,10 +4,12 @@
  */
 package akka.kafka.benchmarks
 
+import akka.kafka.benchmarks.PerfFixtureHelpers.FilledTopic
 import akka.kafka.benchmarks.Timed.runPerfTest
 import akka.kafka.benchmarks.app.RunTestCommand
 import akka.kafka.testkit.scaladsl.ScalatestKafkaSpec
 import org.scalatest.FlatSpecLike
+
 import scala.concurrent.duration._
 
 abstract class BenchmarksBase() extends ScalatestKafkaSpec(0) with FlatSpecLike {
@@ -26,20 +28,16 @@ abstract class BenchmarksBase() extends ScalatestKafkaSpec(0) with FlatSpecLike 
   }
 }
 
-case class MsgConf(msgCount: Int,
-                   msgSize: Int,
-                   numberOfPartitions: Int = 1)
-
 class ApacheKafkaConsumerNokafka extends BenchmarksBase() {
   it should "bench" in {
-    val cmd = RunTestCommand("apache-kafka-plain-consumer-nokafka", bootstrapServers, 2000 * factor, 100)
+    val cmd = RunTestCommand("apache-kafka-plain-consumer-nokafka", bootstrapServers, FilledTopic(2000 * factor, 100))
     runPerfTest(cmd, KafkaConsumerFixtures.noopFixtureGen(cmd), KafkaConsumerBenchmarks.consumePlainNoKafka)
   }
 }
 
 class AlpakkaKafkaConsumerNokafka extends BenchmarksBase() {
   it should "bench" in {
-    val cmd = RunTestCommand("alpakka-kafka-plain-consumer-nokafka", bootstrapServers, 2000 * factor, 100)
+    val cmd = RunTestCommand("alpakka-kafka-plain-consumer-nokafka", bootstrapServers, FilledTopic(2000 * factor, 100))
     runPerfTest(cmd,
                 ReactiveKafkaConsumerFixtures.noopFixtureGen(cmd),
                 ReactiveKafkaConsumerBenchmarks.consumePlainNoKafka)
@@ -48,28 +46,29 @@ class AlpakkaKafkaConsumerNokafka extends BenchmarksBase() {
 
 class ApacheKafkaPlainConsumer extends BenchmarksBase() {
   it should "bench" in {
-    val cmd = RunTestCommand("apache-kafka-plain-consumer", bootstrapServers, 2000 * factor, 100)
+    val cmd = RunTestCommand("apache-kafka-plain-consumer", bootstrapServers, FilledTopic(2000 * factor, 100))
     runPerfTest(cmd, KafkaConsumerFixtures.filledTopics(cmd), KafkaConsumerBenchmarks.consumePlain)
   }
 }
 
 class AlpakkaKafkaPlainConsumer extends BenchmarksBase() {
   it should "bench" in {
-    val cmd = RunTestCommand("alpakka-kafka-plain-consumer", bootstrapServers, 2000 * factor, 100)
+    val cmd = RunTestCommand("alpakka-kafka-plain-consumer", bootstrapServers, FilledTopic(2000 * factor, 100))
     runPerfTest(cmd, ReactiveKafkaConsumerFixtures.plainSources(cmd), ReactiveKafkaConsumerBenchmarks.consumePlain)
   }
 }
 
 class ApacheKafkaBatchedConsumer extends BenchmarksBase() {
   it should "bench with small messages" in {
-    val cmd = RunTestCommand("apache-kafka-batched-consumer", bootstrapServers, 1000 * factor, 100)
+    val cmd = RunTestCommand("apache-kafka-batched-consumer", bootstrapServers, FilledTopic(1000 * factor, 100))
     runPerfTest(cmd,
                 KafkaConsumerFixtures.filledTopics(cmd),
                 KafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
   }
 
   it should "bench with normal messages" in {
-    val cmd = RunTestCommand("apache-kafka-batched-consumer-normal-msg", bootstrapServers, 1000 * factor, 5 * 1000)
+    val cmd =
+      RunTestCommand("apache-kafka-batched-consumer-normal-msg", bootstrapServers, FilledTopic(1000 * factor, 5 * 1000))
     runPerfTest(cmd,
                 KafkaConsumerFixtures.filledTopics(cmd),
                 KafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
@@ -78,9 +77,7 @@ class ApacheKafkaBatchedConsumer extends BenchmarksBase() {
   it should "bench with normal messages and eight partitions" in {
     val cmd = RunTestCommand("apache-kafka-batched-consumer-normal-msg-8-partitions",
                              bootstrapServers,
-                             msgCount = 1000 * factor,
-                             msgSize = 5 * 1000,
-                             numberOfPartitions = 8)
+                             FilledTopic(msgCount = 1000 * factor, msgSize = 5 * 1000, numberOfPartitions = 8))
     runPerfTest(cmd,
                 KafkaConsumerFixtures.filledTopics(cmd),
                 KafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
@@ -90,14 +87,14 @@ class ApacheKafkaBatchedConsumer extends BenchmarksBase() {
 class AlpakkaKafkaBatchedConsumer extends BenchmarksBase() {
 
   it should "bench with small messages" in {
-    val cmd = RunTestCommand("alpakka-kafka-batched-consumer", bootstrapServers, 1000 * factor, 100)
+    val cmd = RunTestCommand("alpakka-kafka-batched-consumer", bootstrapServers, FilledTopic(1000 * factor, 100))
     runPerfTest(cmd,
                 ReactiveKafkaConsumerFixtures.committableSources(cmd),
                 ReactiveKafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
   }
 
   it should "bench with normal messages" in {
-    val cmd = RunTestCommand("alpakka-kafka-batched-consumer-normal-msg", bootstrapServers, 1000 * factor, 5 * 1000)
+    val cmd = RunTestCommand("alpakka-kafka-batched-consumer-normal-msg", bootstrapServers, FilledTopic(1000 * factor, 5 * 1000))
     runPerfTest(cmd,
                 ReactiveKafkaConsumerFixtures.committableSources(cmd),
                 ReactiveKafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
@@ -106,9 +103,9 @@ class AlpakkaKafkaBatchedConsumer extends BenchmarksBase() {
   it should "bench with normal messages and eight partitions" in {
     val cmd = RunTestCommand("alpakka-kafka-batched-consumer-normal-msg-8-partitions",
                              bootstrapServers,
-                             msgCount = 1000 * factor,
+      FilledTopic(msgCount = 1000 * factor,
                              msgSize = 5 * 1000,
-                             numberOfPartitions = 8)
+                             numberOfPartitions = 8))
     runPerfTest(cmd,
                 ReactiveKafkaConsumerFixtures.committableSources(cmd),
                 ReactiveKafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
@@ -117,14 +114,14 @@ class AlpakkaKafkaBatchedConsumer extends BenchmarksBase() {
 
 class ApacheKafkaAtMostOnceConsumer extends BenchmarksBase() {
   it should "bench" in {
-    val cmd = RunTestCommand("apache-kafka-at-most-once-consumer", bootstrapServers, 50000, 100)
+    val cmd = RunTestCommand("apache-kafka-at-most-once-consumer", bootstrapServers, FilledTopic(50 * factor, 100))
     runPerfTest(cmd, KafkaConsumerFixtures.filledTopics(cmd), KafkaConsumerBenchmarks.consumeCommitAtMostOnce)
   }
 }
 
 class AlpakkaKafkaAtMostOnceConsumer extends BenchmarksBase() {
   it should "bench" in {
-    val cmd = RunTestCommand("alpakka-kafka-at-most-once-consumer", bootstrapServers, 50000, 100)
+    val cmd = RunTestCommand("alpakka-kafka-at-most-once-consumer", bootstrapServers, FilledTopic(50 * factor, 100))
     runPerfTest(cmd,
                 ReactiveKafkaConsumerFixtures.committableSources(cmd),
                 ReactiveKafkaConsumerBenchmarks.consumeCommitAtMostOnce)
@@ -135,17 +132,18 @@ class ApacheKafkaPlainProducer extends BenchmarksBase() {
   private val prefix = "apache-kafka-plain-producer"
 
   it should "bench with small messages" in {
-    val cmd = RunTestCommand(prefix, bootstrapServers, 2000 * factor, 100)
+    val cmd = RunTestCommand(prefix, bootstrapServers, FilledTopic(2000 * factor, 100))
     runPerfTest(cmd, KafkaProducerFixtures.initializedProducer(cmd), KafkaProducerBenchmarks.plainFlow)
   }
 
   it should "bench with normal messages" in {
-    val cmd = RunTestCommand(prefix + "-normal-msg", bootstrapServers, 2000 * factor, 5000)
+    val cmd = RunTestCommand(prefix + "-normal-msg", bootstrapServers, FilledTopic(2000 * factor, 5000))
     runPerfTest(cmd, KafkaProducerFixtures.initializedProducer(cmd), KafkaProducerBenchmarks.plainFlow)
   }
 
   it should "bench with normal messages written to 8 partitions" in {
-    val cmd = RunTestCommand(prefix + "-normal-msg-8-partitions", bootstrapServers, 2000 * factor, 5000, numberOfPartitions = 8)
+    val cmd =
+      RunTestCommand(prefix + "-normal-msg-8-partitions", bootstrapServers, FilledTopic(2000 * factor, 5000, numberOfPartitions = 8))
     runPerfTest(cmd, KafkaProducerFixtures.initializedProducer(cmd), KafkaProducerBenchmarks.plainFlow)
   }
 }
@@ -154,31 +152,32 @@ class AlpakkaKafkaPlainProducer extends BenchmarksBase() {
   private val prefix = "alpakka-kafka-plain-producer"
 
   it should "bench with small messages" in {
-    val cmd = RunTestCommand(prefix, bootstrapServers, 2000 * factor, 100)
+    val cmd = RunTestCommand(prefix, bootstrapServers, FilledTopic(2000 * factor, 100))
     runPerfTest(cmd, ReactiveKafkaProducerFixtures.flowFixture(cmd), ReactiveKafkaProducerBenchmarks.plainFlow)
   }
 
   it should "bench with normal messages" in {
-    val cmd = RunTestCommand(prefix + "-normal-msg", bootstrapServers, 2000 * factor, 5000)
+    val cmd = RunTestCommand(prefix + "-normal-msg", bootstrapServers, FilledTopic(2000 * factor, 5000))
     runPerfTest(cmd, ReactiveKafkaProducerFixtures.flowFixture(cmd), ReactiveKafkaProducerBenchmarks.plainFlow)
   }
 
   it should "bench with normal messages written to 8 partitions" in {
-    val cmd = RunTestCommand(prefix + "-normal-msg-8-partitions", bootstrapServers, 2000 * factor, 5000, numberOfPartitions = 8)
+    val cmd =
+      RunTestCommand(prefix + "-normal-msg-8-partitions", bootstrapServers, FilledTopic(2000 * factor, 5000, numberOfPartitions = 8))
     runPerfTest(cmd, ReactiveKafkaProducerFixtures.flowFixture(cmd), ReactiveKafkaProducerBenchmarks.plainFlow)
   }
 }
 
 class ApacheKafkaTransactions extends BenchmarksBase() {
   it should "bench with small messages" in {
-    val cmd = RunTestCommand("apache-kafka-transactions", bootstrapServers, 100 * factor, 100)
+    val cmd = RunTestCommand("apache-kafka-transactions", bootstrapServers, FilledTopic(100 * factor, 100))
     runPerfTest(cmd,
                 KafkaTransactionFixtures.initialize(cmd),
                 KafkaTransactionBenchmarks.consumeTransformProduceTransaction(commitInterval = 100.milliseconds))
   }
 
   it should "bench with normal messages" in {
-    val cmd = RunTestCommand("apache-kafka-transactions-normal-msg", bootstrapServers, 100 * factor, 5000)
+    val cmd = RunTestCommand("apache-kafka-transactions-normal-msg", bootstrapServers, FilledTopic(100 * factor, 5000))
     runPerfTest(cmd,
                 KafkaTransactionFixtures.initialize(cmd),
                 KafkaTransactionBenchmarks.consumeTransformProduceTransaction(commitInterval = 100.milliseconds))
@@ -187,7 +186,7 @@ class ApacheKafkaTransactions extends BenchmarksBase() {
 
 class AlpakkaKafkaTransactions extends BenchmarksBase() {
   it should "bench with small messages" in {
-    val cmd = RunTestCommand("alpakka-kafka-transactions", bootstrapServers, 100 * factor, 100)
+    val cmd = RunTestCommand("alpakka-kafka-transactions", bootstrapServers, FilledTopic(100 * factor, 100))
     runPerfTest(
       cmd,
       ReactiveKafkaTransactionFixtures.transactionalSourceAndSink(cmd, commitInterval = 100.milliseconds),
@@ -196,7 +195,7 @@ class AlpakkaKafkaTransactions extends BenchmarksBase() {
   }
 
   it should "bench with normal messages" in {
-    val cmd = RunTestCommand("alpakka-kafka-transactions-normal-msg", bootstrapServers, 100 * factor, 5000)
+    val cmd = RunTestCommand("alpakka-kafka-transactions-normal-msg", bootstrapServers, FilledTopic(100 * factor, 5000))
     runPerfTest(
       cmd,
       ReactiveKafkaTransactionFixtures.transactionalSourceAndSink(cmd, commitInterval = 100.milliseconds),

--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/Benchmarks.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/Benchmarks.scala
@@ -10,12 +10,30 @@ import akka.kafka.benchmarks.app.RunTestCommand
 import akka.kafka.testkit.scaladsl.ScalatestKafkaSpec
 import org.scalatest.FlatSpecLike
 
+import BenchmarksBase._
+
 import scala.concurrent.duration._
 
-abstract class BenchmarksBase() extends ScalatestKafkaSpec(0) with FlatSpecLike {
-
+object BenchmarksBase {
   // Message count multiplier to adapt for shorter local testing
   val factor = 1000
+
+  val topic_50_100 = FilledTopic(50 * factor, 100)
+
+  val topic_100_100 = FilledTopic(100 * factor, 100)
+  val topic_100_5000 = FilledTopic(100 * factor, 5000)
+
+  val topic_1000_100 = FilledTopic(1000 * factor, 100)
+  val topic_1000_5000 = FilledTopic(1000 * factor, 5 * 1000)
+  val topic_1000_5000_8 = FilledTopic(msgCount = 1000 * factor, msgSize = 5 * 1000, numberOfPartitions = 8)
+
+  val topic_2000_100 = FilledTopic(2000 * factor, 100)
+  val topic_2000_5000 = FilledTopic(2000 * factor, 5000)
+  val topic_2000_5000_8 = FilledTopic(2000 * factor, 5000, numberOfPartitions = 8)
+
+}
+
+abstract class BenchmarksBase() extends ScalatestKafkaSpec(0) with FlatSpecLike {
 
   override def bootstrapServers: String =
     (1 to BuildInfo.kafkaScale).map(i => sys.props(s"kafka_${i}_9094")).mkString(",")
@@ -30,14 +48,14 @@ abstract class BenchmarksBase() extends ScalatestKafkaSpec(0) with FlatSpecLike 
 
 class ApacheKafkaConsumerNokafka extends BenchmarksBase() {
   it should "bench" in {
-    val cmd = RunTestCommand("apache-kafka-plain-consumer-nokafka", bootstrapServers, FilledTopic(2000 * factor, 100))
+    val cmd = RunTestCommand("apache-kafka-plain-consumer-nokafka", bootstrapServers, topic_2000_100)
     runPerfTest(cmd, KafkaConsumerFixtures.noopFixtureGen(cmd), KafkaConsumerBenchmarks.consumePlainNoKafka)
   }
 }
 
 class AlpakkaKafkaConsumerNokafka extends BenchmarksBase() {
   it should "bench" in {
-    val cmd = RunTestCommand("alpakka-kafka-plain-consumer-nokafka", bootstrapServers, FilledTopic(2000 * factor, 100))
+    val cmd = RunTestCommand("alpakka-kafka-plain-consumer-nokafka", bootstrapServers, topic_2000_100)
     runPerfTest(cmd,
                 ReactiveKafkaConsumerFixtures.noopFixtureGen(cmd),
                 ReactiveKafkaConsumerBenchmarks.consumePlainNoKafka)
@@ -46,21 +64,21 @@ class AlpakkaKafkaConsumerNokafka extends BenchmarksBase() {
 
 class ApacheKafkaPlainConsumer extends BenchmarksBase() {
   it should "bench" in {
-    val cmd = RunTestCommand("apache-kafka-plain-consumer", bootstrapServers, FilledTopic(2000 * factor, 100))
+    val cmd = RunTestCommand("apache-kafka-plain-consumer", bootstrapServers, topic_2000_100)
     runPerfTest(cmd, KafkaConsumerFixtures.filledTopics(cmd), KafkaConsumerBenchmarks.consumePlain)
   }
 }
 
 class AlpakkaKafkaPlainConsumer extends BenchmarksBase() {
   it should "bench" in {
-    val cmd = RunTestCommand("alpakka-kafka-plain-consumer", bootstrapServers, FilledTopic(2000 * factor, 100))
+    val cmd = RunTestCommand("alpakka-kafka-plain-consumer", bootstrapServers, topic_2000_100)
     runPerfTest(cmd, ReactiveKafkaConsumerFixtures.plainSources(cmd), ReactiveKafkaConsumerBenchmarks.consumePlain)
   }
 }
 
 class ApacheKafkaBatchedConsumer extends BenchmarksBase() {
   it should "bench with small messages" in {
-    val cmd = RunTestCommand("apache-kafka-batched-consumer", bootstrapServers, FilledTopic(1000 * factor, 100))
+    val cmd = RunTestCommand("apache-kafka-batched-consumer", bootstrapServers, topic_1000_100)
     runPerfTest(cmd,
                 KafkaConsumerFixtures.filledTopics(cmd),
                 KafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
@@ -68,16 +86,15 @@ class ApacheKafkaBatchedConsumer extends BenchmarksBase() {
 
   it should "bench with normal messages" in {
     val cmd =
-      RunTestCommand("apache-kafka-batched-consumer-normal-msg", bootstrapServers, FilledTopic(1000 * factor, 5 * 1000))
+      RunTestCommand("apache-kafka-batched-consumer-normal-msg", bootstrapServers, topic_1000_5000)
     runPerfTest(cmd,
                 KafkaConsumerFixtures.filledTopics(cmd),
                 KafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
   }
 
   it should "bench with normal messages and eight partitions" in {
-    val cmd = RunTestCommand("apache-kafka-batched-consumer-normal-msg-8-partitions",
-                             bootstrapServers,
-                             FilledTopic(msgCount = 1000 * factor, msgSize = 5 * 1000, numberOfPartitions = 8))
+    val cmd =
+      RunTestCommand("apache-kafka-batched-consumer-normal-msg-8-partitions", bootstrapServers, topic_1000_5000_8)
     runPerfTest(cmd,
                 KafkaConsumerFixtures.filledTopics(cmd),
                 KafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
@@ -87,25 +104,22 @@ class ApacheKafkaBatchedConsumer extends BenchmarksBase() {
 class AlpakkaKafkaBatchedConsumer extends BenchmarksBase() {
 
   it should "bench with small messages" in {
-    val cmd = RunTestCommand("alpakka-kafka-batched-consumer", bootstrapServers, FilledTopic(1000 * factor, 100))
+    val cmd = RunTestCommand("alpakka-kafka-batched-consumer", bootstrapServers, topic_1000_100)
     runPerfTest(cmd,
                 ReactiveKafkaConsumerFixtures.committableSources(cmd),
                 ReactiveKafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
   }
 
   it should "bench with normal messages" in {
-    val cmd = RunTestCommand("alpakka-kafka-batched-consumer-normal-msg", bootstrapServers, FilledTopic(1000 * factor, 5 * 1000))
+    val cmd = RunTestCommand("alpakka-kafka-batched-consumer-normal-msg", bootstrapServers, topic_1000_5000)
     runPerfTest(cmd,
                 ReactiveKafkaConsumerFixtures.committableSources(cmd),
                 ReactiveKafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
   }
 
   it should "bench with normal messages and eight partitions" in {
-    val cmd = RunTestCommand("alpakka-kafka-batched-consumer-normal-msg-8-partitions",
-                             bootstrapServers,
-      FilledTopic(msgCount = 1000 * factor,
-                             msgSize = 5 * 1000,
-                             numberOfPartitions = 8))
+    val cmd =
+      RunTestCommand("alpakka-kafka-batched-consumer-normal-msg-8-partitions", bootstrapServers, topic_1000_5000_8)
     runPerfTest(cmd,
                 ReactiveKafkaConsumerFixtures.committableSources(cmd),
                 ReactiveKafkaConsumerBenchmarks.consumerAtLeastOnceBatched(batchSize = 1000))
@@ -114,14 +128,14 @@ class AlpakkaKafkaBatchedConsumer extends BenchmarksBase() {
 
 class ApacheKafkaAtMostOnceConsumer extends BenchmarksBase() {
   it should "bench" in {
-    val cmd = RunTestCommand("apache-kafka-at-most-once-consumer", bootstrapServers, FilledTopic(50 * factor, 100))
+    val cmd = RunTestCommand("apache-kafka-at-most-once-consumer", bootstrapServers, topic_50_100)
     runPerfTest(cmd, KafkaConsumerFixtures.filledTopics(cmd), KafkaConsumerBenchmarks.consumeCommitAtMostOnce)
   }
 }
 
 class AlpakkaKafkaAtMostOnceConsumer extends BenchmarksBase() {
   it should "bench" in {
-    val cmd = RunTestCommand("alpakka-kafka-at-most-once-consumer", bootstrapServers, FilledTopic(50 * factor, 100))
+    val cmd = RunTestCommand("alpakka-kafka-at-most-once-consumer", bootstrapServers, topic_50_100)
     runPerfTest(cmd,
                 ReactiveKafkaConsumerFixtures.committableSources(cmd),
                 ReactiveKafkaConsumerBenchmarks.consumeCommitAtMostOnce)
@@ -132,18 +146,18 @@ class ApacheKafkaPlainProducer extends BenchmarksBase() {
   private val prefix = "apache-kafka-plain-producer"
 
   it should "bench with small messages" in {
-    val cmd = RunTestCommand(prefix, bootstrapServers, FilledTopic(2000 * factor, 100))
+    val cmd = RunTestCommand(prefix, bootstrapServers, topic_2000_100)
     runPerfTest(cmd, KafkaProducerFixtures.initializedProducer(cmd), KafkaProducerBenchmarks.plainFlow)
   }
 
   it should "bench with normal messages" in {
-    val cmd = RunTestCommand(prefix + "-normal-msg", bootstrapServers, FilledTopic(2000 * factor, 5000))
+    val cmd = RunTestCommand(prefix + "-normal-msg", bootstrapServers, topic_2000_5000)
     runPerfTest(cmd, KafkaProducerFixtures.initializedProducer(cmd), KafkaProducerBenchmarks.plainFlow)
   }
 
   it should "bench with normal messages written to 8 partitions" in {
     val cmd =
-      RunTestCommand(prefix + "-normal-msg-8-partitions", bootstrapServers, FilledTopic(2000 * factor, 5000, numberOfPartitions = 8))
+      RunTestCommand(prefix + "-normal-msg-8-partitions", bootstrapServers, topic_2000_5000_8)
     runPerfTest(cmd, KafkaProducerFixtures.initializedProducer(cmd), KafkaProducerBenchmarks.plainFlow)
   }
 }
@@ -152,32 +166,32 @@ class AlpakkaKafkaPlainProducer extends BenchmarksBase() {
   private val prefix = "alpakka-kafka-plain-producer"
 
   it should "bench with small messages" in {
-    val cmd = RunTestCommand(prefix, bootstrapServers, FilledTopic(2000 * factor, 100))
+    val cmd = RunTestCommand(prefix, bootstrapServers, topic_2000_100)
     runPerfTest(cmd, ReactiveKafkaProducerFixtures.flowFixture(cmd), ReactiveKafkaProducerBenchmarks.plainFlow)
   }
 
   it should "bench with normal messages" in {
-    val cmd = RunTestCommand(prefix + "-normal-msg", bootstrapServers, FilledTopic(2000 * factor, 5000))
+    val cmd = RunTestCommand(prefix + "-normal-msg", bootstrapServers, topic_2000_5000)
     runPerfTest(cmd, ReactiveKafkaProducerFixtures.flowFixture(cmd), ReactiveKafkaProducerBenchmarks.plainFlow)
   }
 
   it should "bench with normal messages written to 8 partitions" in {
     val cmd =
-      RunTestCommand(prefix + "-normal-msg-8-partitions", bootstrapServers, FilledTopic(2000 * factor, 5000, numberOfPartitions = 8))
+      RunTestCommand(prefix + "-normal-msg-8-partitions", bootstrapServers, topic_2000_5000_8)
     runPerfTest(cmd, ReactiveKafkaProducerFixtures.flowFixture(cmd), ReactiveKafkaProducerBenchmarks.plainFlow)
   }
 }
 
 class ApacheKafkaTransactions extends BenchmarksBase() {
   it should "bench with small messages" in {
-    val cmd = RunTestCommand("apache-kafka-transactions", bootstrapServers, FilledTopic(100 * factor, 100))
+    val cmd = RunTestCommand("apache-kafka-transactions", bootstrapServers, topic_100_100)
     runPerfTest(cmd,
                 KafkaTransactionFixtures.initialize(cmd),
                 KafkaTransactionBenchmarks.consumeTransformProduceTransaction(commitInterval = 100.milliseconds))
   }
 
   it should "bench with normal messages" in {
-    val cmd = RunTestCommand("apache-kafka-transactions-normal-msg", bootstrapServers, FilledTopic(100 * factor, 5000))
+    val cmd = RunTestCommand("apache-kafka-transactions-normal-msg", bootstrapServers, topic_100_5000)
     runPerfTest(cmd,
                 KafkaTransactionFixtures.initialize(cmd),
                 KafkaTransactionBenchmarks.consumeTransformProduceTransaction(commitInterval = 100.milliseconds))
@@ -186,7 +200,7 @@ class ApacheKafkaTransactions extends BenchmarksBase() {
 
 class AlpakkaKafkaTransactions extends BenchmarksBase() {
   it should "bench with small messages" in {
-    val cmd = RunTestCommand("alpakka-kafka-transactions", bootstrapServers, FilledTopic(100 * factor, 100))
+    val cmd = RunTestCommand("alpakka-kafka-transactions", bootstrapServers, topic_100_100)
     runPerfTest(
       cmd,
       ReactiveKafkaTransactionFixtures.transactionalSourceAndSink(cmd, commitInterval = 100.milliseconds),
@@ -195,7 +209,7 @@ class AlpakkaKafkaTransactions extends BenchmarksBase() {
   }
 
   it should "bench with normal messages" in {
-    val cmd = RunTestCommand("alpakka-kafka-transactions-normal-msg", bootstrapServers, FilledTopic(100 * factor, 5000))
+    val cmd = RunTestCommand("alpakka-kafka-transactions-normal-msg", bootstrapServers, topic_100_5000)
     runPerfTest(
       cmd,
       ReactiveKafkaTransactionFixtures.transactionalSourceAndSink(cmd, commitInterval = 100.milliseconds),

--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/NoCommitBackpressure.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/NoCommitBackpressure.scala
@@ -1,5 +1,6 @@
 package akka.kafka.benchmarks
 
+import akka.kafka.benchmarks.PerfFixtureHelpers.FilledTopic
 import akka.kafka.benchmarks.Timed.runPerfTest
 import akka.kafka.benchmarks.app.RunTestCommand
 
@@ -7,28 +8,26 @@ class RawKafkaCommitEveryPollConsumer extends BenchmarksBase() {
   private val prefix = "apache-kafka-batched-no-pausing-"
 
   it should "bench with small messages" in {
-    val cmd = RunTestCommand(prefix + "consumer", bootstrapServers, 1000 * factor, 100)
+    val cmd = RunTestCommand(prefix + "consumer", bootstrapServers, FilledTopic(1000 * factor, 100))
     runPerfTest(cmd,
-      KafkaConsumerFixtures.filledTopics(cmd),
-      KafkaConsumerBenchmarks.consumerAtLeastOnceCommitEveryPoll())
+                KafkaConsumerFixtures.filledTopics(cmd),
+                KafkaConsumerBenchmarks.consumerAtLeastOnceCommitEveryPoll())
   }
 
   it should "bench with normal messages" in {
-    val cmd = RunTestCommand(prefix + "consumer-normal-msg", bootstrapServers, 1000 * factor, 5 * 1000)
+    val cmd = RunTestCommand(prefix + "consumer-normal-msg", bootstrapServers, FilledTopic(1000 * factor, 5 * 1000))
     runPerfTest(cmd,
-      KafkaConsumerFixtures.filledTopics(cmd),
-      KafkaConsumerBenchmarks.consumerAtLeastOnceCommitEveryPoll())
+                KafkaConsumerFixtures.filledTopics(cmd),
+                KafkaConsumerBenchmarks.consumerAtLeastOnceCommitEveryPoll())
   }
 
   it should "bench with normal messages and eight partitions" in {
     val cmd = RunTestCommand(prefix + "consumer-normal-msg-8-partitions",
-      bootstrapServers,
-      msgCount = 1000 * factor,
-      msgSize = 5 * 1000,
-      numberOfPartitions = 8)
+                             bootstrapServers,
+                             FilledTopic(msgCount = 1000 * factor, msgSize = 5 * 1000, numberOfPartitions = 8))
     runPerfTest(cmd,
-      KafkaConsumerFixtures.filledTopics(cmd),
-      KafkaConsumerBenchmarks.consumerAtLeastOnceCommitEveryPoll())
+                KafkaConsumerFixtures.filledTopics(cmd),
+                KafkaConsumerBenchmarks.consumerAtLeastOnceCommitEveryPoll())
   }
 }
 
@@ -36,28 +35,25 @@ class AlpakkaCommitAndForgetConsumer extends BenchmarksBase() {
   val prefix = "alpakka-kafka-commit-and-forget-"
 
   it should "bench with small messages" in {
-    val cmd = RunTestCommand(prefix + "consumer", bootstrapServers, 1000 * factor, 100)
+    val cmd = RunTestCommand(prefix + "consumer", bootstrapServers, FilledTopic(1000 * factor, 100))
     runPerfTest(cmd,
-      ReactiveKafkaConsumerFixtures.committableSources(cmd),
-      ReactiveKafkaConsumerBenchmarks.consumerCommitAndForget(commitBatchSize = 1000))
+                ReactiveKafkaConsumerFixtures.committableSources(cmd),
+                ReactiveKafkaConsumerBenchmarks.consumerCommitAndForget(commitBatchSize = 1000))
   }
 
   it should "bench with normal messages" in {
-    val cmd = RunTestCommand(prefix + "normal-msg", bootstrapServers, 1000 * factor, 5 * 1000)
+    val cmd = RunTestCommand(prefix + "normal-msg", bootstrapServers, FilledTopic(1000 * factor, 5 * 1000))
     runPerfTest(cmd,
-      ReactiveKafkaConsumerFixtures.committableSources(cmd),
-      ReactiveKafkaConsumerBenchmarks.consumerCommitAndForget(commitBatchSize = 1000))
+                ReactiveKafkaConsumerFixtures.committableSources(cmd),
+                ReactiveKafkaConsumerBenchmarks.consumerCommitAndForget(commitBatchSize = 1000))
   }
 
   it should "bench with normal messages and eight partitions" in {
     val cmd = RunTestCommand(prefix + "normal-msg-8-partitions",
-      bootstrapServers,
-      msgCount = 1000 * factor,
-      msgSize = 5 * 1000,
-      numberOfPartitions = 8)
+                             bootstrapServers,
+                             FilledTopic(msgCount = 1000 * factor, msgSize = 5 * 1000, numberOfPartitions = 8))
     runPerfTest(cmd,
-      ReactiveKafkaConsumerFixtures.committableSources(cmd),
-      ReactiveKafkaConsumerBenchmarks.consumerCommitAndForget(commitBatchSize = 1000))
+                ReactiveKafkaConsumerFixtures.committableSources(cmd),
+                ReactiveKafkaConsumerBenchmarks.consumerCommitAndForget(commitBatchSize = 1000))
   }
 }
-

--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/NoCommitBackpressure.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/NoCommitBackpressure.scala
@@ -1,21 +1,22 @@
 package akka.kafka.benchmarks
 
-import akka.kafka.benchmarks.PerfFixtureHelpers.FilledTopic
 import akka.kafka.benchmarks.Timed.runPerfTest
 import akka.kafka.benchmarks.app.RunTestCommand
+
+import BenchmarksBase._
 
 class RawKafkaCommitEveryPollConsumer extends BenchmarksBase() {
   private val prefix = "apache-kafka-batched-no-pausing-"
 
   it should "bench with small messages" in {
-    val cmd = RunTestCommand(prefix + "consumer", bootstrapServers, FilledTopic(1000 * factor, 100))
+    val cmd = RunTestCommand(prefix + "consumer", bootstrapServers, topic_1000_100)
     runPerfTest(cmd,
                 KafkaConsumerFixtures.filledTopics(cmd),
                 KafkaConsumerBenchmarks.consumerAtLeastOnceCommitEveryPoll())
   }
 
   it should "bench with normal messages" in {
-    val cmd = RunTestCommand(prefix + "consumer-normal-msg", bootstrapServers, FilledTopic(1000 * factor, 5 * 1000))
+    val cmd = RunTestCommand(prefix + "consumer-normal-msg", bootstrapServers, topic_1000_5000)
     runPerfTest(cmd,
                 KafkaConsumerFixtures.filledTopics(cmd),
                 KafkaConsumerBenchmarks.consumerAtLeastOnceCommitEveryPoll())
@@ -24,7 +25,7 @@ class RawKafkaCommitEveryPollConsumer extends BenchmarksBase() {
   it should "bench with normal messages and eight partitions" in {
     val cmd = RunTestCommand(prefix + "consumer-normal-msg-8-partitions",
                              bootstrapServers,
-                             FilledTopic(msgCount = 1000 * factor, msgSize = 5 * 1000, numberOfPartitions = 8))
+                             topic_1000_5000_8)
     runPerfTest(cmd,
                 KafkaConsumerFixtures.filledTopics(cmd),
                 KafkaConsumerBenchmarks.consumerAtLeastOnceCommitEveryPoll())
@@ -35,14 +36,14 @@ class AlpakkaCommitAndForgetConsumer extends BenchmarksBase() {
   val prefix = "alpakka-kafka-commit-and-forget-"
 
   it should "bench with small messages" in {
-    val cmd = RunTestCommand(prefix + "consumer", bootstrapServers, FilledTopic(1000 * factor, 100))
+    val cmd = RunTestCommand(prefix + "consumer", bootstrapServers, topic_1000_100)
     runPerfTest(cmd,
                 ReactiveKafkaConsumerFixtures.committableSources(cmd),
                 ReactiveKafkaConsumerBenchmarks.consumerCommitAndForget(commitBatchSize = 1000))
   }
 
   it should "bench with normal messages" in {
-    val cmd = RunTestCommand(prefix + "normal-msg", bootstrapServers, FilledTopic(1000 * factor, 5 * 1000))
+    val cmd = RunTestCommand(prefix + "normal-msg", bootstrapServers, topic_1000_5000)
     runPerfTest(cmd,
                 ReactiveKafkaConsumerFixtures.committableSources(cmd),
                 ReactiveKafkaConsumerBenchmarks.consumerCommitAndForget(commitBatchSize = 1000))
@@ -51,7 +52,7 @@ class AlpakkaCommitAndForgetConsumer extends BenchmarksBase() {
   it should "bench with normal messages and eight partitions" in {
     val cmd = RunTestCommand(prefix + "normal-msg-8-partitions",
                              bootstrapServers,
-                             FilledTopic(msgCount = 1000 * factor, msgSize = 5 * 1000, numberOfPartitions = 8))
+                             topic_1000_5000_8)
     runPerfTest(cmd,
                 ReactiveKafkaConsumerFixtures.committableSources(cmd),
                 ReactiveKafkaConsumerBenchmarks.consumerCommitAndForget(commitBatchSize = 1000))

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaConsumerFixtureGen.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaConsumerFixtureGen.scala
@@ -27,8 +27,7 @@ object KafkaConsumerFixtures extends PerfFixtureHelpers {
   def filledTopics(c: RunTestCommand) = FixtureGen[KafkaConsumerTestFixture](
     c,
     msgCount => {
-      val topic = randomId()
-      fillTopic(topic, c)
+      fillTopic(c.filledTopic, c.kafkaHost)
       val consumerJavaProps = new java.util.Properties
       consumerJavaProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, c.kafkaHost)
       consumerJavaProps.put(ConsumerConfig.CLIENT_ID_CONFIG, randomId())
@@ -37,8 +36,8 @@ object KafkaConsumerFixtures extends PerfFixtureHelpers {
 
       val consumer =
         new KafkaConsumer[Array[Byte], String](consumerJavaProps, new ByteArrayDeserializer, new StringDeserializer)
-      consumer.subscribe(Set(topic).asJava)
-      KafkaConsumerTestFixture(topic, msgCount, consumer)
+      consumer.subscribe(Set(c.filledTopic.topic).asJava)
+      KafkaConsumerTestFixture(c.filledTopic.topic, msgCount, consumer)
     }
   )
 }

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaProducerFixtureGen.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaProducerFixtureGen.scala
@@ -5,6 +5,7 @@
 
 package akka.kafka.benchmarks
 
+import akka.kafka.benchmarks.PerfFixtureHelpers.FilledTopic
 import akka.kafka.benchmarks.app.RunTestCommand
 import org.apache.kafka.clients.producer.KafkaProducer
 
@@ -28,9 +29,9 @@ object KafkaProducerFixtures extends PerfFixtureHelpers {
   def initializedProducer(c: RunTestCommand) = FixtureGen[KafkaProducerTestFixture](
     c,
     msgCount => {
-      val topic = randomId()
-      val rawProducer = initTopicAndProducer(topic, c.copy(msgCount = 1))
-      KafkaProducerTestFixture(topic, msgCount, c.msgSize, rawProducer, c.numberOfPartitions)
+      val ft = FilledTopic(msgCount = 1, msgSize = c.msgSize, numberOfPartitions = c.numberOfPartitions)
+      val rawProducer = createTopic(ft, c.kafkaHost)
+      KafkaProducerTestFixture(ft.topic, msgCount, c.msgSize, rawProducer, c.numberOfPartitions)
     }
   )
 }

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaTransactionFixtureGen.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaTransactionFixtureGen.scala
@@ -43,8 +43,7 @@ object KafkaTransactionFixtures extends PerfFixtureHelpers {
     FixtureGen[KafkaTransactionTestFixture](
       c,
       msgCount => {
-        val sourceTopic = randomId()
-        fillTopic(sourceTopic, c)
+        fillTopic(c.filledTopic, c.kafkaHost)
         val groupId = randomId()
         val sinkTopic = randomId()
 
@@ -58,7 +57,7 @@ object KafkaTransactionFixtures extends PerfFixtureHelpers {
         consumerJavaProps.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG,
                               IsolationLevel.READ_COMMITTED.toString.toLowerCase(Locale.ENGLISH))
         val consumer = new KafkaConsumer[Array[Byte], String](consumerJavaProps)
-        consumer.subscribe(Set(sourceTopic).asJava)
+        consumer.subscribe(Set(c.filledTopic.topic).asJava)
 
         val producerJavaProps = new java.util.Properties
         producerJavaProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, classOf[ByteArraySerializer])
@@ -68,7 +67,7 @@ object KafkaTransactionFixtures extends PerfFixtureHelpers {
         producerJavaProps.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, randomId())
         val producer = new KafkaProducer[Array[Byte], String](producerJavaProps)
 
-        KafkaTransactionTestFixture(sourceTopic, sinkTopic, msgCount, groupId, consumer, producer)
+        KafkaTransactionTestFixture(c.filledTopic.topic, sinkTopic, msgCount, groupId, consumer, producer)
       }
     )
 }

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/PerfFixtureHelpers.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/PerfFixtureHelpers.scala
@@ -9,7 +9,6 @@ import java.util
 import java.util.concurrent.TimeUnit
 import java.util.{Arrays, Properties, UUID}
 
-import akka.kafka.benchmarks.app.RunTestCommand
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.kafka.clients.admin.{AdminClient, NewTopic}
 import org.apache.kafka.clients.producer._
@@ -21,6 +20,17 @@ import scala.language.postfixOps
 
 object PerfFixtureHelpers {
   def stringOfSize(size: Int) = new String(Array.fill(size)('0'))
+
+  def randomId(): String = UUID.randomUUID().toString
+
+  case class FilledTopic(
+      topic: String = randomId(),
+      msgCount: Int,
+      msgSize: Int,
+      numberOfPartitions: Int = 1
+  ) {
+    def replicationFactor = BuildInfo.kafkaScale
+  }
 }
 
 private[benchmarks] trait PerfFixtureHelpers extends LazyLogging {
@@ -29,33 +39,58 @@ private[benchmarks] trait PerfFixtureHelpers extends LazyLogging {
   val producerTimeout = 6 minutes
   val logPercentStep = 25
 
-  def randomId() = UUID.randomUUID().toString
+  def randomId(): String = PerfFixtureHelpers.randomId()
 
-  def fillTopic(topic: String, cmd: RunTestCommand): Unit = {
-    val producer = initTopicAndProducer(topic, cmd)
-    producer.close()
+  def fillTopic(ft: FilledTopic, kafkaHost: String): Unit =
+    initTopicAndProducer(ft, kafkaHost)
+
+  def createTopic(ft: FilledTopic, kafkaHost: String): KafkaProducer[Array[Byte], String] = {
+    val props = new Properties
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaHost)
+    val admin = AdminClient.create(props)
+    val producer = createTopicAndFill(ft, props, admin)
+    admin.close(5, TimeUnit.SECONDS)
+    producer
   }
 
-  def initTopicAndProducer(topic: String, cmd: RunTestCommand): KafkaProducer[Array[Byte], String] = {
+  private def initTopicAndProducer(ft: FilledTopic, kafkaHost: String): Unit = {
     val props = new Properties
-    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, cmd.kafkaHost)
-    createTopic(props, topic, cmd.numberOfPartitions, cmd.replicationFactor)
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaHost)
+    //
+    val admin = AdminClient.create(props)
+    val existing = admin.listTopics().names().get(10, TimeUnit.SECONDS)
+    if (!existing.contains(ft.topic)) {
+      val producer = createTopicAndFill(ft, props, admin)
+      producer.close(5, TimeUnit.SECONDS)
+    }
+    admin.close(5, TimeUnit.SECONDS)
+  }
+
+  private def createTopicAndFill(ft: FilledTopic, props: Properties, admin: AdminClient) = {
+    val result = admin.createTopics(
+      Arrays.asList(
+        new NewTopic(ft.topic, ft.numberOfPartitions, ft.replicationFactor.toShort)
+          .configs(new util.HashMap[String, String]())
+      )
+    )
+    result.all().get(10, TimeUnit.SECONDS)
+    // fill topic with messages
     val producer =
       new KafkaProducer[Array[Byte], String](props, new ByteArraySerializer, new StringSerializer)
     val lastElementStoredPromise = Promise[Unit]
-    val loggedStep = if (cmd.msgCount > logPercentStep) cmd.msgCount / (100 / logPercentStep) else 1
-    val msg = stringOfSize(cmd.msgSize)
-    for (i <- 0L to cmd.msgCount.toLong) {
+    val loggedStep = if (ft.msgCount > logPercentStep) ft.msgCount / (100 / logPercentStep) else 1
+    val msg = stringOfSize(ft.msgSize)
+    for (i <- 0L to ft.msgCount.toLong) {
       if (!lastElementStoredPromise.isCompleted) {
-        val partition: Int = (i % cmd.numberOfPartitions).toInt
+        val partition: Int = (i % ft.numberOfPartitions).toInt
         producer.send(
-          new ProducerRecord[Array[Byte], String](topic, partition, null, msg),
+          new ProducerRecord[Array[Byte], String](ft.topic, partition, null, msg),
           new Callback {
             override def onCompletion(recordMetadata: RecordMetadata, e: Exception): Unit =
               if (e == null) {
                 if (i % loggedStep == 0)
-                  logger.info(s"Written $i elements to Kafka (${100 * i / cmd.msgCount}%)")
-                if (i >= cmd.msgCount - 1 && !lastElementStoredPromise.isCompleted)
+                  logger.info(s"Written $i elements to Kafka (${100 * i / ft.msgCount}%)")
+                if (i >= ft.msgCount - 1 && !lastElementStoredPromise.isCompleted)
                   lastElementStoredPromise.success(())
               } else {
                 if (!lastElementStoredPromise.isCompleted) {
@@ -70,16 +105,5 @@ private[benchmarks] trait PerfFixtureHelpers extends LazyLogging {
     val lastElementStoredFuture = lastElementStoredPromise.future
     Await.result(lastElementStoredFuture, atMost = producerTimeout)
     producer
-  }
-
-  def createTopic(props: Properties, topicName: String, partitions: Int, replicationFactor: Int) = {
-    val admin = AdminClient.create(props)
-    val result = admin.createTopics(
-      Arrays.asList(
-        new NewTopic(topicName, partitions, replicationFactor.toShort).configs(new util.HashMap[String, String]())
-      )
-    )
-    result.all().get(10, TimeUnit.SECONDS)
-    admin.close()
   }
 }

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/PerfFixtureHelpers.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/PerfFixtureHelpers.scala
@@ -26,9 +26,9 @@ object PerfFixtureHelpers {
   case class FilledTopic(
       msgCount: Int,
       msgSize: Int,
-      numberOfPartitions: Int = 1
+      numberOfPartitions: Int = 1,
+      topic: String = randomId()
   ) {
-    val topic: String = randomId()
     def replicationFactor = BuildInfo.kafkaScale
   }
 }
@@ -59,11 +59,11 @@ private[benchmarks] trait PerfFixtureHelpers extends LazyLogging {
     //
     val admin = AdminClient.create(props)
     val existing = admin.listTopics().names().get(10, TimeUnit.SECONDS)
-    if (!existing.contains(ft.topic)) {
+    if (existing.contains(ft.topic)) {
+      logger.info(s"Reusing existing topic $ft")
+    } else {
       val producer = createTopicAndFill(ft, props, admin)
       producer.close(5, TimeUnit.SECONDS)
-    } else {
-      logger.info(s"Reusing existing topic $ft")
     }
     admin.close(5, TimeUnit.SECONDS)
   }

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/PerfFixtureHelpers.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/PerfFixtureHelpers.scala
@@ -24,11 +24,11 @@ object PerfFixtureHelpers {
   def randomId(): String = UUID.randomUUID().toString
 
   case class FilledTopic(
-      topic: String = randomId(),
       msgCount: Int,
       msgSize: Int,
       numberOfPartitions: Int = 1
   ) {
+    val topic: String = randomId()
     def replicationFactor = BuildInfo.kafkaScale
   }
 }
@@ -62,6 +62,8 @@ private[benchmarks] trait PerfFixtureHelpers extends LazyLogging {
     if (!existing.contains(ft.topic)) {
       val producer = createTopicAndFill(ft, props, admin)
       producer.close(5, TimeUnit.SECONDS)
+    } else {
+      logger.info(s"Reusing existing topic $ft")
     }
     admin.close(5, TimeUnit.SECONDS)
   }

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaConsumerFixtures.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaConsumerFixtures.scala
@@ -33,11 +33,10 @@ object ReactiveKafkaConsumerFixtures extends PerfFixtureHelpers {
     FixtureGen[ReactiveKafkaConsumerTestFixture[ConsumerRecord[Array[Byte], String]]](
       c,
       msgCount => {
-        val topic = randomId()
-        fillTopic(topic, c)
+        fillTopic(c.filledTopic, c.kafkaHost)
         val settings = createConsumerSettings(c.kafkaHost)
-        val source = Consumer.plainSource(settings, Subscriptions.topics(topic))
-        ReactiveKafkaConsumerTestFixture(topic, msgCount, source, c.numberOfPartitions)
+        val source = Consumer.plainSource(settings, Subscriptions.topics(c.filledTopic.topic))
+        ReactiveKafkaConsumerTestFixture(c.filledTopic.topic, msgCount, source, c.numberOfPartitions)
       }
     )
 
@@ -45,11 +44,10 @@ object ReactiveKafkaConsumerFixtures extends PerfFixtureHelpers {
     FixtureGen[ReactiveKafkaConsumerTestFixture[CommittableMessage[Array[Byte], String]]](
       c,
       msgCount => {
-        val topic = randomId()
-        fillTopic(topic, c)
+        fillTopic(c.filledTopic, c.kafkaHost)
         val settings = createConsumerSettings(c.kafkaHost)
-        val source = Consumer.committableSource(settings, Subscriptions.topics(topic))
-        ReactiveKafkaConsumerTestFixture(topic, msgCount, source, c.numberOfPartitions)
+        val source = Consumer.committableSource(settings, Subscriptions.topics(c.filledTopic.topic))
+        ReactiveKafkaConsumerTestFixture(c.filledTopic.topic, msgCount, source, c.numberOfPartitions)
       }
     )
 

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaProducerFixtures.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaProducerFixtures.scala
@@ -41,9 +41,8 @@ object ReactiveKafkaProducerFixtures extends PerfFixtureHelpers {
       c,
       msgCount => {
         val flow: FlowType[Int] = Producer.flexiFlow(createProducerSettings(c.kafkaHost))
-        val topic = randomId()
-        initTopicAndProducer(topic, c.copy(msgCount = 1))
-        ReactiveKafkaProducerTestFixture(topic, msgCount, c.msgSize, flow, c.numberOfPartitions)
+        fillTopic(c.filledTopic.copy(msgCount = 1), c.kafkaHost)
+        ReactiveKafkaProducerTestFixture(c.filledTopic.topic, msgCount, c.msgSize, flow, c.numberOfPartitions)
       }
     )
 

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaTransactionFixtures.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaTransactionFixtures.scala
@@ -55,18 +55,17 @@ object ReactiveKafkaTransactionFixtures extends PerfFixtureHelpers {
     FixtureGen[ReactiveKafkaTransactionTestFixture[KTransactionMessage, KProducerMessage, KResult]](
       c,
       msgCount => {
-        val sourceTopic = randomId()
-        fillTopic(sourceTopic, c)
+        fillTopic(c.filledTopic, c.kafkaHost)
         val sinkTopic = randomId()
 
         val consumerSettings = createConsumerSettings(c.kafkaHost)
         val source: Source[KTransactionMessage, Control] =
-          Transactional.source(consumerSettings, Subscriptions.topics(sourceTopic))
+          Transactional.source(consumerSettings, Subscriptions.topics(c.filledTopic.topic))
 
         val producerSettings = createProducerSettings(c.kafkaHost).withEosCommitInterval(commitInterval)
         val flow: Flow[KProducerMessage, KResult, NotUsed] = Transactional.flow(producerSettings, randomId())
 
-        ReactiveKafkaTransactionTestFixture[KTransactionMessage, KProducerMessage, KResult](sourceTopic,
+        ReactiveKafkaTransactionTestFixture[KTransactionMessage, KProducerMessage, KResult](c.filledTopic.topic,
                                                                                             sinkTopic,
                                                                                             msgCount,
                                                                                             source,

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/Timed.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/Timed.scala
@@ -36,7 +36,7 @@ object Timed extends LazyLogging {
   def runPerfTest[F](command: RunTestCommand, fixtureGen: FixtureGen[F], testBody: (F, Meter) => Unit): Unit = {
     val name = command.testName
     val msgCount = command.msgCount
-    logger.info(s"Generating fixture for $name")
+    logger.info(s"Generating fixture for $name ${command.filledTopic}")
     val fixture = fixtureGen.generate(msgCount)
     val metrics = new MetricRegistry()
     val meter = metrics.meter(name)

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/app/RunTestCommand.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/app/RunTestCommand.scala
@@ -6,11 +6,12 @@
 package akka.kafka.benchmarks.app
 
 import akka.kafka.benchmarks.BuildInfo
+import akka.kafka.benchmarks.PerfFixtureHelpers.FilledTopic
 
 case class RunTestCommand(testName: String,
                           kafkaHost: String,
                           msgCount: Int,
                           msgSize: Int,
                           numberOfPartitions: Int = 1) {
-  def replicationFactor = BuildInfo.kafkaScale
+  val filledTopic = FilledTopic(msgCount = msgCount, msgSize = msgSize, numberOfPartitions = numberOfPartitions)
 }

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/app/RunTestCommand.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/app/RunTestCommand.scala
@@ -5,13 +5,12 @@
 
 package akka.kafka.benchmarks.app
 
-import akka.kafka.benchmarks.BuildInfo
 import akka.kafka.benchmarks.PerfFixtureHelpers.FilledTopic
 
-case class RunTestCommand(testName: String,
-                          kafkaHost: String,
-                          msgCount: Int,
-                          msgSize: Int,
-                          numberOfPartitions: Int = 1) {
-  val filledTopic = FilledTopic(msgCount = msgCount, msgSize = msgSize, numberOfPartitions = numberOfPartitions)
+case class RunTestCommand(testName: String, kafkaHost: String, filledTopic: FilledTopic) {
+
+  val msgCount = filledTopic.msgCount
+  val msgSize = filledTopic.msgSize
+  val numberOfPartitions = filledTopic.numberOfPartitions
+
 }


### PR DESCRIPTION
## Purpose

To shorten the time it takes to run the benchmarks, the different topics are created and filled with data only once. If the topic exists, the next spec reads the existing data.

## Background Context

Especially the tests with 5000 bytes messages require a lot of disk space during the benchmarks.