### PR TITLE
Clarify exactly-once-semantics limitations

### DIFF
--- a/docs/src/main/paradox/transactions.md
+++ b/docs/src/main/paradox/transactions.md
@@ -69,7 +69,7 @@ Any state in the transformation logic is not part of a transaction.  It's left t
 
 Any side effects that occur in the transformation logic is not part of a transaction (i.e. writes to an database).  
 
-The exactly-once-semantics are guaranteed only between a subscribed set of consumed partitions and a set of partitions that are produced to, on the same Kafka cluster.
+The exactly-once-semantics are guaranteed only when your flow consumes from and produces to the same Kafka cluster. Producing to partitions from a 3rd-party source or consuming partitions from one Kafka cluster and producing to another Kafka cluster are not supported.
 
 ## Further Reading
 

--- a/docs/src/main/paradox/transactions.md
+++ b/docs/src/main/paradox/transactions.md
@@ -69,7 +69,7 @@ Any state in the transformation logic is not part of a transaction.  It's left t
 
 Any side effects that occur in the transformation logic is not part of a transaction (i.e. writes to an database).  
 
-The exactly-once-semantics are guaranteed only between a pair of two topics. Consuming messages from a topic in a different flow after transactional processing has the usual at-least-once semantics.
+The exactly-once-semantics are guaranteed only between a subscribed set of consumed partitions and a set of partitions that are produced to, on the same Kafka cluster.
 
 ## Further Reading
 


### PR DESCRIPTION
Though this wording is still rather confusing - when would you not be using
a set of consumed partitions and a set of partitions that are produced to?