### PR TITLE
Rebalance: filter messages of revoked partitions

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -9,7 +9,7 @@ import akka.actor.{ActorRef, ExtendedActorSystem, Terminated}
 import akka.annotation.InternalApi
 import akka.kafka.Subscriptions._
 import akka.kafka.scaladsl.PartitionAssignmentHandler
-import akka.kafka._
+import akka.kafka.{AutoSubscription, ConsumerSettings, ManualSubscription, RestrictedConsumer, Subscription}
 import akka.stream.{ActorMaterializerHelper, SourceShape}
 import org.apache.kafka.common.TopicPartition
 

--- a/tests/src/test/scala/akka/kafka/scaladsl/RebalanceSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/RebalanceSpec.scala
@@ -29,7 +29,8 @@ class RebalanceSpec extends SpecBase with TestcontainersKafkaLike with Inside {
   "Fetched records" must {
 
     // The `max.poll.records` controls how many records Kafka fetches internally during a poll.
-    // documented in https://github.com/akka/alpakka-kafka/pull/865
+    // issue explained in https://github.com/akka/alpakka-kafka/issues/872
+    // this test added with https://github.com/akka/alpakka-kafka/pull/865
     "actually show even if partition is revoked" in assertAllStagesStopped {
       val count = 20L
       // de-coupling consecutive test runs with crossScalaVersions on Travis
@@ -37,8 +38,7 @@ class RebalanceSpec extends SpecBase with TestcontainersKafkaLike with Inside {
       val topic1 = createTopic(topicSuffix, partitions = 2)
       val group1 = createGroupId(1)
       val consumerSettings = consumerDefaults
-      // This test FAILS with the default value as messages are enqueue in the stage
-        .withProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "1")
+        .withProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "500") // 500 is the default value
         .withGroupId(group1)
 
       awaitProduce(produce(topic1, 0 to count.toInt, partition1))


### PR DESCRIPTION
## Purpose

This adds another `PartitionAssignmentHandler` which will add filtering in the stage so that messages of partitions that were revoked are not issued anymore.

## References

Issue #872 
Test in #865 

## Changes

* Add `filterRevokedPartitions` in `BaseSingleSourceLogic` to filter the internal buffer from subclasses
* A new partition assignment handler adds filtering from `onAssigned`

## Background Context

As the `RebalanceSpec` test in https://github.com/akka/alpakka-kafka/pull/865 shows, the consumer stage's buffer continues to emit messages of revoked partitions that will be re-emitted by a different consumer.
