### PR TITLE
Benchmarks: producer writing 500 bytes messages

### DIFF
--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/Benchmarks.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/Benchmarks.scala
@@ -28,6 +28,7 @@ object BenchmarksBase {
   val topic_1000_5000_8 = FilledTopic(msgCount = 1000 * factor, msgSize = 5 * 1000, numberOfPartitions = 8)
 
   val topic_2000_100 = FilledTopic(2000 * factor, 100)
+  val topic_2000_500 = FilledTopic(2000 * factor, 500)
   val topic_2000_5000 = FilledTopic(2000 * factor, 5000)
   val topic_2000_5000_8 = FilledTopic(2000 * factor, 5000, numberOfPartitions = 8)
 
@@ -139,46 +140,6 @@ class AlpakkaKafkaAtMostOnceConsumer extends BenchmarksBase() {
     runPerfTest(cmd,
                 ReactiveKafkaConsumerFixtures.committableSources(cmd),
                 ReactiveKafkaConsumerBenchmarks.consumeCommitAtMostOnce)
-  }
-}
-
-class ApacheKafkaPlainProducer extends BenchmarksBase() {
-  private val prefix = "apache-kafka-plain-producer"
-
-  it should "bench with small messages" in {
-    val cmd = RunTestCommand(prefix, bootstrapServers, topic_2000_100)
-    runPerfTest(cmd, KafkaProducerFixtures.initializedProducer(cmd), KafkaProducerBenchmarks.plainFlow)
-  }
-
-  it should "bench with normal messages" in {
-    val cmd = RunTestCommand(prefix + "-normal-msg", bootstrapServers, topic_2000_5000)
-    runPerfTest(cmd, KafkaProducerFixtures.initializedProducer(cmd), KafkaProducerBenchmarks.plainFlow)
-  }
-
-  it should "bench with normal messages written to 8 partitions" in {
-    val cmd =
-      RunTestCommand(prefix + "-normal-msg-8-partitions", bootstrapServers, topic_2000_5000_8)
-    runPerfTest(cmd, KafkaProducerFixtures.initializedProducer(cmd), KafkaProducerBenchmarks.plainFlow)
-  }
-}
-
-class AlpakkaKafkaPlainProducer extends BenchmarksBase() {
-  private val prefix = "alpakka-kafka-plain-producer"
-
-  it should "bench with small messages" in {
-    val cmd = RunTestCommand(prefix, bootstrapServers, topic_2000_100)
-    runPerfTest(cmd, ReactiveKafkaProducerFixtures.flowFixture(cmd), ReactiveKafkaProducerBenchmarks.plainFlow)
-  }
-
-  it should "bench with normal messages" in {
-    val cmd = RunTestCommand(prefix + "-normal-msg", bootstrapServers, topic_2000_5000)
-    runPerfTest(cmd, ReactiveKafkaProducerFixtures.flowFixture(cmd), ReactiveKafkaProducerBenchmarks.plainFlow)
-  }
-
-  it should "bench with normal messages written to 8 partitions" in {
-    val cmd =
-      RunTestCommand(prefix + "-normal-msg-8-partitions", bootstrapServers, topic_2000_5000_8)
-    runPerfTest(cmd, ReactiveKafkaProducerFixtures.flowFixture(cmd), ReactiveKafkaProducerBenchmarks.plainFlow)
   }
 }
 

--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/NoCommitBackpressure.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/NoCommitBackpressure.scala
@@ -15,21 +15,22 @@ class RawKafkaCommitEveryPollConsumer extends BenchmarksBase() {
                 KafkaConsumerBenchmarks.consumerAtLeastOnceCommitEveryPoll())
   }
 
-  it should "bench with normal messages" in {
-    val cmd = RunTestCommand(prefix + "consumer-normal-msg", bootstrapServers, topic_1000_5000)
-    runPerfTest(cmd,
-                KafkaConsumerFixtures.filledTopics(cmd),
-                KafkaConsumerBenchmarks.consumerAtLeastOnceCommitEveryPoll())
-  }
-
-  it should "bench with normal messages and eight partitions" in {
-    val cmd = RunTestCommand(prefix + "consumer-normal-msg-8-partitions",
-                             bootstrapServers,
-                             topic_1000_5000_8)
-    runPerfTest(cmd,
-                KafkaConsumerFixtures.filledTopics(cmd),
-                KafkaConsumerBenchmarks.consumerAtLeastOnceCommitEveryPoll())
-  }
+// These are not plotted anyway
+//  it should "bench with normal messages" in {
+//    val cmd = RunTestCommand(prefix + "consumer-normal-msg", bootstrapServers, topic_1000_5000)
+//    runPerfTest(cmd,
+//                KafkaConsumerFixtures.filledTopics(cmd),
+//                KafkaConsumerBenchmarks.consumerAtLeastOnceCommitEveryPoll())
+//  }
+//
+//  it should "bench with normal messages and eight partitions" in {
+//    val cmd = RunTestCommand(prefix + "consumer-normal-msg-8-partitions",
+//                             bootstrapServers,
+//                             topic_1000_5000_8)
+//    runPerfTest(cmd,
+//                KafkaConsumerFixtures.filledTopics(cmd),
+//                KafkaConsumerBenchmarks.consumerAtLeastOnceCommitEveryPoll())
+//  }
 }
 
 class AlpakkaCommitAndForgetConsumer extends BenchmarksBase() {
@@ -42,19 +43,20 @@ class AlpakkaCommitAndForgetConsumer extends BenchmarksBase() {
                 ReactiveKafkaConsumerBenchmarks.consumerCommitAndForget(commitBatchSize = 1000))
   }
 
-  it should "bench with normal messages" in {
-    val cmd = RunTestCommand(prefix + "normal-msg", bootstrapServers, topic_1000_5000)
-    runPerfTest(cmd,
-                ReactiveKafkaConsumerFixtures.committableSources(cmd),
-                ReactiveKafkaConsumerBenchmarks.consumerCommitAndForget(commitBatchSize = 1000))
-  }
-
-  it should "bench with normal messages and eight partitions" in {
-    val cmd = RunTestCommand(prefix + "normal-msg-8-partitions",
-                             bootstrapServers,
-                             topic_1000_5000_8)
-    runPerfTest(cmd,
-                ReactiveKafkaConsumerFixtures.committableSources(cmd),
-                ReactiveKafkaConsumerBenchmarks.consumerCommitAndForget(commitBatchSize = 1000))
-  }
+// These are not plotted anyway
+//  it should "bench with normal messages" in {
+//    val cmd = RunTestCommand(prefix + "normal-msg", bootstrapServers, topic_1000_5000)
+//    runPerfTest(cmd,
+//                ReactiveKafkaConsumerFixtures.committableSources(cmd),
+//                ReactiveKafkaConsumerBenchmarks.consumerCommitAndForget(commitBatchSize = 1000))
+//  }
+//
+//  it should "bench with normal messages and eight partitions" in {
+//    val cmd = RunTestCommand(prefix + "normal-msg-8-partitions",
+//                             bootstrapServers,
+//                             topic_1000_5000_8)
+//    runPerfTest(cmd,
+//                ReactiveKafkaConsumerFixtures.committableSources(cmd),
+//                ReactiveKafkaConsumerBenchmarks.consumerCommitAndForget(commitBatchSize = 1000))
+//  }
 }

--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/Producer.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/Producer.scala
@@ -1,0 +1,56 @@
+package akka.kafka.benchmarks
+
+import akka.kafka.benchmarks.BenchmarksBase.{topic_2000_100, topic_2000_500, topic_2000_5000, topic_2000_5000_8}
+import akka.kafka.benchmarks.Timed.runPerfTest
+import akka.kafka.benchmarks.app.RunTestCommand
+
+class ApacheKafkaPlainProducer extends BenchmarksBase() {
+  private val prefix = "apache-kafka-plain-producer"
+
+  it should "bench with small messages" in {
+    val cmd = RunTestCommand(prefix, bootstrapServers, topic_2000_100)
+    runPerfTest(cmd, KafkaProducerFixtures.initializedProducer(cmd), KafkaProducerBenchmarks.plainFlow)
+  }
+
+  it should "bench with 500b messages" in {
+    val cmd = RunTestCommand(prefix + "-500b", bootstrapServers, topic_2000_500)
+    runPerfTest(cmd, KafkaProducerFixtures.initializedProducer(cmd), KafkaProducerBenchmarks.plainFlow)
+  }
+
+  it should "bench with normal messages" in {
+    val cmd = RunTestCommand(prefix + "-normal-msg", bootstrapServers, topic_2000_5000)
+    runPerfTest(cmd, KafkaProducerFixtures.initializedProducer(cmd), KafkaProducerBenchmarks.plainFlow)
+  }
+
+  it should "bench with normal messages written to 8 partitions" in {
+    val cmd =
+      RunTestCommand(prefix + "-normal-msg-8-partitions", bootstrapServers, topic_2000_5000_8)
+    runPerfTest(cmd, KafkaProducerFixtures.initializedProducer(cmd), KafkaProducerBenchmarks.plainFlow)
+  }
+}
+
+class AlpakkaKafkaPlainProducer extends BenchmarksBase() {
+  private val prefix = "alpakka-kafka-plain-producer"
+
+  it should "bench with small messages" in {
+    val cmd = RunTestCommand(prefix, bootstrapServers, topic_2000_100)
+    runPerfTest(cmd, ReactiveKafkaProducerFixtures.flowFixture(cmd), ReactiveKafkaProducerBenchmarks.plainFlow)
+  }
+
+  it should "bench with 500b messages" in {
+    val cmd = RunTestCommand(prefix + "-500b", bootstrapServers, topic_2000_500)
+    runPerfTest(cmd, ReactiveKafkaProducerFixtures.flowFixture(cmd), ReactiveKafkaProducerBenchmarks.plainFlow)
+  }
+
+  it should "bench with normal messages" in {
+    val cmd = RunTestCommand(prefix + "-normal-msg", bootstrapServers, topic_2000_5000)
+    runPerfTest(cmd, ReactiveKafkaProducerFixtures.flowFixture(cmd), ReactiveKafkaProducerBenchmarks.plainFlow)
+  }
+
+  it should "bench with normal messages written to 8 partitions" in {
+    val cmd =
+      RunTestCommand(prefix + "-normal-msg-8-partitions", bootstrapServers, topic_2000_5000_8)
+    runPerfTest(cmd, ReactiveKafkaProducerFixtures.flowFixture(cmd), ReactiveKafkaProducerBenchmarks.plainFlow)
+  }
+}
+


### PR DESCRIPTION
Add another producer benchmark writing 500b messages to understand the Akka Streams overhead a bit better.
