### PR TITLE
Scala 2.12.10; plugin and test library upgrades

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ jobs:
       env: CMD="++2.11.12 test"
       name: "Run tests with Scala 2.11 and AdoptOpenJDK 8"
       if: type != cron
-    - env: CMD="++2.12.9 test"
+    - env: CMD="++2.12.10 test"
       name: "Run tests with Scala 2.12 and AdoptOpenJDK 8"
     - env: CMD="++2.13.0 test"
       name: "Run tests with Scala 2.13 and AdoptOpenJDK 8"
@@ -56,7 +56,7 @@ jobs:
     - env:
       - JDK="adopt@~1.11.0-4"
       - _JAVA_OPTIONS="-XX:+UnlockExperimentalVMOptions -XX:+UseJVMCICompiler"
-      - CMD="++2.12.9 test"
+      - CMD="++2.12.10 test"
       name: "Run tests with Scala 2.12 and AdoptOpenJDK 11"
     - env:
       - JDK="adopt@~1.11.0-4"

--- a/build.sbt
+++ b/build.sbt
@@ -7,12 +7,13 @@ name := "akka-stream-kafka"
 val Nightly = sys.env.get("TRAVIS_EVENT_TYPE").contains("cron")
 
 val Scala211 = "2.11.12"
+val Scala212 = "2.12.10"
 val Scala213 = "2.13.0"
 val akkaVersion = if (Nightly) "2.6.0-M8" else "2.5.23"
 val kafkaVersion = "2.1.1"
 val kafkaVersionForDocs = "21"
 val scalatestVersion = "3.0.8"
-val testcontainersVersion = "1.11.2"
+val testcontainersVersion = "1.12.2"
 val slf4jVersion = "1.7.26"
 val confluentAvroSerializerVersion = "5.0.3"
 
@@ -66,8 +67,8 @@ val commonSettings = Def.settings(
   startYear := Some(2014),
   licenses := Seq("Apache-2.0" -> url("http://opensource.org/licenses/Apache-2.0")),
   description := "Alpakka is a Reactive Enterprise Integration library for Java and Scala, based on Reactive Streams and Akka.",
-  crossScalaVersions := Seq("2.12.9", Scala211, Scala213).filterNot(_ == Scala211 && Nightly),
-  scalaVersion := "2.12.9",
+  crossScalaVersions := Seq(Scala212, Scala211, Scala213).filterNot(_ == Scala211 && Nightly),
+  scalaVersion := Scala212,
   crossVersion := CrossVersion.binary,
   javacOptions ++= Seq(
       "-Xlint:deprecation"
@@ -98,22 +99,24 @@ val commonSettings = Def.settings(
       "-skip-packages",
       "akka.pattern" // for some reason Scaladoc creates this
     ) ++ {
-      if (scalaBinaryVersion.value == "2.13")
-        Seq(
-          "-doc-source-url", {
-            val branch = if (isSnapshot.value) "master" else s"v${version.value}"
-            s"https://github.com/akka/alpakka-kafka/tree/${branch}€{FILE_PATH_EXT}#L€{FILE_LINE}"
-          },
-          "-doc-canonical-base-url",
-          "https://doc.akka.io/api/alpakka-kafka/current/"
-        )
-      else
-        Seq(
-          "-doc-source-url", {
-            val branch = if (isSnapshot.value) "master" else s"v${version.value}"
-            s"https://github.com/akka/alpakka-kafka/tree/${branch}€{FILE_PATH}.scala#L1"
-          }
-        )
+      scalaBinaryVersion.value match {
+        case "2.12" | "2.13" =>
+          Seq(
+            "-doc-source-url", {
+              val branch = if (isSnapshot.value) "master" else s"v${version.value}"
+              s"https://github.com/akka/alpakka-kafka/tree/${branch}€{FILE_PATH_EXT}#L€{FILE_LINE}"
+            },
+            "-doc-canonical-base-url",
+            "https://doc.akka.io/api/alpakka-kafka/current/"
+          )
+        case "2.11" =>
+          Seq(
+            "-doc-source-url", {
+              val branch = if (isSnapshot.value) "master" else s"v${version.value}"
+              s"https://github.com/akka/alpakka-kafka/tree/${branch}€{FILE_PATH}.scala#L1"
+            }
+          )
+      }
     },
   Compile / doc / scalacOptions -= "-Xfatal-warnings",
   // show full stack traces and test case durations

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,13 +1,13 @@
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.4")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.4.4")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.9")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.2.0")
 addSbtPlugin("se.marcuslonnberg" % "sbt-docker" % "1.5.0")
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-dependencies" % "0.1")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-dependencies" % "0.2")
 addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.25")
 addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.1")
-addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.16")
+addSbtPlugin("com.lightbend" % "sbt-whitesource" % "0.1.17")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.0")
 addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.5")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
@@ -21,7 +21,7 @@ addSbtPlugin("com.github.ehsanyou" % "sbt-docker-compose" % "67284e73-envvars-2m
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2+10-148ba0ff")
 resolvers += Resolver.bintrayIvyRepo("2m", "sbt-plugins")
 
-addSbtPlugin("net.aichler" % "sbt-jupiter-interface" % "0.8.2")
+addSbtPlugin("net.aichler" % "sbt-jupiter-interface" % "0.8.3")
 resolvers += Resolver.jcenterRepo
 
 libraryDependencies += "com.spotify" % "docker-client" % "8.16.0"


### PR DESCRIPTION
## Purpose

* Scala 2.12.10 (was 2.12.9)
* use new scaladoc flags for 2.12
* Upgrade some sbt-plugins
	* sbt-jupiter-interface pulls up JUnit Jupiter to 5.1.1 in testkit
