### PR TITLE
Benchmarks: create new topics for producers tests

### DIFF
--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/Producer.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/Producer.scala
@@ -8,23 +8,23 @@ class ApacheKafkaPlainProducer extends BenchmarksBase() {
   private val prefix = "apache-kafka-plain-producer"
 
   it should "bench with small messages" in {
-    val cmd = RunTestCommand(prefix, bootstrapServers, topic_2000_100)
+    val cmd = RunTestCommand(prefix, bootstrapServers, topic_2000_100.freshTopic)
     runPerfTest(cmd, KafkaProducerFixtures.initializedProducer(cmd), KafkaProducerBenchmarks.plainFlow)
   }
 
   it should "bench with 500b messages" in {
-    val cmd = RunTestCommand(prefix + "-500b", bootstrapServers, topic_2000_500)
+    val cmd = RunTestCommand(prefix + "-500b", bootstrapServers, topic_2000_500.freshTopic)
     runPerfTest(cmd, KafkaProducerFixtures.initializedProducer(cmd), KafkaProducerBenchmarks.plainFlow)
   }
 
   it should "bench with normal messages" in {
-    val cmd = RunTestCommand(prefix + "-normal-msg", bootstrapServers, topic_2000_5000)
+    val cmd = RunTestCommand(prefix + "-normal-msg", bootstrapServers, topic_2000_5000.freshTopic)
     runPerfTest(cmd, KafkaProducerFixtures.initializedProducer(cmd), KafkaProducerBenchmarks.plainFlow)
   }
 
   it should "bench with normal messages written to 8 partitions" in {
     val cmd =
-      RunTestCommand(prefix + "-normal-msg-8-partitions", bootstrapServers, topic_2000_5000_8)
+      RunTestCommand(prefix + "-normal-msg-8-partitions", bootstrapServers, topic_2000_5000_8.freshTopic)
     runPerfTest(cmd, KafkaProducerFixtures.initializedProducer(cmd), KafkaProducerBenchmarks.plainFlow)
   }
 }
@@ -33,23 +33,23 @@ class AlpakkaKafkaPlainProducer extends BenchmarksBase() {
   private val prefix = "alpakka-kafka-plain-producer"
 
   it should "bench with small messages" in {
-    val cmd = RunTestCommand(prefix, bootstrapServers, topic_2000_100)
+    val cmd = RunTestCommand(prefix, bootstrapServers, topic_2000_100.freshTopic)
     runPerfTest(cmd, ReactiveKafkaProducerFixtures.flowFixture(cmd), ReactiveKafkaProducerBenchmarks.plainFlow)
   }
 
   it should "bench with 500b messages" in {
-    val cmd = RunTestCommand(prefix + "-500b", bootstrapServers, topic_2000_500)
+    val cmd = RunTestCommand(prefix + "-500b", bootstrapServers, topic_2000_500.freshTopic)
     runPerfTest(cmd, ReactiveKafkaProducerFixtures.flowFixture(cmd), ReactiveKafkaProducerBenchmarks.plainFlow)
   }
 
   it should "bench with normal messages" in {
-    val cmd = RunTestCommand(prefix + "-normal-msg", bootstrapServers, topic_2000_5000)
+    val cmd = RunTestCommand(prefix + "-normal-msg", bootstrapServers, topic_2000_5000.freshTopic)
     runPerfTest(cmd, ReactiveKafkaProducerFixtures.flowFixture(cmd), ReactiveKafkaProducerBenchmarks.plainFlow)
   }
 
   it should "bench with normal messages written to 8 partitions" in {
     val cmd =
-      RunTestCommand(prefix + "-normal-msg-8-partitions", bootstrapServers, topic_2000_5000_8)
+      RunTestCommand(prefix + "-normal-msg-8-partitions", bootstrapServers, topic_2000_5000_8.freshTopic)
     runPerfTest(cmd, ReactiveKafkaProducerFixtures.flowFixture(cmd), ReactiveKafkaProducerBenchmarks.plainFlow)
   }
 }

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/PerfFixtureHelpers.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/PerfFixtureHelpers.scala
@@ -30,6 +30,7 @@ object PerfFixtureHelpers {
       topic: String = randomId()
   ) {
     def replicationFactor = BuildInfo.kafkaScale
+    def freshTopic: FilledTopic = copy(topic = randomId())
   }
 }
 


### PR DESCRIPTION
## Purpose

Try if topic name reuse causes the benchmarks to show the unexpected drop in Raw Kafka performance since build 550.

![image](https://user-images.githubusercontent.com/458526/65897701-279f2080-e3b0-11e9-8bac-9b95c3ed7253.png)

## References

This drop must be connected to https://github.com/akka/alpakka-kafka/pull/902

## Changes

Use a fresh topic name for producer benchmarks so they do not interfere with consumer benchmarks.