### PR TITLE
Consumer: make partition assignment handler public API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -271,8 +271,8 @@ lazy val tests = project
         "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.0" % Test, // ApacheV2
         "org.junit.vintage" % "junit-vintage-engine" % JupiterKeys.junitVintageVersion.value % Test,
         // See http://hamcrest.org/JavaHamcrest/distributables#upgrading-from-hamcrest-1x
-        "org.hamcrest" % "hamcrest-library" % "2.1" % Test,
-        "org.hamcrest" % "hamcrest" % "2.1" % Test,
+        "org.hamcrest" % "hamcrest-library" % "2.2" % Test,
+        "org.hamcrest" % "hamcrest" % "2.2" % Test,
         "net.aichler" % "jupiter-interface" % JupiterKeys.jupiterVersion.value % Test,
         "com.typesafe.akka" %% "akka-slf4j" % akkaVersion % Test,
         "ch.qos.logback" % "logback-classic" % "1.2.3" % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -374,6 +374,7 @@ lazy val docs = project
         "scaladoc.com.typesafe.config.base_url" -> s"https://lightbend.github.io/config/latest/api/",
         "javadoc.org.apache.kafka.base_url" -> s"https://kafka.apache.org/$kafkaVersionForDocs/javadoc/"
       ),
+    apidocRootPackage := "akka",
     paradoxRoots := List("index.html",
                          "release-notes/1.0-M1.html",
                          "release-notes/1.0-RC1.html",

--- a/core/src/main/mima-filters/1.1.0.backwards.excludes/PR949-partition-assignment-handler.excludes
+++ b/core/src/main/mima-filters/1.1.0.backwards.excludes/PR949-partition-assignment-handler.excludes
@@ -1,0 +1,8 @@
+# Internal API
+ProblemFilters.exclude[Problem]("akka.kafka.Subscriptions#TopicSubscription.*")
+ProblemFilters.exclude[Problem]("akka.kafka.Subscriptions#TopicSubscriptionPattern.*")
+ProblemFilters.exclude[MissingTypesProblem]("akka.kafka.Subscriptions$TopicSubscription$")
+ProblemFilters.exclude[MissingTypesProblem]("akka.kafka.Subscriptions$TopicSubscriptionPattern$")
+# Sealed trait
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.kafka.AutoSubscription.partitionAssignmentHandler")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.kafka.AutoSubscription.withPartitionAssignmentHandler")

--- a/core/src/main/scala/akka/kafka/RestrictedConsumer.scala
+++ b/core/src/main/scala/akka/kafka/RestrictedConsumer.scala
@@ -53,4 +53,14 @@ final class RestrictedConsumer(consumer: Consumer[_, _], duration: java.time.Dur
    * See [[org.apache.kafka.clients.consumer.KafkaConsumer#seek(TopicPartition, Long)]]
    */
   def seek(tp: TopicPartition, offset: Long): Unit = consumer.seek(tp, offset)
+
+  /**
+   * See [[org.apache.kafka.clients.consumer.KafkaConsumer#seekToBeginning(java.util.Collection[TopicPartition])]]
+   */
+  def seekToBeginning(tps: java.util.Collection[TopicPartition]): Unit = consumer.seekToBeginning(tps)
+
+  /**
+   * See [[org.apache.kafka.clients.consumer.KafkaConsumer#seekToEnd(java.util.Collection[TopicPartition])]]
+   */
+  def seekToEnd(tps: java.util.Collection[TopicPartition]): Unit = consumer.seekToEnd(tps)
 }

--- a/core/src/main/scala/akka/kafka/RestrictedConsumer.scala
+++ b/core/src/main/scala/akka/kafka/RestrictedConsumer.scala
@@ -6,7 +6,7 @@
 package akka.kafka
 
 import akka.annotation.ApiMayChange
-import org.apache.kafka.clients.consumer.{Consumer, OffsetAndMetadata}
+import org.apache.kafka.clients.consumer.{Consumer, OffsetAndMetadata, OffsetAndTimestamp}
 import org.apache.kafka.common.TopicPartition
 
 /**
@@ -28,21 +28,29 @@ final class RestrictedConsumer(consumer: Consumer[_, _], duration: java.time.Dur
     consumer.beginningOffsets(tps, duration)
 
   /**
-   * See [[org.apache.kafka.clients.consumer.KafkaConsumer#commitSync(Map, java.time.Duration)]]
+   * See [[org.apache.kafka.clients.consumer.KafkaConsumer#commitSync(Map,java.time.Duration)]]
    */
   def commitSync(offsets: java.util.Map[TopicPartition, OffsetAndMetadata]): Unit =
     consumer.commitSync(offsets, duration)
 
   /**
-   * See [[org.apache.kafka.clients.consumer.KafkaConsumer#committed(TopicPartition, Duration)]]
+   * See [[org.apache.kafka.clients.consumer.KafkaConsumer#committed(TopicPartition,java.time.Duration)]]
    */
   def committed(tp: TopicPartition): OffsetAndMetadata = consumer.committed(tp, duration)
 
   /**
-   * See [[org.apache.kafka.clients.consumer.KafkaConsumer#endOffsets(java.util.Collection[TopicPartition], java.time.Duration)]]
+   * See [[org.apache.kafka.clients.consumer.KafkaConsumer#endOffsets(java.util.Collection[TopicPartition],java.time.Duration)]]
    */
   def endOffsets(tps: java.util.Collection[TopicPartition]): java.util.Map[TopicPartition, java.lang.Long] =
     consumer.endOffsets(tps, duration)
+
+  /**
+   * See [[org.apache.kafka.clients.consumer.KafkaConsumer#offsetsForTimes(java.util.Map[TopicPartition,Long],java.time.Duration)]]
+   */
+  def offsetsForTimes(
+      timestampsToSearch: java.util.Map[TopicPartition, java.lang.Long]
+  ): java.util.Map[TopicPartition, OffsetAndTimestamp] =
+    consumer.offsetsForTimes(timestampsToSearch, duration)
 
   /**
    * See [[org.apache.kafka.clients.consumer.KafkaConsumer#position(TopicPartition, java.time.Duration)]]

--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -39,11 +39,14 @@ import scala.concurrent.{Future, Promise}
 
       val revokedCB = getAsyncCallback[Set[TopicPartition]](partitionRevokedHandler)
 
-      new PartitionAssignmentHelpers.AsyncCallbacks(autoSubscription, sourceActor.ref, assignedCB, revokedCB)
+      PartitionAssignmentHelpers.chain(
+        new PartitionAssignmentHelpers.AsyncCallbacks(autoSubscription, sourceActor.ref, assignedCB, revokedCB),
+        autoSubscription.partitionAssignmentHandler
+      )
     }
 
     subscription match {
-      case sub @ TopicSubscription(topics, _) =>
+      case sub @ TopicSubscription(topics, _, _) =>
         consumerActor.tell(
           KafkaConsumerActor.Internal.Subscribe(
             topics,
@@ -51,7 +54,7 @@ import scala.concurrent.{Future, Promise}
           ),
           sourceActor.ref
         )
-      case sub @ TopicSubscriptionPattern(topics, _) =>
+      case sub @ TopicSubscriptionPattern(topics, _, _) =>
         consumerActor.tell(
           KafkaConsumerActor.Internal.SubscribePattern(
             topics,

--- a/core/src/main/scala/akka/kafka/javadsl/PartitionAssignmentHandler.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/PartitionAssignmentHandler.scala
@@ -12,15 +12,15 @@ import org.apache.kafka.common.TopicPartition
 /**
  * The API is new and may change in further releases.
  *
- * Allows to execute user code when Kafka rebalances partitions between consumers, or an Alpakka Kafka consumer is stopped.
+ * Allows the user to execute user code when Kafka rebalances partitions between consumers, or an Alpakka Kafka consumer is stopped.
  * Use with care: These callbacks are called synchronously on the same thread Kafka's `poll()` is called.
  * A warning will be logged if a callback takes longer than the configured `partition-handler-warning`.
  *
- * There is no point in calling `CommittableOffset`'s commit methods as their committing won't be executed as long as any of
- * the callbacks in this class are called.
+ * There is no point in calling `Committable`'s commit methods as their committing won't be executed as long as any of
+ * the callbacks in this class are called. Calling `commitSync` on the passed [[akka.kafka.RestrictedConsumer]] is available.
  *
  * This complements the methods of Kafka's [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener ConsumerRebalanceListener]] with
- * an `onStop` callback.
+ * an `onStop` callback which is called before `Consumer.close`.
  */
 @ApiMayChange
 trait PartitionAssignmentHandler {
@@ -29,7 +29,7 @@ trait PartitionAssignmentHandler {
    * See [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener#onPartitionsRevoked]]
    *
    * @param revokedTps The list of partitions that were revoked from the consumer
-   * @param consumer A restricted version of the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
+   * @param consumer The [[akka.kafka.RestrictedConsumer]] gives some access to the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
    */
   def onRevoke(revokedTps: java.util.Set[TopicPartition], consumer: RestrictedConsumer): Unit
 
@@ -37,7 +37,7 @@ trait PartitionAssignmentHandler {
    * See [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener#onPartitionsAssigned]]
    *
    * @param assignedTps The list of partitions that are now assigned to the consumer (may include partitions previously assigned to the consumer)
-   * @param consumer A restricted version of the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
+   * @param consumer The [[akka.kafka.RestrictedConsumer]] gives some access to the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
    */
   def onAssign(assignedTps: java.util.Set[TopicPartition], consumer: RestrictedConsumer): Unit
 
@@ -46,7 +46,7 @@ trait PartitionAssignmentHandler {
    * See [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener#onPartitionsRevoked]]
    *
    * @param currentTps The list of partitions that are currently assigned to the consumer
-   * @param consumer A restricted version of the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
+   * @param consumer The [[akka.kafka.RestrictedConsumer]] gives some access to the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
    */
   def onStop(currentTps: java.util.Set[TopicPartition], consumer: RestrictedConsumer): Unit
 

--- a/core/src/main/scala/akka/kafka/javadsl/PartitionAssignmentHandler.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/PartitionAssignmentHandler.scala
@@ -3,10 +3,10 @@
  * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
  */
 
-package akka.kafka.scaladsl
+package akka.kafka.javadsl
 
-import akka.annotation.ApiMayChange
 import akka.kafka.RestrictedConsumer
+import akka.annotation.ApiMayChange
 import org.apache.kafka.common.TopicPartition
 
 /**
@@ -20,7 +20,7 @@ import org.apache.kafka.common.TopicPartition
  * the callbacks in this class are called.
  *
  * This complements the methods of Kafka's [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener ConsumerRebalanceListener]] with
- * an `onStop` callback which is called before `Consumer.close`.
+ * an `onStop` callback.
  */
 @ApiMayChange
 trait PartitionAssignmentHandler {
@@ -31,7 +31,7 @@ trait PartitionAssignmentHandler {
    * @param revokedTps The list of partitions that were revoked from the consumer
    * @param consumer A restricted version of the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
    */
-  def onRevoke(revokedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit
+  def onRevoke(revokedTps: java.util.Set[TopicPartition], consumer: RestrictedConsumer): Unit
 
   /**
    * See [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener#onPartitionsAssigned]]
@@ -39,7 +39,7 @@ trait PartitionAssignmentHandler {
    * @param assignedTps The list of partitions that are now assigned to the consumer (may include partitions previously assigned to the consumer)
    * @param consumer A restricted version of the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
    */
-  def onAssign(assignedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit
+  def onAssign(assignedTps: java.util.Set[TopicPartition], consumer: RestrictedConsumer): Unit
 
   /**
    * Called before a consumer is closed.
@@ -48,5 +48,6 @@ trait PartitionAssignmentHandler {
    * @param currentTps The list of partitions that are currently assigned to the consumer
    * @param consumer A restricted version of the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
    */
-  def onStop(currentTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit
+  def onStop(currentTps: java.util.Set[TopicPartition], consumer: RestrictedConsumer): Unit
+
 }

--- a/core/src/main/scala/akka/kafka/scaladsl/PartitionAssignmentHandler.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/PartitionAssignmentHandler.scala
@@ -12,12 +12,12 @@ import org.apache.kafka.common.TopicPartition
 /**
  * The API is new and may change in further releases.
  *
- * Allows to execute user code when Kafka rebalances partitions between consumers, or an Alpakka Kafka consumer is stopped.
+ * Allows the user to execute user code when Kafka rebalances partitions between consumers, or an Alpakka Kafka consumer is stopped.
  * Use with care: These callbacks are called synchronously on the same thread Kafka's `poll()` is called.
  * A warning will be logged if a callback takes longer than the configured `partition-handler-warning`.
  *
- * There is no point in calling `CommittableOffset`'s commit methods as their committing won't be executed as long as any of
- * the callbacks in this class are called.
+ * There is no point in calling `Committable`'s commit methods as their committing won't be executed as long as any of
+ * the callbacks in this class are called. Calling `commitSync` on the passed [[akka.kafka.RestrictedConsumer]] is available.
  *
  * This complements the methods of Kafka's [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener ConsumerRebalanceListener]] with
  * an `onStop` callback which is called before `Consumer.close`.
@@ -29,7 +29,7 @@ trait PartitionAssignmentHandler {
    * See [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener#onPartitionsRevoked]]
    *
    * @param revokedTps The list of partitions that were revoked from the consumer
-   * @param consumer A restricted version of the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
+   * @param consumer The [[akka.kafka.RestrictedConsumer]] gives some access to the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
    */
   def onRevoke(revokedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit
 
@@ -37,7 +37,7 @@ trait PartitionAssignmentHandler {
    * See [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener#onPartitionsAssigned]]
    *
    * @param assignedTps The list of partitions that are now assigned to the consumer (may include partitions previously assigned to the consumer)
-   * @param consumer A restricted version of the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
+   * @param consumer The [[akka.kafka.RestrictedConsumer]] gives some access to the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
    */
   def onAssign(assignedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit
 
@@ -46,7 +46,7 @@ trait PartitionAssignmentHandler {
    * See [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener#onPartitionsRevoked]]
    *
    * @param currentTps The list of partitions that are currently assigned to the consumer
-   * @param consumer A restricted version of the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
+   * @param consumer The [[akka.kafka.RestrictedConsumer]] gives some access to the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
    */
   def onStop(currentTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit
 }

--- a/docs/src/main/paradox/consumer-rebalance.md
+++ b/docs/src/main/paradox/consumer-rebalance.md
@@ -1,7 +1,14 @@
 ---
 project.description: React on Kafka rebalancing the partitions assigned to an Alpakka Kafka consumer.
 ---
-# React on Partition Assigment 
+# React on Partition Assignment
+
+Alpakka Kafka allows to react to the Kafka broker's balancing of partitions within a consumer group in two ways:
+
+1. callbacks to the `PartitionAssignmentHandler`
+1. messages to a @ref[rebalance listener actor](#listening-for-rebalance-events)
+
+## Partition Assignment Handler
 
 Kafka balances partitions between all consumers within a consumer group. When new consumers join or leave the group partitions are revoked from and assigned to those consumers.
 
@@ -30,3 +37,18 @@ Scala
 
 Java
 : @@snip [snip](/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java) { #partitionAssignmentHandler }
+
+
+## Listening for rebalance events
+
+You may set up an rebalance event listener actor that will be notified when your consumer will be assigned or revoked 
+from consuming from specific topic partitions. Two kinds of messages will be sent to this listener actor 
+
+* `akka.kafka.TopicPartitionsAssigned` and
+* `akka.kafka.TopicPartitionsRevoked`, like this:
+
+Scala
+: @@ snip [snip](/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala) { #withRebalanceListenerActor }
+
+Java
+: @@ snip [snip](/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java) { #withRebalanceListenerActor }

--- a/docs/src/main/paradox/consumer-rebalance.md
+++ b/docs/src/main/paradox/consumer-rebalance.md
@@ -1,0 +1,32 @@
+---
+project.description: React on Kafka rebalancing the partitions assigned to an Alpakka Kafka consumer.
+---
+# React on Partition Assigment 
+
+Kafka balances partitions between all consumers within a consumer group. When new consumers join or leave the group partitions are revoked from and assigned to those consumers.
+
+Alpakka Kafka's @apidoc[PartitionAssignmentHandler] expects three callbacks to be implemented, all are called with a set of @javadoc[TopicPartition](org.apache.kafka.common.TopicPartition)s and a reference to the @apidoc[RestrictedConsumer] which allows some access to the Kafka @javadoc[Consumer](org.apache.kafka.clients.consumer.Consumer) instance used internally by Alpakka Kafka.
+
+1. `onRevoke` is called when the Kafka broker revokes partitions from this consumer
+1. `onAssign` is called when the Kafka broker assigns partitions to this consumer
+1. `onStop` is called when the Alpakka Kafka consumer source is about to stop
+
+Rebalancing starts with revoking partitions from all consumers in a consumer group and assigning all partitions to consumers in a second phase. During rebalance no consumer within that consumer group receives any messages.
+
+The @apidoc[PartitionAssignmentHandler] is Alpakka Kafka's replacement of the Kafka client library's @javadoc[ConsumerRebalanceListener](org.apache.kafka.clients.consumer.ConsumerRebalanceListener).
+
+@@@ warning
+
+All methods on the @apidoc[PartitionAssignmentHandler] are called synchronously during Kafka's poll and rebalance logic. They block any other activity for that consumer.
+
+If any of these methods take longer than the timeout configured in `akka.kafka.consumer.partition-handler-warning` (default 5 seconds) a warning will be logged.
+
+@@@
+
+This example shows an implementation of the `PartitionAssignmentHandler` and how it is passed to the consumer via the `Subscription`.
+
+Scala
+: @@snip [snip](/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala) { #partitionAssignmentHandler }
+
+Java
+: @@snip [snip](/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java) { #partitionAssignmentHandler }

--- a/docs/src/main/paradox/consumer.md
+++ b/docs/src/main/paradox/consumer.md
@@ -349,6 +349,7 @@ Java
 @@@ index
 
 * [subscription](subscription.md)
+* [rebalance](consumer-rebalance.md)
 * [metadata](consumer-metadata.md)
 
 @@@

--- a/docs/src/main/paradox/consumer.md
+++ b/docs/src/main/paradox/consumer.md
@@ -298,21 +298,6 @@ Java
 Accessing of Kafka consumer metadata is possible as described in @ref[Consumer Metadata](consumer-metadata.md).
 
 
-## Listening for rebalance events
-
-You may set up an rebalance event listener actor that will be notified when your consumer will be assigned or revoked 
-from consuming from specific topic partitions. Two kinds of messages will be sent to this listener actor 
-
-* `akka.kafka.TopicPartitionsAssigned` and 
-* `akka.kafka.TopicPartitionsRevoked`, like this:
-
-Scala
-: @@ snip [snip](/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala) { #withRebalanceListenerActor }
-
-Java
-: @@ snip [snip](/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java) { #withRebalanceListenerActor }
-
-
 ## Controlled shutdown
 The `Source` created with `Consumer.plainSource` and similar  methods materializes to a `Consumer.Control` (@scala[@scaladoc[API](akka.kafka.scaladsl.Consumer$$Control)]@java[@scaladoc[API](akka.kafka.javadsl.Consumer$$Control)]) 
 instance. This can be used to stop the stream in a controlled manner.

--- a/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java
@@ -31,7 +31,6 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.hamcrest.CoreMatchers;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -497,21 +496,31 @@ class ConsumerExampleTest extends TestcontainersKafkaTest {
     AtomicReference<Set<TopicPartition>> assigned = new AtomicReference<>();
     AtomicReference<Set<TopicPartition>> stopped = new AtomicReference<>();
 
-    PartitionAssignmentHandler handler =
+    // #partitionAssignmentHandler
+    PartitionAssignmentHandler assignmentHandler =
         new PartitionAssignmentHandler() {
           public void onRevoke(Set<TopicPartition> revokedTps, RestrictedConsumer consumer) {
+            // #partitionAssignmentHandler
             revoked.set(revokedTps);
+            // #partitionAssignmentHandler
           }
 
           public void onAssign(Set<TopicPartition> assignedTps, RestrictedConsumer consumer) {
+            // #partitionAssignmentHandler
             assigned.set(assignedTps);
+            // #partitionAssignmentHandler
           }
 
           public void onStop(Set<TopicPartition> currentTps, RestrictedConsumer consumer) {
+            // #partitionAssignmentHandler
             stopped.set(currentTps);
+            // #partitionAssignmentHandler
           }
         };
-    Subscription subscription = Subscriptions.topics(topic).withPartitionAssignmentHandler(handler);
+
+    Subscription subscription =
+        Subscriptions.topics(topic).withPartitionAssignmentHandler(assignmentHandler);
+    // #partitionAssignmentHandler
 
     Consumer.DrainingControl<List<ConsumerRecord<String, String>>> control =
         Consumer.plainSource(consumerSettings, subscription)

--- a/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
@@ -401,20 +401,29 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
     val revokedPromise = Promise[Set[TopicPartition]]
     val stopPromise = Promise[Set[TopicPartition]]
 
-    val handler = new PartitionAssignmentHandler {
-      override def onRevoke(revokedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit =
+    // #partitionAssignmentHandler
+    val assignmentHandler = new PartitionAssignmentHandler {
+      override def onRevoke(revokedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = // ???
+        // #partitionAssignmentHandler
         revokedPromise.success(revokedTps)
 
-      override def onAssign(assignedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit =
+      // #partitionAssignmentHandler
+      override def onAssign(assignedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = // ???
+        // #partitionAssignmentHandler
         assignedPromise.success(assignedTps)
 
-      override def onStop(currentTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit =
+      // #partitionAssignmentHandler
+      override def onStop(currentTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = // ???
+        // #partitionAssignmentHandler
         stopPromise.success(currentTps)
+      // #partitionAssignmentHandler
     }
 
     val subscription = Subscriptions
       .topics(topic)
-      .withPartitionAssignmentHandler(handler)
+      .withPartitionAssignmentHandler(assignmentHandler)
+
+    // #partitionAssignmentHandler
 
     val (control, result) =
       Consumer


### PR DESCRIPTION
## Purpose

Allow users to pass a `PartitionAssignmentHandler` which allows for hooking into Kafka rebalances.

Potential use cases may include
* direct control over committing via the Kafka consumer API
* store offsets to an external storage
* seek offsets on assignment in a different way (see #911)

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
Fixes #539, #843, #911
#761

## Changes

* Let subscriptions pass a `PartitionAssignmentHandler`
* Add `javadsl.PartitionAssignmentHandler`
* Add `seekToBeginning` and `seekToEnd` (usful for #911)
* Test cases in Scala an Java
* Upgrade Hamcrest 2.1 to 2.2

## TODO

- [ ] Documentation