### PR TITLE
Cron builds: allow compiler warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,7 +85,7 @@ val commonSettings = Def.settings(
       if (scalaBinaryVersion.value == "2.13") Seq.empty
       else Seq("-Yno-adapted-args", "-Xfuture")
     } ++ {
-      if (insideCI.value) Seq("-Xfatal-warnings")
+      if (insideCI.value && !Nightly) Seq("-Xfatal-warnings")
       else Seq.empty
     },
   Compile / doc / scalacOptions := scalacOptions.value ++ Seq(


### PR DESCRIPTION
Akka 2.6 introduces deprecations that can't be handled in an Akka 2.5 compatible way.
This switches off `fatal-warnings` for the cron triggered builds.