### PR TITLE
Committer: change type bound to allow offset batches

### DIFF
--- a/core/src/main/scala/akka/kafka/javadsl/Committer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Committer.scala
@@ -36,7 +36,7 @@ object Committer {
    * `CommittableOffsetBatch` as context.
    */
   @ApiMayChange
-  def flowWithOffsetContext[E, C <: CommittableOffset](
+  def flowWithOffsetContext[E, C <: Committable](
       settings: CommitterSettings
   ): FlowWithContext[E, C, NotUsed, CommittableOffsetBatch, NotUsed] =
     scaladsl.Committer.flowWithOffsetContext[E](settings).asJava
@@ -53,7 +53,7 @@ object Committer {
    * Batches offsets from context and commits them to Kafka.
    */
   @ApiMayChange
-  def sinkWithOffsetContext[E, C <: CommittableOffset](
+  def sinkWithOffsetContext[E, C <: Committable](
       settings: CommitterSettings
   ): Sink[Pair[E, C], CompletionStage[Done]] =
     akka.stream.scaladsl

--- a/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
@@ -52,8 +52,8 @@ object Committer {
   @ApiMayChange
   def flowWithOffsetContext[E](
       settings: CommitterSettings
-  ): FlowWithContext[E, CommittableOffset, NotUsed, CommittableOffsetBatch, NotUsed] = {
-    val value = Flow[(E, CommittableOffset)]
+  ): FlowWithContext[E, Committable, NotUsed, CommittableOffsetBatch, NotUsed] = {
+    val value = Flow[(E, Committable)]
       .map(_._2)
       .via(batchFlow(settings))
       .map(b => (NotUsed, b))
@@ -73,8 +73,8 @@ object Committer {
    * Batches offsets from context and commits them to Kafka.
    */
   @ApiMayChange
-  def sinkWithOffsetContext[E](settings: CommitterSettings): Sink[(E, CommittableOffset), Future[Done]] =
-    Flow[(E, CommittableOffset)]
+  def sinkWithOffsetContext[E](settings: CommitterSettings): Sink[(E, Committable), Future[Done]] =
+    Flow[(E, Committable)]
       .via(flowWithOffsetContext(settings))
       .toMat(Sink.ignore)(Keep.right)
 


### PR DESCRIPTION
Change the type bound on the new `Committer.flowWithOffsetContext` and `Committer.sinkWithOffsetContext` from `CommittableOffset` to `Comittable` so that commit offsets can be accepted pre-aggreaget in `CommittableOffsetBatch` (which does not inherit `CommittableOffset`).