### PR TITLE
Benchmarks: try producing with ridiculous parallelism

### DIFF
--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaProducerFixtures.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaProducerFixtures.scala
@@ -17,7 +17,7 @@ import org.apache.kafka.common.serialization.{ByteArraySerializer, StringSeriali
 
 object ReactiveKafkaProducerFixtures extends PerfFixtureHelpers {
 
-  val Parallelism = 100
+  val Parallelism = 1000000
 
   type K = Array[Byte]
   type V = String


### PR DESCRIPTION
## Purpose

Experiment with producer benchmarks and how they get affected by the backpressure.
