### PR TITLE
Producer: change default parallelism

### DIFF
--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaProducerFixtures.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaProducerFixtures.scala
@@ -17,7 +17,7 @@ import org.apache.kafka.common.serialization.{ByteArraySerializer, StringSeriali
 
 object ReactiveKafkaProducerFixtures extends PerfFixtureHelpers {
 
-  val Parallelism = 2000000
+  val Parallelism = 10000
 
   type K = Array[Byte]
   type V = String

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -16,7 +16,8 @@ akka.kafka.producer {
   resolve-timeout = 3 seconds
 
   # Tuning parameter of how many sends that can run in parallel.
-  parallelism = 100
+  # In 2.0.0: changed the default from 100 to 10000
+  parallelism = 10000
 
   # Duration to wait for `KafkaProducer.close` to finish.
   close-timeout = 60s


### PR DESCRIPTION
Change the default parallelism from 100 to 10_000 to let the Kafka Producer
back-pressure by blocking on `send`.

See https://github.com/akka/alpakka-kafka/issues/909