### PR TITLE
Remove methods deprecated before 1.0

### DIFF
--- a/core/src/main/mima-filters/1.1.0.backwards.excludes/PR945-remove-deprecations.excludes
+++ b/core/src/main/mima-filters/1.1.0.backwards.excludes/PR945-remove-deprecations.excludes
@@ -1,0 +1,6 @@
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.Metadata.createGetCommitedOffset")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.ConsumerSettings.withWakeupTimeout")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.ConsumerSettings.withMaxWakeups")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.ConsumerSettings.withWakeupDebug")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.javadsl.Producer.commitableSink")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.scaladsl.Producer.commitableSink")

--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -214,44 +214,6 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
     val partitionHandlerWarning: FiniteDuration
 ) {
 
-  @deprecated("use the factory methods `ConsumerSettings.apply` and `create` instead", "1.0-M1")
-  def this(properties: Map[String, String],
-           keyDeserializer: Option[Deserializer[K]],
-           valueDeserializer: Option[Deserializer[V]],
-           pollInterval: FiniteDuration,
-           pollTimeout: FiniteDuration,
-           stopTimeout: FiniteDuration,
-           closeTimeout: FiniteDuration,
-           commitTimeout: FiniteDuration,
-           wakeupTimeout: FiniteDuration,
-           maxWakeups: Int,
-           commitRefreshInterval: Duration,
-           dispatcher: String,
-           commitTimeWarning: FiniteDuration,
-           wakeupDebug: Boolean,
-           waitClosePartition: FiniteDuration) = this(
-    properties,
-    keyDeserializer,
-    valueDeserializer,
-    pollInterval,
-    pollTimeout,
-    stopTimeout,
-    closeTimeout,
-    commitTimeout,
-    commitRefreshInterval,
-    dispatcher,
-    commitTimeWarning,
-    waitClosePartition,
-    positionTimeout = 5.seconds,
-    offsetForTimesTimeout = 5.seconds,
-    metadataRequestTimeout = 5.seconds,
-    drainingCheckInterval = 30.millis,
-    enrichAsync = None,
-    consumerFactory = ConsumerSettings.createKafkaConsumer[K, V],
-    connectionCheckerSettings = ConnectionCheckerSettings.Disabled,
-    partitionHandlerWarning = 15.seconds
-  )
-
   /**
    * A comma-separated list of host/port pairs to use for establishing the initial connection to the Kafka cluster.
    */
@@ -392,36 +354,11 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
     copy(commitTimeWarning = commitTimeWarning.asScala)
 
   /**
-   * Not used anymore
-   *
-   * @deprecated not used anymore, since 1.0-RC1
-   */
-  @deprecated("not used anymore", "1.0-RC1")
-  def withWakeupTimeout(wakeupTimeout: FiniteDuration): ConsumerSettings[K, V] = this
-
-  /**
-   * Java API:
-   * Not used anymore
-   *
-   * @deprecated not used anymore, since 1.0-RC1
-   */
-  @deprecated("not used anymore", "1.0-RC1")
-  def withWakeupTimeout(wakeupTimeout: java.time.Duration): ConsumerSettings[K, V] = this
-
-  /**
    * Fully qualified config path which holds the dispatcher configuration
    * to be used by the [[akka.kafka.KafkaConsumerActor]]. Some blocking may occur.
    */
   def withDispatcher(dispatcher: String): ConsumerSettings[K, V] =
     copy(dispatcher = dispatcher)
-
-  /**
-   * Not used anymore
-   *
-   * @deprecated not used anymore, since 1.0-RC1
-   */
-  @deprecated("not used anymore", "1.0-RC1")
-  def withMaxWakeups(maxWakeups: Int): ConsumerSettings[K, V] = this
 
   /**
    * If set to a finite duration, the consumer will re-send the last committed offsets periodically
@@ -443,14 +380,6 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
   def withCommitRefreshInterval(commitRefreshInterval: java.time.Duration): ConsumerSettings[K, V] =
     if (commitRefreshInterval.isZero) copy(commitRefreshInterval = Duration.Inf)
     else copy(commitRefreshInterval = commitRefreshInterval.asScala)
-
-  /**
-   * Not used anymore
-   *
-   * @deprecated not used anymore, since 1.0-RC1
-   */
-  @deprecated("not used anymore", "1.0-RC1")
-  def withWakeupDebug(wakeupDebug: Boolean): ConsumerSettings[K, V] = this
 
   /**
    * Time to wait for pending requests when a partition is closed.

--- a/core/src/main/scala/akka/kafka/Metadata.scala
+++ b/core/src/main/scala/akka/kafka/Metadata.scala
@@ -186,11 +186,4 @@ object Metadata {
    * [[org.apache.kafka.clients.consumer.KafkaConsumer#committed()]]
    */
   def createGetCommittedOffset(partition: TopicPartition): GetCommittedOffset = GetCommittedOffset(partition)
-
-  /**
-   * Java API:
-   * [[org.apache.kafka.clients.consumer.KafkaConsumer#committed()]]
-   */
-  @deprecated("Use createGetCommittedOffset(...) instead", "1.0-M1")
-  def createGetCommitedOffset(partition: TopicPartition): GetCommittedOffset = GetCommittedOffset(partition)
 }

--- a/core/src/main/scala/akka/kafka/ProducerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ProducerSettings.scala
@@ -179,28 +179,6 @@ class ProducerSettings[K, V] @InternalApi private[kafka] (
     val producerFactory: ProducerSettings[K, V] => Producer[K, V]
 ) {
 
-  @deprecated("use the factory methods `ProducerSettings.apply` and `create` instead", "1.0-M1")
-  def this(
-      properties: Map[String, String],
-      keySerializerOpt: Option[Serializer[K]],
-      valueSerializerOpt: Option[Serializer[V]],
-      closeTimeout: FiniteDuration,
-      parallelism: Int,
-      dispatcher: String,
-      eosCommitInterval: FiniteDuration
-  ) =
-    this(
-      properties,
-      keySerializerOpt,
-      valueSerializerOpt,
-      closeTimeout,
-      parallelism,
-      dispatcher,
-      eosCommitInterval,
-      enrichAsync = None,
-      ProducerSettings.createKafkaProducer
-    )
-
   /**
    * A comma-separated list of host/port pairs to use for establishing the initial connection to the Kafka cluster.
    */

--- a/core/src/main/scala/akka/kafka/javadsl/Producer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Producer.scala
@@ -108,29 +108,6 @@ object Producer {
    *
    * - [[akka.kafka.ProducerMessage.PassThroughMessage PassThroughMessage]] does not publish anything, but commits the offset
    *
-   * Note that there is a risk that something fails after publishing but before
-   * committing, so it is "at-least once delivery" semantics.
-   *
-   * @deprecated use `committableSink(ProducerSettings, CommitterSettings)` instead, since 1.0-RC1
-   */
-  @Deprecated
-  def commitableSink[K, V, IN <: Envelope[K, V, ConsumerMessage.Committable]](
-      settings: ProducerSettings[K, V]
-  ): Sink[IN, CompletionStage[Done]] = committableSink(settings)
-
-  /**
-   * Create a sink that is aware of the [[ConsumerMessage.Committable committable offset]]
-   * from a [[Consumer.committableSource]]. It will commit the consumer offset when the message has
-   * been published successfully to the topic.
-   *
-   * It publishes records to Kafka topics conditionally:
-   *
-   * - [[akka.kafka.ProducerMessage.Message Message]] publishes a single message to its topic, and commits the offset
-   *
-   * - [[akka.kafka.ProducerMessage.MultiMessage MultiMessage]] publishes all messages in its `records` field, and commits the offset
-   *
-   * - [[akka.kafka.ProducerMessage.PassThroughMessage PassThroughMessage]] does not publish anything, but commits the offset
-   *
    *
    * Note that there is always a risk that something fails after publishing but before
    * committing, so it is "at-least once delivery" semantics.
@@ -148,33 +125,6 @@ object Producer {
       .committableSink(settings, producer)
       .mapMaterializedValue(_.toJava)
       .asJava
-
-  /**
-   * Create a sink that is aware of the [[ConsumerMessage.Committable committable offset]]
-   * from a [[Consumer.committableSource]]. It will commit the consumer offset when the message has
-   * been published successfully to the topic.
-   *
-   * It publishes records to Kafka topics conditionally:
-   *
-   * - [[akka.kafka.ProducerMessage.Message Message]] publishes a single message to its topic, and commits the offset
-   *
-   * - [[akka.kafka.ProducerMessage.MultiMessage MultiMessage]] publishes all messages in its `records` field, and commits the offset
-   *
-   * - [[akka.kafka.ProducerMessage.PassThroughMessage PassThroughMessage]] does not publish anything, but commits the offset
-   *
-   *
-   * Note that there is always a risk that something fails after publishing but before
-   * committing, so it is "at-least once delivery" semantics.
-   *
-   * Supports sharing a Kafka Producer instance.
-   *
-   * @deprecated use `committableSink(ProducerSettings, CommitterSettings)` instead, since 1.0-RC1
-   */
-  @Deprecated
-  def commitableSink[K, V](
-      settings: ProducerSettings[K, V],
-      producer: org.apache.kafka.clients.producer.Producer[K, V]
-  ): Sink[Envelope[K, V, ConsumerMessage.Committable], CompletionStage[Done]] = committableSink(settings, producer)
 
   /**
    * Create a sink that is aware of the [[ConsumerMessage.Committable committable offset]]

--- a/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
@@ -101,27 +101,6 @@ object Producer {
    *
    * - [[akka.kafka.ProducerMessage.PassThroughMessage PassThroughMessage]] does not publish anything, but commits the offset
    *
-   * Note that there is a risk that something fails after publishing but before
-   * committing, so it is "at-least once delivery" semantics.
-   */
-  @deprecated("use `committableSink(ProducerSettings, CommitterSettings)` instead", "1.0-RC1")
-  def commitableSink[K, V](
-      settings: ProducerSettings[K, V]
-  ): Sink[Envelope[K, V, ConsumerMessage.Committable], Future[Done]] = committableSink(settings)
-
-  /**
-   * Create a sink that is aware of the [[ConsumerMessage.Committable committable offset]]
-   * from a [[Consumer.committableSource]]. It will commit the consumer offset when the message has
-   * been published successfully to the topic.
-   *
-   * It publishes records to Kafka topics conditionally:
-   *
-   * - [[akka.kafka.ProducerMessage.Message Message]] publishes a single message to its topic, and commits the offset
-   *
-   * - [[akka.kafka.ProducerMessage.MultiMessage MultiMessage]] publishes all messages in its `records` field, and commits the offset
-   *
-   * - [[akka.kafka.ProducerMessage.PassThroughMessage PassThroughMessage]] does not publish anything, but commits the offset
-   *
    *
    * Note that there is always a risk that something fails after publishing but before
    * committing, so it is "at-least once delivery" semantics.
@@ -136,31 +115,6 @@ object Producer {
     flexiFlow[K, V, ConsumerMessage.Committable](settings, producer)
       .mapAsync(settings.parallelism)(_.passThrough.commitScaladsl())
       .toMat(Sink.ignore)(Keep.right)
-
-  /**
-   * Create a sink that is aware of the [[ConsumerMessage.CommittableOffset committable offset]]
-   * from a [[Consumer.committableSource]]. It will commit the consumer offset when the message has
-   * been published successfully to the topic.
-   *
-   * It publishes records to Kafka topics conditionally:
-   *
-   * - [[akka.kafka.ProducerMessage.Message Message]] publishes a single message to its topic, and commits the offset
-   *
-   * - [[akka.kafka.ProducerMessage.MultiMessage MultiMessage]] publishes all messages in its `records` field, and commits the offset
-   *
-   * - [[akka.kafka.ProducerMessage.PassThroughMessage PassThroughMessage]] does not publish anything, but commits the offset
-   *
-   *
-   * Note that there is always a risk that something fails after publishing but before
-   * committing, so it is "at-least once delivery" semantics.
-   *
-   * Supports sharing a Kafka Producer instance.
-   */
-  @deprecated("use `committableSink(ProducerSettings, CommitterSettings)` instead", "1.0-RC1")
-  def commitableSink[K, V](
-      settings: ProducerSettings[K, V],
-      producer: org.apache.kafka.clients.producer.Producer[K, V]
-  ): Sink[Envelope[K, V, ConsumerMessage.Committable], Future[Done]] = committableSink(settings, producer)
 
   /**
    * Create a sink that is aware of the [[ConsumerMessage.Committable committable offset]]


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

Remove methods that were deprecated before 1.0.

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #680

## Changes

- [ ] Should the `Producer.flow` be removed? (we recommend `flexiFlow` since 0.21)
