### PR TITLE
Committable partitioned source with manual offset seek support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import com.typesafe.tools.mima.core.{Problem, ProblemFilters}
+
 enablePlugins(AutomateHeaderPlugin)
 
 name := "akka-stream-kafka"
@@ -202,7 +204,8 @@ lazy val core = project
     mimaPreviousArtifacts := Set(
         organization.value %% name.value % previousStableVersion.value
           .getOrElse(throw new Error("Unable to determine previous version"))
-      )
+      ),
+    mimaBinaryIssueFilters += ProblemFilters.exclude[Problem]("akka.kafka.internal.*")
   )
 
 lazy val testkit = project

--- a/core/src/main/scala/akka/kafka/CommitterSettings.scala
+++ b/core/src/main/scala/akka/kafka/CommitterSettings.scala
@@ -134,7 +134,5 @@ class CommitterSettings private (
     s"maxBatch=$maxBatch," +
     s"maxInterval=${maxInterval.toCoarsest}," +
     s"parallelism=$parallelism," +
-    s"delivery=$delivery"
-  ")"
-
+    s"delivery=$delivery)"
 }

--- a/core/src/main/scala/akka/kafka/internal/CommittableSources.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommittableSources.scala
@@ -7,7 +7,7 @@ package akka.kafka.internal
 
 import akka.actor.ActorRef
 import akka.annotation.InternalApi
-import akka.kafka.ConsumerMessage.{CommittableMessage, CommittableOffset, CommittableOffsetBatch, GroupTopicPartition}
+import akka.kafka.ConsumerMessage.{CommittableMessage, CommittableOffset, CommittableOffsetBatch}
 import akka.kafka._
 import akka.kafka.internal.KafkaConsumerActor.Internal.{Commit, CommitSingle, CommitWithoutReply}
 import akka.kafka.scaladsl.Consumer.Control
@@ -91,17 +91,19 @@ private[kafka] final class ExternalCommittableSource[K, V](consumer: ActorRef,
 
 /** Internal API */
 @InternalApi
-private[kafka] final class CommittableSubSource[K, V](settings: ConsumerSettings[K, V],
-                                                      subscription: AutoSubscription,
-                                                      _metadataFromRecord: ConsumerRecord[K, V] => String =
-                                                        CommittableMessageBuilder.NoMetadataFromRecord)
-    extends KafkaSourceStage[K, V, (TopicPartition, Source[CommittableMessage[K, V], NotUsed])](
+private[kafka] final class CommittableSubSource[K, V](
+    settings: ConsumerSettings[K, V],
+    subscription: AutoSubscription,
+    _metadataFromRecord: ConsumerRecord[K, V] => String = CommittableMessageBuilder.NoMetadataFromRecord,
+    getOffsetsOnAssign: Option[Set[TopicPartition] => Future[Map[TopicPartition, Long]]] = None,
+    onRevoke: Set[TopicPartition] => Unit = _ => ()
+) extends KafkaSourceStage[K, V, (TopicPartition, Source[CommittableMessage[K, V], NotUsed])](
       s"CommittableSubSource ${subscription.renderStageAttribute}"
     ) {
   override protected def logic(
       shape: SourceShape[(TopicPartition, Source[CommittableMessage[K, V], NotUsed])]
   ): GraphStageLogic with Control =
-    new SubSourceLogic[K, V, CommittableMessage[K, V]](shape, settings, subscription)
+    new SubSourceLogic[K, V, CommittableMessage[K, V]](shape, settings, subscription, getOffsetsOnAssign, onRevoke)
     with CommittableMessageBuilder[K, V] with MetricsControl {
       override def metadataFromRecord(record: ConsumerRecord[K, V]): String = _metadataFromRecord(record)
       override def groupId: String = settings.properties(ConsumerConfig.GROUP_ID_CONFIG)

--- a/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
@@ -258,6 +258,22 @@ object Consumer {
     Source.fromGraph(new PlainSubSource[K, V](settings, subscription, Some(getOffsetsOnAssign), onRevoke))
 
   /**
+   * The same as [[#plainPartitionedManualOffsetSource]] but with offset commit support.
+   */
+  def committablePartitionedManualOffsetSource[K, V](
+      settings: ConsumerSettings[K, V],
+      subscription: AutoSubscription,
+      getOffsetsOnAssign: Set[TopicPartition] => Future[Map[TopicPartition, Long]],
+      onRevoke: Set[TopicPartition] => Unit = _ => ()
+  ): Source[(TopicPartition, Source[CommittableMessage[K, V], NotUsed]), Control] =
+    Source.fromGraph(
+      new CommittableSubSource[K, V](settings,
+                                     subscription,
+                                     getOffsetsOnAssign = Some(getOffsetsOnAssign),
+                                     onRevoke = onRevoke)
+    )
+
+  /**
    * The same as [[#plainPartitionedSource]] but with offset commit support.
    */
   def committablePartitionedSource[K, V](

--- a/docs/src/main/paradox/consumer.md
+++ b/docs/src/main/paradox/consumer.md
@@ -16,19 +16,20 @@ Alpakka Kafka offers a large variety of consumers that connect to Kafka and stre
 
 These factory methods are part of the @scala[@scaladoc[Consumer API](akka.kafka.scaladsl.Consumer$)]@java[@scaladoc[Consumer API](akka.kafka.javadsl.Consumer$)].
 
-| Offsets handling                    | Partition aware | Subscription        | Shared consumer | Factory method | Stream element type |
-|-------------------------------------|-----------------|---------------------|-----------------|----------------|---------------------|
-| No (auto commit can be enabled)     | No              | Topic or Partition  | No              | `plainSource` | `ConsumerRecord` |
-| No (auto commit can be enabled)     | No              | Partition           | Yes             | `plainExternalSource` | `ConsumerRecord` |
-| Explicit committing                 | No              | Topic or Partition  | No              | `committableSource` | `CommittableMessage` |
-| Explicit committing                 | No              | Partition           | Yes             | `committableExternalSource` | `CommittableMessage` |
-| Explicit committing with metadata   | No              | Topic or Partition  | No              | `commitWithMetadataSource` | `CommittableMessage` |
-| Explicit committing (with metadata) | No              | Topic or Partition  | No              | `sourceWithOffsetContext` | `ConsumerRecord` |
-| Offset committed per element        | No              | Topic or Partition  | No              | `atMostOnceSource` | `ConsumerRecord` |
-| No (auto commit can be enabled)     | Yes             | Topic or Partition  | No              | `plainPartitionedSource` | `(TopicPartition, Source[ConsumerRecord, ..])` |
-| External to Kafka                   | Yes             | Topic or Partition  | No              | `plainPartitionedManualOffsetSource` | `(TopicPartition, Source[ConsumerRecord, ..])` |
-| Explicit committing                 | Yes             | Topic or Partition  | No              | `committablePartitionedSource` | `(TopicPartition, Source[CommittableMessage, ..])`     |
-| Explicit committing with metadata   | Yes             | Topic or Partition  | No              | `commitWithMetadataPartitionedSource` | `(TopicPartition, Source[CommittableMessage, ..])`  |
+| Offsets handling                        | Partition aware | Subscription        | Shared consumer | Factory method | Stream element type |
+|-----------------------------------------|-----------------|---------------------|-----------------|----------------|---------------------|
+| No (auto commit can be enabled)         | No              | Topic or Partition  | No              | `plainSource` | `ConsumerRecord` |
+| No (auto commit can be enabled)         | No              | Partition           | Yes             | `plainExternalSource` | `ConsumerRecord` |
+| Explicit committing                     | No              | Topic or Partition  | No              | `committableSource` | `CommittableMessage` |
+| Explicit committing                     | No              | Partition           | Yes             | `committableExternalSource` | `CommittableMessage` |
+| Explicit committing with metadata       | No              | Topic or Partition  | No              | `commitWithMetadataSource` | `CommittableMessage` |
+| Explicit committing (with metadata)     | No              | Topic or Partition  | No              | `sourceWithOffsetContext` | `ConsumerRecord` |
+| Offset committed per element            | No              | Topic or Partition  | No              | `atMostOnceSource` | `ConsumerRecord` |
+| No (auto commit can be enabled)         | Yes             | Topic or Partition  | No              | `plainPartitionedSource` | `(TopicPartition, Source[ConsumerRecord, ..])` |
+| External to Kafka                       | Yes             | Topic or Partition  | No              | `plainPartitionedManualOffsetSource` | `(TopicPartition, Source[ConsumerRecord, ..])` |
+| Explicit committing                     | Yes             | Topic or Partition  | No              | `committablePartitionedSource` | `(TopicPartition, Source[CommittableMessage, ..])`     |
+| External to Kafka & Explicit Committing | Yes             | Topic or Partition  | No              | `committablePartitionedManualOffsetSource` | `(TopicPartition, Source[CommittableMessage, ..])` |
+| Explicit committing with metadata       | Yes             | Topic or Partition  | No              | `commitWithMetadataPartitionedSource` | `(TopicPartition, Source[CommittableMessage, ..])`  |
 
 ### Transactional consumers
 
@@ -196,6 +197,12 @@ Scala
 Java
 : @@ snip [snip](/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java) { #commitWithMetadata }
 
+## Offset Storage in Kafka & external
+
+In some cases you may wish to use external offset storage as your primary means to manage offsets, but also commit offsets to Kafka. 
+This gives you all the benefits of controlling offsets described in @ref:[Offset Storage external to Kafka](#offset-storage-external-to-kafka) and allows you to use tooling in the Kafka ecosystem to track consumer group lag. 
+You can use the `Consumer.committablePartitionedManualOffsetSource` (@scala[@scaladoc[Consumer API](akka.kafka.scaladsl.Consumer$)]@java[@scaladoc[Consumer API](akka.kafka.javadsl.Consumer$)]) source, which emits a `CommittableMessage`, to seek to appropriate offsets on startup, do your processing, commit to external storage, and then commit offsets back to Kafka. 
+This will only provide at-least-once guarantees for your consumer group lag monitoring because it's possible for a failure between storing your offsets externally and committing to Kafka, but it will give you a more accurate representation of consumer group lag then when turning on auto commits with the `enable.auto.commit` consumer property.
 
 ## Consume "at-most-once"
 


### PR DESCRIPTION
## Purpose

Add a new Consumer source `Consumer.committablePartitionedManualOffsetSource` that allows you to use a Kafka subscription, manually seek to offsets, and emit a `CommittableMessage` so you can choose to commit offsets to Kafka.  Normally when the user manages their own offsets they're not concerned with committing offsets to Kafka, but it can be useful to do both so that you can enable standard consumer group lag monitoring software in the Kafka ecosystem (i.e. [`kafka-lag-exporter`](https://github.com/lightbend/kafka-lag-exporter)).

## Changes

* Add Java and Scala API for `Consumer.committablePartitionedManualOffsetSource`
* Duplicate tests from `plainPartitionedManualOffsetSource` for `committablePartitionedManualOffsetSource`.  I could DRY this up, or maybe we will decide adding full test coverage for the new source isn't necessary because they use the same logic in `SubSourceLogic`.
* New docs.  I described the workflow, but we may want to choose to add an example.

## Background Context

The alternative means of enabling consumer group lag tooling with existing sources is by setting `enable.auto.commit` to `true` and use `plainPartitionedManualOffsetSource`.  This setting will commit offsets as soon (or soon after) they're received by the `KafkaConsumer` which could lead to a misrepresentation of lag as some offsets could be marked as committed when they're not fully processed yet.  By allowing the user to commit offsets after the message is fully processed we can provide at-least-once guarantees with consumer group lag metrics.
