### PR TITLE
Add partitioned transactional source phase 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ jobs:
 
     - stage: integration
       env: CMD="tests/it:test"
-      name: "Run multi-broker integration tests"
+      name: "Run multi-broker and long running integration tests"
     - env: CMD="benchmarks/it:compile"
       name: "Compile benchmark tests"
 
@@ -75,10 +75,6 @@ jobs:
       name: "Publish API and reference documentation"
 
 stages:
-  # runs on master commits and PRs
-  - name: debug
-    if: NOT tag =~ ^v
-
   # runs on master commits and PRs
   - name: check
     if: NOT tag =~ ^v

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,6 @@ services:
   - docker
 
 before_install:
-  # upgrade to a later docker-compose which supports services.kafka.scale
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/1.22.0/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
   # fetch full history for correct current and previous version detection
   - git fetch --unshallow
   # using jabba for custom jdk management
@@ -80,6 +75,10 @@ jobs:
       name: "Publish API and reference documentation"
 
 stages:
+  # runs on master commits and PRs
+  - name: debug
+    if: NOT tag =~ ^v
+
   # runs on master commits and PRs
   - name: check
     if: NOT tag =~ ^v

--- a/build.sbt
+++ b/build.sbt
@@ -183,6 +183,9 @@ lazy val `alpakka-kafka` =
             |  tests/it:test
             |    run integration tests backed by Docker containers
             |
+            |  tests/testOnly -- -t "A consume-transform-produce cycle must complete in happy-path scenario"
+            |    run a single test with an exact name (use -z for partial match)
+            |
             |  benchmarks/it:testOnly *.AlpakkaKafkaPlainConsumer
             |    run a single benchmark backed by Docker containers
           """.stripMargin

--- a/core/src/main/mima-filters/1.1.0.backwards.excludes/PR930-partitioned-transactions-source.excludes
+++ b/core/src/main/mima-filters/1.1.0.backwards.excludes/PR930-partitioned-transactions-source.excludes
@@ -1,0 +1,5 @@
+ProblemFilters.exclude[MissingTypesProblem]("akka.kafka.ConsumerMessage$PartitionOffsetCommittedMarker$")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.ConsumerMessage#PartitionOffsetCommittedMarker.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.ConsumerMessage#PartitionOffsetCommittedMarker.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.ConsumerMessage#PartitionOffset.withCommittedMarker")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.kafka.ConsumerMessage#PartitionOffsetCommittedMarker.unapply")

--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -96,9 +96,6 @@ object ConsumerMessage {
     def withMetadata(metadata: String) =
       PartitionOffsetMetadata(key, offset, metadata)
 
-    @InternalApi private[kafka] def withCommittedMarker(committedMarker: CommittedMarker) =
-      PartitionOffsetCommittedMarker(key, offset, committedMarker)
-
     override def toString = s"PartitionOffset(key=$key,offset=$offset)"
 
     override def equals(other: Any): Boolean = other match {
@@ -138,7 +135,8 @@ object ConsumerMessage {
   @InternalApi private[kafka] final case class PartitionOffsetCommittedMarker(
       override val key: GroupTopicPartition,
       override val offset: Long,
-      private[kafka] val committedMarker: CommittedMarker
+      private[kafka] val committedMarker: CommittedMarker,
+      private[kafka] val fromPartitionedSource: Boolean
   ) extends PartitionOffset(key, offset)
 
   /**

--- a/core/src/main/scala/akka/kafka/internal/CommittableSources.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommittableSources.scala
@@ -211,7 +211,7 @@ private[kafka] class KafkaAsyncConsumerCommitterRef(private val consumerActor: A
 }
 
 @InternalApi
-private class CommittableSubSourceStageLogic[K, V](
+private final class CommittableSubSourceStageLogic[K, V](
     shape: SourceShape[CommittableMessage[K, V]],
     tp: TopicPartition,
     consumerActor: ActorRef,

--- a/core/src/main/scala/akka/kafka/internal/CommittableSources.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommittableSources.scala
@@ -10,11 +10,12 @@ import akka.annotation.InternalApi
 import akka.kafka.ConsumerMessage.{CommittableMessage, CommittableOffset, CommittableOffsetBatch}
 import akka.kafka._
 import akka.kafka.internal.KafkaConsumerActor.Internal.{Commit, CommitSingle, CommitWithoutReply}
+import akka.kafka.internal.SubSourceLogic._
 import akka.kafka.scaladsl.Consumer.Control
 import akka.pattern.AskTimeoutException
 import akka.stream.SourceShape
 import akka.stream.scaladsl.Source
-import akka.stream.stage.GraphStageLogic
+import akka.stream.stage.{AsyncCallback, GraphStageLogic}
 import akka.util.Timeout
 import akka.{Done, NotUsed}
 import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord, OffsetAndMetadata}
@@ -102,17 +103,34 @@ private[kafka] final class CommittableSubSource[K, V](
     ) {
   override protected def logic(
       shape: SourceShape[(TopicPartition, Source[CommittableMessage[K, V], NotUsed])]
-  ): GraphStageLogic with Control =
-    new SubSourceLogic[K, V, CommittableMessage[K, V]](shape, settings, subscription, getOffsetsOnAssign, onRevoke)
-      with CommittableMessageBuilder[K, V]
-      with MetricsControl {
-      override def metadataFromRecord(record: ConsumerRecord[K, V]): String = _metadataFromRecord(record)
-      override def groupId: String = settings.properties(ConsumerConfig.GROUP_ID_CONFIG)
-      lazy val committer: KafkaAsyncConsumerCommitterRef = {
-        val ec = materializer.executionContext
-        new KafkaAsyncConsumerCommitterRef(consumerActor, settings.commitTimeout)(ec)
-      }
+  ): GraphStageLogic with Control = {
+
+    val factory = new SubSourceStageLogicFactory[K, V, CommittableMessage[K, V]] {
+      def create(
+          shape: SourceShape[CommittableMessage[K, V]],
+          tp: TopicPartition,
+          consumerActor: ActorRef,
+          subSourceStartedCb: AsyncCallback[(TopicPartition, ControlAndStageActor)],
+          subSourceCancelledCb: AsyncCallback[(TopicPartition, SubSourceCancellationStrategy)],
+          actorNumber: Int
+      ): SubSourceStageLogic[K, V, CommittableMessage[K, V]] =
+        new CommittableSubSourceStageLogic(shape,
+                                           tp,
+                                           consumerActor,
+                                           subSourceStartedCb,
+                                           subSourceCancelledCb,
+                                           actorNumber,
+                                           settings,
+                                           _metadataFromRecord)
+
     }
+    new SubSourceLogic[K, V, CommittableMessage[K, V]](shape,
+                                                       settings,
+                                                       subscription,
+                                                       getOffsetsOnAssign,
+                                                       onRevoke,
+                                                       subSourceStageLogicFactory = factory)
+  }
 }
 
 /**
@@ -190,4 +208,30 @@ private[kafka] class KafkaAsyncConsumerCommitterRef(private val consumerActor: A
         this.consumerActor == that.consumerActor && this.commitTimeout == that.commitTimeout
       case _ => false
     }
+}
+
+@InternalApi
+private class CommittableSubSourceStageLogic[K, V](
+    shape: SourceShape[CommittableMessage[K, V]],
+    tp: TopicPartition,
+    consumerActor: ActorRef,
+    subSourceStartedCb: AsyncCallback[(TopicPartition, ControlAndStageActor)],
+    subSourceCancelledCb: AsyncCallback[(TopicPartition, SubSourceCancellationStrategy)],
+    actorNumber: Int,
+    consumerSettings: ConsumerSettings[K, V],
+    _metadataFromRecord: ConsumerRecord[K, V] => String = CommittableMessageBuilder.NoMetadataFromRecord
+) extends SubSourceStageLogic[K, V, CommittableMessage[K, V]](shape,
+                                                                tp,
+                                                                consumerActor,
+                                                                subSourceStartedCb,
+                                                                subSourceCancelledCb,
+                                                                actorNumber)
+    with CommittableMessageBuilder[K, V] {
+
+  override def metadataFromRecord(record: ConsumerRecord[K, V]): String = _metadataFromRecord(record)
+  override def groupId: String = consumerSettings.properties(ConsumerConfig.GROUP_ID_CONFIG)
+  lazy val committer: KafkaAsyncConsumerCommitterRef = {
+    val ec = materializer.executionContext
+    new KafkaAsyncConsumerCommitterRef(consumerActor, consumerSettings.commitTimeout)(ec)
+  }
 }

--- a/core/src/main/scala/akka/kafka/internal/CommittingProducerSinkStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommittingProducerSinkStage.scala
@@ -73,7 +73,7 @@ private final class CommittingProducerSinkStageLogic[K, V, IN <: Envelope[K, V, 
   // ---- initialization
   override def preStart(): Unit = {
     super.preStart()
-    resolveProducer()
+    resolveProducer(stage.producerSettings)
   }
 
   /** When the producer is set up, the sink pulls and schedules the first commit. */

--- a/core/src/main/scala/akka/kafka/internal/DeferredProducer.scala
+++ b/core/src/main/scala/akka/kafka/internal/DeferredProducer.scala
@@ -22,7 +22,7 @@ import scala.util.{Failure, Success}
 private[kafka] object DeferredProducer {
 
   /**
-   * The [[ProducerAssignmentLifecycle]] allows us to change track the status of the aynchronous producer assignment
+   * The [[ProducerAssignmentLifecycle]] allows us to track the state of the asynchronous producer assignment
    * within the stage. This is useful when we need to manage different behavior during the assignment process. For
    * example, in [[TransactionalProducerStageLogic]] we match on the lifecycle when extracting the transactional.id
    * of the first message received from a partitioned source.
@@ -76,7 +76,7 @@ private[kafka] trait DeferredProducer[K, V] {
     }
   }
 
-  protected def changeProducerAssignmentLifecycle(state: ProducerAssignmentLifecycle): Unit = {
+  private def changeProducerAssignmentLifecycle(state: ProducerAssignmentLifecycle): Unit = {
     val oldState = producerAssignmentLifecycle
     producerAssignmentLifecycle = state
     log.debug("Asynchronous producer assignment lifecycle changed '{} -> {}'", oldState, state)

--- a/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
+++ b/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
@@ -45,6 +45,8 @@ private[kafka] trait TransactionalMessageBuilderBase[K, V, Msg] extends MessageB
   def committedMarker: CommittedMarker
 
   def onMessage(consumerMessage: ConsumerRecord[K, V]): Unit
+
+  def fromPartitionedSource: Boolean
 }
 
 /** Internal API */
@@ -60,7 +62,8 @@ private[kafka] trait TransactionalMessageBuilder[K, V]
         partition = rec.partition
       ),
       offset = rec.offset,
-      committedMarker
+      committedMarker,
+      fromPartitionedSource
     )
     ConsumerMessage.TransactionalMessage(rec, offset)
   }
@@ -79,7 +82,8 @@ private[kafka] trait TransactionalOffsetContextBuilder[K, V]
         partition = rec.partition
       ),
       offset = rec.offset,
-      committedMarker
+      committedMarker,
+      fromPartitionedSource
     )
     (rec, offset)
   }

--- a/core/src/main/scala/akka/kafka/javadsl/Transactional.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Transactional.scala
@@ -55,30 +55,30 @@ object Transactional {
       .map(_._1)
       .asJava
 
-  /**
-   * Internal API. Work in progress.
-   *
-   * The `partitionedSource` is a way to track automatic partition assignment from kafka.
-   * Each source is setup for for Exactly Only Once (EoS) kafka message semantics.
-   * To enable EoS it's necessary to use the [[Transactional.sink]] or [[Transactional.flow]] (for passthrough).
-   * When Kafka rebalances partitions, all sources complete before the remaining sources are issued again.
-   *
-   * By generating the `transactionalId` from the [[TopicPartition]], multiple instances of your application can run
-   * without having to manually assign partitions to each instance.
-   */
-  @ApiMayChange
-  @InternalApi
-  private[kafka] def partitionedSource[K, V](
-      consumerSettings: ConsumerSettings[K, V],
-      subscription: AutoSubscription
-  ): Source[Pair[TopicPartition, Source[TransactionalMessage[K, V], NotUsed]], Control] =
-    scaladsl.Transactional
-      .partitionedSource(consumerSettings, subscription)
-      .map {
-        case (tp, source) => Pair(tp, source.asJava)
-      }
-      .mapMaterializedValue(ConsumerControlAsJava.apply)
-      .asJava
+//  /**
+//   * Internal API. Work in progress.
+//   *
+//   * The `partitionedSource` is a way to track automatic partition assignment from kafka.
+//   * Each source is setup for for Exactly Only Once (EoS) kafka message semantics.
+//   * To enable EoS it's necessary to use the [[Transactional.sink]] or [[Transactional.flow]] (for passthrough).
+//   * When Kafka rebalances partitions, all sources complete before the remaining sources are issued again.
+//   *
+//   * By generating the `transactionalId` from the [[TopicPartition]], multiple instances of your application can run
+//   * without having to manually assign partitions to each instance.
+//   */
+//  @ApiMayChange
+//  @InternalApi
+//  private[kafka] def partitionedSource[K, V](
+//      consumerSettings: ConsumerSettings[K, V],
+//      subscription: AutoSubscription
+//  ): Source[Pair[TopicPartition, Source[TransactionalMessage[K, V], NotUsed]], Control] =
+//    scaladsl.Transactional
+//      .partitionedSource(consumerSettings, subscription)
+//      .map {
+//        case (tp, source) => Pair(tp, source.asJava)
+//      }
+//      .mapMaterializedValue(ConsumerControlAsJava.apply)
+//      .asJava
 
   /**
    * Sink that is aware of the [[ConsumerMessage.TransactionalMessage.partitionOffset]] from a [[Transactional.source]].  It will

--- a/docs/src/main/paradox/transactions.md
+++ b/docs/src/main/paradox/transactions.md
@@ -78,6 +78,8 @@ Scala
 Java
 : @@ snip [snip](/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java) { #transactionalSink }
 
+
+<!-- TODO: uncomment when Transacitonal.partitionedSource is ready
 ### Partitioned Source Example
 
 Scala
@@ -85,6 +87,7 @@ Scala
 
 Java
 : @@ snip [snip](/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java) { #partitionedTransactionalSink }
+-->
 
 ### Recovery From Failure
 

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
@@ -189,6 +189,8 @@ abstract class KafkaTestKitClass(override val system: ActorSystem, override val 
 object KafkaTestKitClass {
   val topicCounter = new AtomicInteger()
   def createReplicationFactorBrokerProps(replicationFactor: Int): Map[String, String] = Map(
-    "offsets.topic.replication.factor" -> s"$replicationFactor"
+    "offsets.topic.replication.factor" -> s"$replicationFactor",
+    "transaction.state.log.replication.factor" -> s"$replicationFactor",
+    "transaction.state.log.min.isr" -> s"$replicationFactor"
   )
 }

--- a/tests/src/it/resources/logback-test.xml
+++ b/tests/src/it/resources/logback-test.xml
@@ -29,6 +29,6 @@
 
     <root level="DEBUG">
         <appender-ref ref="FILE" />
-        <appender-ref ref="STDOUT" />
+        <!--appender-ref ref="STDOUT" /-->
     </root>
 </configuration>

--- a/tests/src/it/scala/akka/kafka/TransactionsPartitionedSourceSpec.scala
+++ b/tests/src/it/scala/akka/kafka/TransactionsPartitionedSourceSpec.scala
@@ -9,6 +9,7 @@ import akka.kafka.testkit.scaladsl.TestcontainersKafkaPerClassLike
 import akka.stream._
 import akka.stream.scaladsl.{Keep, RestartSource, Sink}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
+import org.scalatest.concurrent.PatienceConfiguration.Interval
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Ignore, Matchers, WordSpecLike}
 
@@ -96,8 +97,8 @@ class TransactionsPartitionedSourceSpec extends SpecBase
         .map(_.toString)
         .map(runStream)
 
-      while (completedCopy.get() < consumers) {
-        Thread.sleep(2000)
+      eventually(Interval(2.seconds)) {
+        completedCopy.get() should be < consumers
       }
 
       val consumer = consumePartitionOffsetValues(

--- a/tests/src/it/scala/akka/kafka/TransactionsPartitionedSourceSpec.scala
+++ b/tests/src/it/scala/akka/kafka/TransactionsPartitionedSourceSpec.scala
@@ -1,0 +1,127 @@
+package akka.kafka
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.Done
+import akka.kafka.scaladsl.SpecBase
+import akka.kafka.testkit.KafkaTestkitTestcontainersSettings
+import akka.kafka.testkit.scaladsl.TestcontainersKafkaPerClassLike
+import akka.stream._
+import akka.stream.scaladsl.{Keep, RestartSource, Sink}
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{Ignore, Matchers, WordSpecLike}
+
+import scala.collection.immutable
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future, TimeoutException}
+import scala.util.{Failure, Success}
+
+@Ignore
+class TransactionsPartitionedSourceSpec extends SpecBase
+  with TestcontainersKafkaPerClassLike
+  with WordSpecLike
+  with ScalaFutures
+  with Matchers
+  with TransactionsOps
+  with Repeated {
+
+  val replicationFactor = 2
+
+  implicit val pc = PatienceConfig(45.seconds, 1.second)
+
+  override val testcontainersSettings = KafkaTestkitTestcontainersSettings(system)
+    .withNumBrokers(3)
+    .withInternalTopicsReplicationFactor(replicationFactor)
+
+  "A multi-broker consume-transform-produce cycle" must {
+    "provide consistency when multiple partitioned transactional streams are being restarted" in assertAllStagesStopped {
+      val sourcePartitions = 4
+      val destinationPartitions = 4
+      val consumers = 3
+      val replication = replicationFactor
+
+      val sourceTopic = createTopic(1, sourcePartitions, replication)
+      val sinkTopic = createTopic(2, destinationPartitions, replication)
+      val group = createGroupId(1)
+      val transactionalId = createTransactionalId()
+
+      val elements = 100 * 1000 // 100 * 1,000 = 100,000
+      val restartAfter = (10 * 1000) / sourcePartitions // (10 * 1,000) / 10 = 100
+
+      val producers: immutable.Seq[Future[Done]] =
+        (0 until sourcePartitions).map { part =>
+          produce(sourceTopic, range = 1 to elements, partition = part)
+        }
+
+      Await.result(Future.sequence(producers), 4.minute)
+
+      val consumerSettings = consumerDefaults.withGroupId(group)
+
+      val completedCopy = new AtomicInteger(0)
+      val completedWithTimeout = new AtomicInteger(0)
+
+      def runStream(id: String): UniqueKillSwitch =
+        RestartSource
+          .onFailuresWithBackoff(10.millis, 100.millis, 0.2)(
+            () => {
+              transactionalPartitionedCopyStream(
+                consumerSettings,
+                txProducerDefaults,
+                sourceTopic,
+                sinkTopic,
+                transactionalId,
+                idleTimeout = 10.seconds,
+                maxPartitions = sourcePartitions,
+                restartAfter = Some(restartAfter)
+              )
+                .recover {
+                  case e: TimeoutException =>
+                    if (completedWithTimeout.incrementAndGet() > 10)
+                      "no more messages to copy"
+                    else
+                      throw new Error("Continue restarting copy stream")
+                }
+            }
+          )
+          .viaMat(KillSwitches.single)(Keep.right)
+          .toMat(Sink.onComplete {
+            case Success(_) =>
+              completedCopy.incrementAndGet()
+            case Failure(_) => // restart
+          })(Keep.left)
+          .run()
+
+      val controls: Seq[UniqueKillSwitch] = (0 until consumers)
+        .map(_.toString)
+        .map(runStream)
+
+      while (completedCopy.get() < consumers) {
+        Thread.sleep(2000)
+      }
+
+      val consumer = consumePartitionOffsetValues(
+        probeConsumerSettings(createGroupId(2)),
+        sinkTopic,
+        elementsToTake = (elements * destinationPartitions).toLong
+      )
+
+      val actualValues = Await.result(consumer, 10.minutes)
+
+      log.debug("Expected elements: {}, actual elements: {}", elements, actualValues.length)
+
+      assertPartitionedConsistency(elements, destinationPartitions, actualValues)
+
+      controls.foreach(_.shutdown())
+    }
+  }
+
+  private def probeConsumerSettings(groupId: String): ConsumerSettings[String, String] =
+    withProbeConsumerSettings(consumerDefaults, groupId)
+
+  override def producerDefaults: ProducerSettings[String, String] =
+    withTestProducerSettings(super.producerDefaults)
+
+  def txProducerDefaults: ProducerSettings[String, String] =
+    withTransactionalProducerSettings(super.producerDefaults)
+}

--- a/tests/src/it/scala/akka/kafka/TransactionsSourceSpec.scala
+++ b/tests/src/it/scala/akka/kafka/TransactionsSourceSpec.scala
@@ -11,6 +11,7 @@ import akka.stream._
 import akka.stream.scaladsl.{Flow, Keep, RestartSource, Sink}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import org.apache.kafka.clients.producer.ProducerRecord
+import org.scalatest.concurrent.PatienceConfiguration.Interval
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Matchers, WordSpecLike}
 
@@ -89,8 +90,8 @@ class TransactionsSourceSpec extends SpecBase
 
       val probeConsumerGroup = createGroupId(2)
 
-      while (completedCopy.get() < consumers) {
-        Thread.sleep(2000)
+      eventually(Interval(2.seconds)) {
+        completedCopy.get() should be < consumers
       }
 
       val consumer = offsetValueSource(probeConsumerSettings(probeConsumerGroup), sinkTopic)

--- a/tests/src/it/scala/akka/kafka/TransactionsSourceSpec.scala
+++ b/tests/src/it/scala/akka/kafka/TransactionsSourceSpec.scala
@@ -1,0 +1,189 @@
+package akka.kafka
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import akka.Done
+import akka.kafka.scaladsl.Consumer.Control
+import akka.kafka.scaladsl.{Consumer, SpecBase, Transactional}
+import akka.kafka.testkit.KafkaTestkitTestcontainersSettings
+import akka.kafka.testkit.scaladsl.TestcontainersKafkaPerClassLike
+import akka.stream._
+import akka.stream.scaladsl.{Flow, Keep, RestartSource, Sink}
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{Matchers, WordSpecLike}
+
+import scala.collection.immutable
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future, TimeoutException}
+import scala.util.{Failure, Success}
+
+class TransactionsSourceSpec extends SpecBase
+  with TestcontainersKafkaPerClassLike
+  with WordSpecLike
+  with ScalaFutures
+  with Matchers
+  with TransactionsOps
+  with Repeated {
+
+  implicit val pc = PatienceConfig(45.seconds, 1.second)
+
+  override val testcontainersSettings = KafkaTestkitTestcontainersSettings(system)
+    .withNumBrokers(3)
+    .withInternalTopicsReplicationFactor(2)
+
+  "A multi-broker consume-transform-produce cycle" must {
+    "provide consistency when multiple transactional streams are being restarted" in assertAllStagesStopped {
+      val sourcePartitions = 10
+      val destinationPartitions = 4
+      val consumers = 3
+      val replication = 2
+
+      val sourceTopic = createTopic(1, sourcePartitions, replication)
+      val sinkTopic = createTopic(2, destinationPartitions, replication)
+      val group = createGroupId(1)
+
+      val elements = 100 * 1000
+      val restartAfter = 10 * 1000
+
+      val partitionSize = elements / sourcePartitions
+      val producers: immutable.Seq[Future[Done]] =
+        (0 until sourcePartitions).map(
+          part => produce(sourceTopic, ((part * partitionSize) + 1) to (partitionSize * (part + 1)), part)
+        )
+
+      Await.result(Future.sequence(producers), 1.minute)
+
+      val consumerSettings = consumerDefaults.withGroupId(group)
+
+      val completedCopy = new AtomicInteger(0)
+      val completedWithTimeout = new AtomicInteger(0)
+
+      def runStream(id: String): UniqueKillSwitch =
+        RestartSource
+          .onFailuresWithBackoff(10.millis, 100.millis, 0.2)(
+            () => {
+              val transactionId = s"$group-$id"
+              transactionalCopyStream(consumerSettings, txProducerDefaults, sourceTopic, sinkTopic, transactionId, 10.seconds, Some(restartAfter))
+                .recover {
+                  case e: TimeoutException =>
+                    if (completedWithTimeout.incrementAndGet() > 10)
+                      "no more messages to copy"
+                    else
+                      throw new Error("Continue restarting copy stream")
+                }
+            }
+          )
+          .viaMat(KillSwitches.single)(Keep.right)
+          .toMat(Sink.onComplete {
+            case Success(_) =>
+              completedCopy.incrementAndGet()
+            case Failure(_) => // restart
+          })(Keep.left)
+          .run()
+
+      val controls: Seq[UniqueKillSwitch] = (0 until consumers)
+        .map(_.toString)
+        .map(runStream)
+
+      val probeConsumerGroup = createGroupId(2)
+
+      while (completedCopy.get() < consumers) {
+        Thread.sleep(2000)
+      }
+
+      val consumer = offsetValueSource(probeConsumerSettings(probeConsumerGroup), sinkTopic)
+        .take(elements.toLong)
+        .idleTimeout(30.seconds)
+        .alsoTo(
+          Flow[(Long, String)]
+            .scan(0) { case (count, _) => count + 1 }
+            .filter(_ % 10000 == 0)
+            .log("received")
+            .to(Sink.ignore)
+        )
+        .recover {
+          case t => (0L, "no-more-elements")
+        }
+        .filter(_._2 != "no-more-elements")
+        .runWith(Sink.seq)
+
+      val values = Await.result(consumer, 10.minutes)
+
+      val expected = (1 to elements).map(_.toString)
+
+      log.info("Expected elements: {}, actual elements: {}", elements, values.length)
+
+      checkForMissing(values, expected)
+      checkForDuplicates(values, expected)
+
+      controls.foreach(_.shutdown())
+    }
+
+    "drain stream on partitions rebalancing" in assertAllStagesStopped {
+      // Runs a copying transactional flows that delay writing to the output partition using a `delay` stage.
+      // Creates more flows than ktps to trigger partition rebalancing.
+      // The output topic should contain the same elements as the input topic.
+
+      val sourceTopic = createTopic(1, partitions = 2)
+      val sinkTopic = createTopic(2, partitions = 4)
+      val group = createGroupId(1)
+
+      val elements = 100
+      val batchSize = 10
+      Await.result(produce(sourceTopic, 1 to elements), remainingOrDefault)
+
+      val elementsWrote = new AtomicInteger(0)
+
+      val consumerSettings = consumerDefaults.withGroupId(group)
+
+      def runStream(id: String): Consumer.Control = {
+        val control: Control =
+          Transactional
+            .source(consumerSettings, Subscriptions.topics(sourceTopic))
+            .map { msg =>
+              ProducerMessage.single(new ProducerRecord[String, String](sinkTopic, msg.record.value),
+                msg.partitionOffset)
+            }
+            .take(batchSize.toLong)
+            .delay(3.seconds, strategy = DelayOverflowStrategy.backpressure)
+            .addAttributes(Attributes.inputBuffer(batchSize, batchSize + 1))
+            .via(Transactional.flow(producerDefaults, s"$group-$id"))
+            .map(_ => elementsWrote.incrementAndGet())
+            .toMat(Sink.ignore)(Keep.left)
+            .run()
+        control
+      }
+
+      val controls: Seq[Control] = (0 until elements / batchSize)
+        .map(_.toString)
+        .map(runStream)
+
+      val probeConsumerGroup = createGroupId(2)
+      val probeConsumer = valuesProbeConsumer(probeConsumerSettings(probeConsumerGroup), sinkTopic)
+
+      periodicalCheck("Wait for elements written to Kafka", maxTries = 30, 1.second) { () =>
+        elementsWrote.get()
+      }(_ > 10)
+
+      probeConsumer
+        .request(elements.toLong)
+        .expectNextUnorderedN((1 to elements).map(_.toString))
+
+      probeConsumer.cancel()
+
+      val futures: Seq[Future[Done]] = controls.map(_.shutdown())
+      Await.result(Future.sequence(futures), remainingOrDefault)
+    }
+  }
+
+  private def probeConsumerSettings(groupId: String): ConsumerSettings[String, String] =
+    withProbeConsumerSettings(consumerDefaults, groupId)
+
+  override def producerDefaults: ProducerSettings[String, String] =
+    withTestProducerSettings(super.producerDefaults)
+
+  def txProducerDefaults: ProducerSettings[String, String] =
+    withTransactionalProducerSettings(super.producerDefaults)
+}

--- a/tests/src/test/resources/application.conf
+++ b/tests/src/test/resources/application.conf
@@ -17,6 +17,9 @@ akka {
   }
 }
 
+# default is 10 seconds
+# akka.kafka.testkit.consumer-group-timeout = 20 seconds
+
 # #consumer-config-inheritance
 our-kafka-consumer: ${akka.kafka.consumer} {
   kafka-clients {

--- a/tests/src/test/resources/logback-test.xml
+++ b/tests/src/test/resources/logback-test.xml
@@ -43,7 +43,7 @@
     <logger name="com.github.dockerjava" level="WARN"/>
 
     <root level="DEBUG">
-        <!--<appender-ref ref="STDOUT" /-->
+        <!-- appender-ref ref="STDOUT" /-->
         <appender-ref ref="FILE" />
     </root>
 

--- a/tests/src/test/scala/akka/kafka/Repeated.scala
+++ b/tests/src/test/scala/akka/kafka/Repeated.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka
+
+import org.scalatest._
+
+/**
+ * Repeat test suite n times.  Default: 1.
+ * Define number of times to repeat by overriding `timesToRepeat` or passing `-DtimesToRepeat=n`
+ *
+ * Ex) To run a single test 10 times from the terminal
+ *
+ * {{{
+ * sbt "tests/testOnly *.TransactionsSpec -- -z \"must support copy stream with merging and multi message\" -DtimesToRepeat=2"
+ * }}}
+ */
+trait Repeated extends TestSuiteMixin { this: TestSuite =>
+  def timesToRepeat: Int = 1
+
+  protected abstract override def runTest(testName: String, args: Args): Status = {
+    def run0(times: Int): Status = {
+      val status = super.runTest(testName, args)
+      if (times <= 1) status else status.thenRun(run0(times - 1))
+    }
+
+    run0(args.configMap.getWithDefault("timesToRepeat", timesToRepeat.toString).toInt)
+  }
+
+  /**
+   * Retry a code block n times or until Success
+   */
+  @annotation.tailrec
+  final def retry[T](n: Int)(fn: Int => T): T =
+    util.Try { fn(n + 1) } match {
+      case util.Success(x) => x
+      case _ if n > 1 => retry(n - 1)(fn)
+      case util.Failure(e) => throw e
+    }
+}

--- a/tests/src/test/scala/akka/kafka/TransactionsOps.scala
+++ b/tests/src/test/scala/akka/kafka/TransactionsOps.scala
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka
+import akka.{Done, NotUsed}
+import akka.actor.ActorSystem
+import akka.kafka.ConsumerMessage.PartitionOffset
+import akka.kafka.ProducerMessage.MultiMessage
+import akka.kafka.scaladsl.Consumer.Control
+import akka.kafka.scaladsl.{Consumer, Producer, Transactional}
+import akka.stream.Materializer
+import akka.stream.scaladsl.{Flow, Sink, Source}
+import akka.stream.testkit.TestSubscriber
+import akka.stream.testkit.scaladsl.TestSink
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
+import org.scalatest.{Matchers, TestSuite}
+
+import scala.collection.immutable
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+trait TransactionsOps extends TestSuite with Matchers {
+  def transactionalCopyStream(
+      consumerSettings: ConsumerSettings[String, String],
+      producerSettings: ProducerSettings[String, String],
+      sourceTopic: String,
+      sinkTopic: String,
+      transactionalId: String,
+      idleTimeout: FiniteDuration,
+      restartAfter: Option[Int] = None
+  ): Source[ProducerMessage.Results[String, String, PartitionOffset], Control] =
+    Transactional
+      .source(consumerSettings, Subscriptions.topics(sourceTopic))
+      .zip(Source.unfold(1)(count => Some((count + 1, count))))
+      .map {
+        case (msg, count) =>
+          if (restartAfter.exists(restartAfter => count >= restartAfter))
+            throw new Error("Restarting transactional copy stream")
+          msg
+      }
+      .idleTimeout(idleTimeout)
+      .map { msg =>
+        ProducerMessage.single(new ProducerRecord[String, String](sinkTopic, msg.record.value), msg.partitionOffset)
+      }
+      .via(Transactional.flow(producerSettings, transactionalId))
+
+  /**
+   * Copy messages from a source to sink topic. Source and sink must have exactly the same number of partitions.
+   */
+  def transactionalPartitionedCopyStream(
+      consumerSettings: ConsumerSettings[String, String],
+      producerSettings: ProducerSettings[String, String],
+      sourceTopic: String,
+      sinkTopic: String,
+      transactionalId: String,
+      idleTimeout: FiniteDuration,
+      maxPartitions: Int,
+      restartAfter: Option[Int] = None
+  ): Source[ProducerMessage.Results[String, String, PartitionOffset], Control] =
+    Transactional
+      .partitionedSource(consumerSettings, Subscriptions.topics(sourceTopic))
+      .flatMapMerge(
+        maxPartitions, {
+          case (_, source) =>
+            val results: Source[ProducerMessage.Results[String, String, PartitionOffset], NotUsed] = source
+              .zip(Source.unfold(1)(count => Some((count + 1, count))))
+              .map {
+                case (msg, count) =>
+                  if (restartAfter.exists(restartAfter => count >= restartAfter))
+                    throw new Error("Restarting transactional copy stream")
+                  msg
+              }
+              .idleTimeout(idleTimeout)
+              .map { msg =>
+                ProducerMessage.single(new ProducerRecord[String, String](sinkTopic,
+                                                                          msg.record.partition(),
+                                                                          msg.record.key(),
+                                                                          msg.record.value),
+                                       msg.partitionOffset)
+              }
+              .via(Transactional.flow(producerSettings, transactionalId))
+            results
+        }
+      )
+
+  def produceToAllPartitions(producerSettings: ProducerSettings[String, String],
+                             topic: String,
+                             partitions: Int,
+                             range: Range)(implicit mat: Materializer): Future[Done] =
+    Source(range)
+      .map { n =>
+        val msgs = (0 until partitions).map(p => new ProducerRecord(topic, p, n.toString, n.toString))
+        MultiMessage(msgs, n)
+      }
+      .via(Producer.flexiFlow(producerSettings))
+      .runWith(Sink.ignore)
+
+  def checkForDuplicates(values: immutable.Seq[(Long, String)], expected: immutable.IndexedSeq[String]): Unit =
+    withClue("Checking for duplicates: ") {
+      val duplicates = values.map(_._2) diff expected
+      if (duplicates.nonEmpty) {
+        val duplicatesWithDifferentOffsets = values
+          .filter {
+            case (_, value) => duplicates.contains(value)
+          }
+          .groupBy(_._2) // message
+          // workaround for Scala collection refactoring of `mapValues` to remain compat with 2.12/2.13 cross build
+          .map { case (k, v) => (k, v.map(_._1)) } // keep offset
+          .filter {
+            case (_, offsets) => offsets.distinct.size > 1
+          }
+
+        if (duplicatesWithDifferentOffsets.nonEmpty) {
+          fail(s"Got ${duplicates.size} duplicates. Messages and their offsets: $duplicatesWithDifferentOffsets")
+        } else {
+          println("Got duplicates, but all of them were due to rebalance replay when counting")
+        }
+      }
+    }
+
+  def checkForMissing(values: immutable.Seq[(Long, String)], expected: immutable.IndexedSeq[String]): Unit =
+    withClue("Checking for missing: ") {
+      val missing = expected diff values.map(_._2)
+      if (missing.nonEmpty) {
+        val continuousBlocks = missing
+          .scanLeft(("-1", 0)) {
+            case ((last, block), curr) => if (last.toInt + 1 == curr.toInt) (curr, block) else (curr, block + 1)
+          }
+          .tail
+          .groupBy(_._2)
+        val blockDescription = continuousBlocks
+          .map { block =>
+            val msgs = block._2.map(_._1)
+            s"Missing ${msgs.size} in continuous block, first ten: ${msgs.take(10)}"
+          }
+          .mkString(" ")
+        fail(s"Did not get ${missing.size} expected messages. $blockDescription")
+      }
+    }
+
+  def valuesProbeConsumer(
+      settings: ConsumerSettings[String, String],
+      topic: String
+  )(implicit actorSystem: ActorSystem, mat: Materializer): TestSubscriber.Probe[String] =
+    offsetValueSource(settings, topic)
+      .map(_._2)
+      .runWith(TestSink.probe)
+
+  def offsetValueSource(settings: ConsumerSettings[String, String],
+                        topic: String): Source[(Long, String), Consumer.Control] =
+    Consumer
+      .plainSource(settings, Subscriptions.topics(topic))
+      .map(r => (r.offset(), r.value()))
+
+  def consumePartitionOffsetValues(settings: ConsumerSettings[String, String], topic: String, elementsToTake: Long)(
+      implicit mat: Materializer
+  ): Future[immutable.Seq[(Int, Long, String)]] =
+    Consumer
+      .plainSource(settings, Subscriptions.topics(topic))
+      .map(r => (r.partition(), r.offset(), r.value()))
+      .take(elementsToTake)
+      .idleTimeout(30.seconds)
+      .alsoTo(
+        Flow[(Int, Long, String)]
+          .scan(0) { case (count, _) => count + 1 }
+          .filter(_ % 100 == 0)
+          .log("received")
+          .to(Sink.ignore)
+      )
+      .recover {
+        case t => (0, 0L, "no-more-elements")
+      }
+      .filter(_._3 != "no-more-elements")
+      .runWith(Sink.seq)
+
+  def assertPartitionedConsistency(
+      elements: Int,
+      maxPartitions: Int,
+      values: immutable.Seq[(Int, Long, String)]
+  ): Unit = {
+    val expectedValues: immutable.Seq[String] = (1 to elements).map(_.toString)
+
+    for (partition <- 0 until maxPartitions) {
+      println(s"Asserting values for partition: $partition")
+
+      val partitionMessages: immutable.Seq[String] =
+        values.filter(_._1 == partition).map { case (_, _, value) => value }
+
+      assert(partitionMessages.length == elements)
+      expectedValues should contain theSameElementsInOrderAs partitionMessages
+    }
+  }
+
+  def withProbeConsumerSettings(settings: ConsumerSettings[String, String],
+                                groupId: String): ConsumerSettings[String, String] =
+    settings
+      .withGroupId(groupId)
+      .withProperties(ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed")
+
+  def withTestProducerSettings(settings: ProducerSettings[String, String]): ProducerSettings[String, String] =
+    settings
+      .withCloseTimeout(Duration.Zero)
+      .withProperty(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true")
+
+  def withTransactionalProducerSettings(settings: ProducerSettings[String, String]): ProducerSettings[String, String] =
+    settings
+      .withParallelism(20)
+      .withCloseTimeout(Duration.Zero)
+}

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -13,6 +13,7 @@ import akka.kafka._
 import akka.kafka.scaladsl.Consumer.DrainingControl
 import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
 import akka.pattern.ask
+import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.TestSink
@@ -328,6 +329,91 @@ class IntegrationSpec extends SpecBase with TestcontainersKafkaLike with Inside 
       }
     }
 
+    "rebalance safely using transactional partitioned flow" in assertAllStagesStopped {
+      val partitions = 4
+      val totalMessages = 200L
+
+      val topic = createTopic(1, partitions)
+      val outTopic = createTopic(2, partitions)
+      val group = createGroupId(1)
+      val transactionalId = createTransactionalId()
+      val sourceSettings = consumerDefaults
+        .withGroupId(group)
+
+      val topicSubscription = Subscriptions.topics(topic)
+
+      def createAndRunTransactionalFlow(subscription: AutoSubscription) =
+        Transactional
+          .partitionedSource(sourceSettings, subscription)
+          .map {
+            case (tp, source) =>
+              source
+                .map { msg =>
+                  ProducerMessage.single(new ProducerRecord[String, String](outTopic,
+                                                                            msg.record.partition(),
+                                                                            msg.record.key(),
+                                                                            msg.record.value() + "-out"),
+                                         msg.partitionOffset)
+                }
+                .to(Transactional.sink(producerDefaults, transactionalId))
+                .run()
+          }
+          .toMat(Sink.ignore)(Keep.both)
+          .mapMaterializedValue(DrainingControl.apply)
+          .run()
+
+      def createAndRunProducer(elements: immutable.Iterable[Long]) =
+        Source(elements)
+          .map(n => new ProducerRecord(topic, (n % partitions).toInt, DefaultKey, n.toString))
+          .runWith(Producer.plainSink(producerDefaults.withProducer(testProducer)))
+
+      val control = createAndRunTransactionalFlow(topicSubscription)
+
+      // waits until all partitions are assigned to the single consumer
+      waitUntilConsumerSummary(group) {
+        case singleConsumer :: Nil => singleConsumer.assignment.topicPartitions.size == partitions
+      }
+
+      createAndRunProducer(0L until totalMessages / 2).futureValue
+
+      // create another consumer with the same groupId to trigger re-balancing
+      val control2 = createAndRunTransactionalFlow(topicSubscription)
+
+      // waits until partitions are assigned across both consumers
+      waitUntilConsumerSummary(group) {
+        case consumer1 :: consumer2 :: Nil =>
+          val half = partitions / 2
+          consumer1.assignment.topicPartitions.size == half && consumer2.assignment.topicPartitions.size == half
+      }
+
+      createAndRunProducer(totalMessages / 2 until totalMessages).futureValue
+
+      val checkingGroup = createGroupId(2)
+
+      val (counterQueue, counterCompletion) = Source
+        .queue[String](8, OverflowStrategy.fail)
+        .scan(0L)((c, _) => c + 1)
+        .takeWhile(_ < totalMessages, inclusive = true)
+        .toMat(Sink.last)(Keep.both)
+        .run()
+
+      val streamMessages = Consumer
+        .plainSource[String, String](consumerDefaults
+                                       .withGroupId(checkingGroup)
+                                       .withProperty(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed"),
+                                     Subscriptions.topics(outTopic))
+        .mapAsync(1)(el => counterQueue.offer(el.value()).map(_ => el))
+        .scan(0L)((c, _) => c + 1)
+        .toMat(Sink.last)(Keep.both)
+        .mapMaterializedValue(DrainingControl.apply)
+        .run()
+
+      counterCompletion.futureValue shouldBe totalMessages
+
+      control.drainAndShutdown().futureValue
+      control2.drainAndShutdown().futureValue
+      streamMessages.drainAndShutdown().futureValue shouldBe totalMessages
+    }
   }
 
   "Consumer control" must {

--- a/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
@@ -30,10 +30,6 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
   implicit val patience = PatienceConfig(15.seconds, 500.millis)
   override def sleepAfterProduce: FiniteDuration = 500.millis
 
-  override def consumerDefaults: ConsumerSettings[String, String] =
-    super.consumerDefaults
-      .withStopTimeout(10.millis)
-
   "Partitioned source" must {
 
     "begin consuming from the beginning of the topic" in assertAllStagesStopped {

--- a/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
@@ -9,11 +9,13 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import akka.Done
 import akka.kafka.ConsumerMessage.PartitionOffset
-import akka.kafka.scaladsl.Consumer.Control
+import akka.kafka.scaladsl.Consumer.{Control, DrainingControl}
 import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
 import akka.kafka.{ProducerMessage, _}
-import akka.stream.scaladsl.{Keep, RestartSource, Sink}
+import akka.stream.OverflowStrategy
+import akka.stream.scaladsl.{Keep, RestartSource, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
+import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.scalatest.RecoverMethods._
 
@@ -22,6 +24,9 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
 class TransactionsSpec extends SpecBase with TestcontainersKafkaLike with TransactionsOps with Repeated {
+
+  implicit val patience = PatienceConfig(5.seconds, 15.millis)
+
   "A consume-transform-produce cycle" must {
 
     "complete in happy-path scenario" in {
@@ -428,6 +433,92 @@ class TransactionsSpec extends SpecBase with TestcontainersKafkaLike with Transa
         Await.result(control1.shutdown(), remainingOrDefault)
         Await.result(control2.shutdown(), remainingOrDefault)
       }
+    }
+
+    "rebalance safely using transactional partitioned flow" in assertAllStagesStopped {
+      val partitions = 4
+      val totalMessages = 200L
+
+      val topic = createTopic(1, partitions)
+      val outTopic = createTopic(2, partitions)
+      val group = createGroupId(1)
+      val transactionalId = createTransactionalId()
+      val sourceSettings = consumerDefaults
+        .withGroupId(group)
+
+      val topicSubscription = Subscriptions.topics(topic)
+
+      def createAndRunTransactionalFlow(subscription: AutoSubscription) =
+        Transactional
+          .partitionedSource(sourceSettings, subscription)
+          .map {
+            case (tp, source) =>
+              source
+                .map { msg =>
+                  ProducerMessage.single(new ProducerRecord[String, String](outTopic,
+                                                                            msg.record.partition(),
+                                                                            msg.record.key(),
+                                                                            msg.record.value() + "-out"),
+                                         msg.partitionOffset)
+                }
+                .to(Transactional.sink(producerDefaults, transactionalId))
+                .run()
+          }
+          .toMat(Sink.ignore)(Keep.both)
+          .mapMaterializedValue(DrainingControl.apply)
+          .run()
+
+      def createAndRunProducer(elements: immutable.Iterable[Long]) =
+        Source(elements)
+          .map(n => new ProducerRecord(topic, (n % partitions).toInt, DefaultKey, n.toString))
+          .runWith(Producer.plainSink(producerDefaults.withProducer(testProducer)))
+
+      val control = createAndRunTransactionalFlow(topicSubscription)
+
+      // waits until all partitions are assigned to the single consumer
+      waitUntilConsumerSummary(group) {
+        case singleConsumer :: Nil => singleConsumer.assignment.topicPartitions.size == partitions
+      }
+
+      createAndRunProducer(0L until totalMessages / 2).futureValue
+
+      // create another consumer with the same groupId to trigger re-balancing
+      val control2 = createAndRunTransactionalFlow(topicSubscription)
+
+      // waits until partitions are assigned across both consumers
+      waitUntilConsumerSummary(group) {
+        case consumer1 :: consumer2 :: Nil =>
+          val half = partitions / 2
+          consumer1.assignment.topicPartitions.size == half && consumer2.assignment.topicPartitions.size == half
+      }
+
+      createAndRunProducer(totalMessages / 2 until totalMessages).futureValue
+
+      val checkingGroup = createGroupId(2)
+
+      val (counterQueue, counterCompletion) = Source
+        .queue[String](8, OverflowStrategy.fail)
+        .scan(0L)((c, _) => c + 1)
+        .takeWhile(_ < totalMessages, inclusive = true)
+        .toMat(Sink.last)(Keep.both)
+        .run()
+
+      val streamMessages = Consumer
+        .plainSource[String, String](consumerDefaults
+                                       .withGroupId(checkingGroup)
+                                       .withProperty(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed"),
+                                     Subscriptions.topics(outTopic))
+        .mapAsync(1)(el => counterQueue.offer(el.value()).map(_ => el))
+        .scan(0L)((c, _) => c + 1)
+        .toMat(Sink.last)(Keep.both)
+        .mapMaterializedValue(DrainingControl.apply)
+        .run()
+
+      counterCompletion.futureValue shouldBe totalMessages
+
+      control.drainAndShutdown().futureValue
+      control2.drainAndShutdown().futureValue
+      streamMessages.drainAndShutdown().futureValue shouldBe totalMessages
     }
   }
 

--- a/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
@@ -127,4 +127,45 @@ class TransactionsExample extends DocsSpecBase with TestcontainersKafkaLike {
     result.futureValue should have size (10)
   }
 
+//  "Partitioned transactional sink" should "work" in {
+//    val consumerSettings = consumerDefaults.withGroupId(createGroupId())
+//    val producerSettings = producerDefaults
+//    val maxPartitions = 2
+//    val sourceTopic = createTopic(1, maxPartitions, 1)
+//    val sinkTopic = createTopicName(2)
+//    val transactionalId = createTransactionalId()
+//    // #partitionedTransactionalSink
+//    val control =
+//      Transactional
+//        .partitionedSource(consumerSettings, Subscriptions.topics(sourceTopic))
+//        .mapAsyncUnordered(maxPartitions) {
+//          case (tp, source) =>
+//            source
+//              .via(businessFlow)
+//              .map { msg =>
+//                ProducerMessage.single(new ProducerRecord(sinkTopic, msg.record.key, msg.record.value),
+//                                       msg.partitionOffset)
+//              }
+//              .runWith(Transactional.sink(producerSettings, transactionalId))
+//        }
+//        .toMat(Sink.ignore)(Keep.both)
+//        .mapMaterializedValue(DrainingControl.apply)
+//        .run()
+//    // ...
+//
+//    // #partitionedTransactionalSink
+//    val (control2, result) = Consumer
+//      .plainSource(consumerSettings, Subscriptions.topics(sinkTopic))
+//      .toMat(Sink.seq)(Keep.both)
+//      .run()
+//
+//    awaitProduce(produce(sourceTopic, 1 to 10))
+//    control.drainAndShutdown().futureValue should be(Done)
+//    control2.shutdown().futureValue should be(Done)
+//    // #partitionedTransactionalSink
+//    control.drainAndShutdown()
+//    // #partitionedTransactionalSink
+//    result.futureValue should have size (10)
+//  }
+
 }


### PR DESCRIPTION
## Purpose

This PR adds a new partitioned source with support for Kafka transactions, `Transactions.partitionedSource`.  A `Source` is created per partition in a consumer group subscription.  Each `Source` must have a downstream `Transactional.sink|flow` to commit messages transactionally.  A derived `transactional.id` is used per `Transactional.sink|flow` that's based on a user-provided `transactional.id` along with the `group.id`, topic and partition of the originally consumed message.  `Transactions.partitionedSource` will make it easier to run transactional workloads across consumer groups with multiple members.

This PR is based on the extensive work already completed by @charlibot earlier this year. It was rebased by @raboof and updated to accommodate transactional consistency work completed by @2m and @szymonm.  This new branch will serve as the integration point to get this functionality into Alpakka Kafka 2.0.0.

**Update 27/11/2019**

Due to the large number of changes introduced by this PR it has been repurposed as a "phase 1" to lay the groundwork to continue this work.  This PR will not expose the `Transactional.partitionedSource` to the end user.

## References

* Original PR: #705 
* Transactions draining logic PR: #757 
* Original Transactions PR: #420

## Phase 1 tasks

- [x] Core impl.
- [x] Confirm producer per substream is acceptable (https://github.com/akka/alpakka-kafka/pull/705#discussion_r330509381)
- [x] Review docs.  Include details about KIP-447.
- [x] Multi-broker integration test (blocked by https://github.com/akka/alpakka-kafka/pull/939)
- [x] Test: If sub source fails, rebalance occurs and new source is created (https://github.com/akka/alpakka-kafka/pull/705#discussion_r251468274)
- [x] Test: Consistency after rebalance of regular transactions
- [x] Update docs. (_to be continued in phase 2_)
- [x] Test retry infrastructure

## Phase 2 tasks (preliminary)

- Test: Consistency of partitioned source when calling shutdown using draining control
- Set `ConsumerSettings.stopTimeout` to 0 to allow for faster shutdowns when a stream completes/fails.
- Update docs. (_to be continued in phase 2_)
- Add more low level testing of draining control logic