### PR TITLE
Pass ProducerSettings to stage

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -22,6 +22,10 @@ akka.kafka.producer {
   # Duration to wait for `KafkaProducer.close` to finish.
   close-timeout = 60s
 
+  # Call `KafkaProducer.close` when the stream is shutdown. This is important to override to false
+  # when the producer instance is shared across multiple producer stages.
+  close-on-producer-stop = true
+
   # Fully qualified config path which holds the dispatcher configuration
   # to be used by the producer stages. Some blocking may occur.
   # When this value is empty, the dispatcher configured for the stream

--- a/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
@@ -9,11 +9,10 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import akka.annotation.InternalApi
 import akka.kafka.ProducerMessage._
+import akka.kafka.ProducerSettings
 import akka.stream._
-import org.apache.kafka.clients.producer.Producer
 
-import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration._
+import scala.concurrent.Future
 
 /**
  * INTERNAL API
@@ -22,9 +21,7 @@ import scala.concurrent.duration._
  */
 @InternalApi
 private[internal] trait ProducerStage[K, V, P, IN <: Envelope[K, V, P], OUT <: Results[K, V, P]] {
-  val closeTimeout: FiniteDuration
-  val closeProducerOnStop: Boolean
-  val producerProvider: ExecutionContext => Future[Producer[K, V]]
+  val settings: ProducerSettings[K, V]
 
   val in: Inlet[IN] = Inlet[IN]("messages")
   val out: Outlet[Future[OUT]] = Outlet[Future[OUT]]("result")

--- a/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
@@ -4,20 +4,20 @@
  */
 
 package akka.kafka.internal
+
 import akka.Done
 import akka.annotation.InternalApi
-import akka.kafka.ConsumerMessage
 import akka.kafka.ConsumerMessage.{GroupTopicPartition, PartitionOffsetCommittedMarker}
 import akka.kafka.ProducerMessage.{Envelope, Results}
 import akka.kafka.internal.ProducerStage.{MessageCallback, ProducerCompletionState}
-import akka.stream.{Attributes, FlowShape}
+import akka.kafka.{ConsumerMessage, ProducerSettings}
 import akka.stream.stage._
+import akka.stream.{Attributes, FlowShape}
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.clients.producer.Producer
 import org.apache.kafka.common.TopicPartition
 
-import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
@@ -26,15 +26,12 @@ import scala.jdk.CollectionConverters._
  */
 @InternalApi
 private[kafka] final class TransactionalProducerStage[K, V, P](
-    val closeTimeout: FiniteDuration,
-    val closeProducerOnStop: Boolean,
-    val producerProvider: ExecutionContext => Future[Producer[K, V]],
-    commitInterval: FiniteDuration
+    val settings: ProducerSettings[K, V]
 ) extends GraphStage[FlowShape[Envelope[K, V, P], Future[Results[K, V, P]]]]
     with ProducerStage[K, V, P, Envelope[K, V, P], Results[K, V, P]] {
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
-    new TransactionalProducerStageLogic(this, producerProvider, inheritedAttributes, commitInterval)
+    new TransactionalProducerStageLogic(this, inheritedAttributes)
 }
 
 /** Internal API */
@@ -100,12 +97,8 @@ private object TransactionalProducerStage {
  */
 private final class TransactionalProducerStageLogic[K, V, P](
     stage: TransactionalProducerStage[K, V, P],
-    producerFactory: ExecutionContext => Future[Producer[K, V]],
-    inheritedAttributes: Attributes,
-    commitInterval: FiniteDuration
-) extends DefaultProducerStageLogic[K, V, P, Envelope[K, V, P], Results[K, V, P]](stage,
-                                                                                    producerFactory,
-                                                                                    inheritedAttributes)
+    inheritedAttributes: Attributes
+) extends DefaultProducerStageLogic[K, V, P, Envelope[K, V, P], Results[K, V, P]](stage, inheritedAttributes)
     with StageLogging
     with MessageCallback[K, V, P]
     with ProducerCompletionState {
@@ -128,7 +121,7 @@ private final class TransactionalProducerStageLogic[K, V, P](
     initTransactions()
     beginTransaction()
     resumeDemand()
-    scheduleOnce(commitSchedulerKey, commitInterval)
+    scheduleOnce(commitSchedulerKey, stage.settings.eosCommitInterval)
   }
 
   // suspend demand until a Producer has been created
@@ -158,7 +151,7 @@ private final class TransactionalProducerStageLogic[K, V, P](
         suspendDemand()
         scheduleOnce(commitSchedulerKey, messageDrainInterval)
       case _ =>
-        scheduleOnce(commitSchedulerKey, commitInterval)
+        scheduleOnce(commitSchedulerKey, stage.settings.eosCommitInterval)
     }
   }
 
@@ -201,7 +194,7 @@ private final class TransactionalProducerStageLogic[K, V, P](
 
   val onInternalCommitAckCb: AsyncCallback[Unit] = {
     getAsyncCallback[Unit](
-      _ => scheduleOnce(commitSchedulerKey, commitInterval)
+      _ => scheduleOnce(commitSchedulerKey, stage.settings.eosCommitInterval)
     )
   }
 

--- a/core/src/main/scala/akka/kafka/javadsl/Committer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Committer.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.CompletionStage
 import akka.annotation.ApiMayChange
 import akka.japi.Pair
 import akka.{Done, NotUsed}
-import akka.kafka.ConsumerMessage.{Committable, CommittableOffset, CommittableOffsetBatch}
+import akka.kafka.ConsumerMessage.{Committable, CommittableOffsetBatch}
 import akka.kafka.{scaladsl, CommitterSettings}
 import akka.stream.javadsl.{Flow, FlowWithContext, Sink}
 

--- a/core/src/main/scala/akka/kafka/javadsl/Producer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Producer.scala
@@ -41,30 +41,16 @@ object Producer {
    * partition number, and an optional key and value.
    *
    * Supports sharing a Kafka Producer instance.
+   *
+   * @deprecated Pass in external or shared producer using `ProducerSettings.withProducerFactory` or `ProducerSettings.withProducer`, since 1.1.1
    */
+  @Deprecated
   def plainSink[K, V](
       settings: ProducerSettings[K, V],
       producer: org.apache.kafka.clients.producer.Producer[K, V]
   ): Sink[ProducerRecord[K, V], CompletionStage[Done]] =
     scaladsl.Producer
       .plainSink(settings, producer)
-      .mapMaterializedValue(_.toJava)
-      .asJava
-
-  /**
-   * Create a sink for publishing records to Kafka topics.
-   *
-   * The [[org.apache.kafka.clients.producer.ProducerRecord Kafka ProducerRecord]] contains the topic name to which the record is being sent, an optional
-   * partition number, and an optional key and value.
-   *
-   * Supports sharing a Kafka Producer instance provided by a `CompletionStage`
-   */
-  def plainSink[K, V](
-      settings: ProducerSettings[K, V],
-      producer: CompletionStage[org.apache.kafka.clients.producer.Producer[K, V]]
-  ): Sink[ProducerRecord[K, V], CompletionStage[Done]] =
-    scaladsl.Producer
-      .plainSink(settings, producer.toScala)
       .mapMaterializedValue(_.toJava)
       .asJava
 
@@ -166,7 +152,10 @@ object Producer {
    * committing, so it is "at-least once delivery" semantics.
    *
    * Uses a shared a Kafka Producer instance.
+   *
+   * @deprecated Pass in external or shared producer using `ProducerSettings.withProducerFactory` or `ProducerSettings.withProducer`, since 1.1.1
    */
+  @Deprecated
   def committableSink[K, V, IN <: Envelope[K, V, ConsumerMessage.Committable]](
       producerSettings: ProducerSettings[K, V],
       committerSettings: CommitterSettings,
@@ -222,7 +211,10 @@ object Producer {
    * committing, so it is "at-least once delivery" semantics.
    *
    * Uses a shared a Kafka Producer instance.
+   *
+   * @deprecated Pass in external or shared producer using `ProducerSettings.withProducerFactory` or `ProducerSettings.withProducer`, since 1.1.1
    */
+  @Deprecated
   @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/880")
   def committableSinkWithOffsetContext[K, V, IN <: Envelope[K, V, _], C <: Committable](
       producerSettings: ProducerSettings[K, V],
@@ -341,39 +333,16 @@ object Producer {
    * be committed later in the flow.
    *
    * Supports sharing a Kafka Producer instance.
+   *
+   * @deprecated Pass in external or shared producer using `ProducerSettings.withProducerFactory` or `ProducerSettings.withProducer`, since 1.1.1
    */
+  @Deprecated
   def flexiFlow[K, V, PassThrough](
       settings: ProducerSettings[K, V],
       producer: org.apache.kafka.clients.producer.Producer[K, V]
   ): Flow[Envelope[K, V, PassThrough], Results[K, V, PassThrough], NotUsed] =
     scaladsl.Producer
       .flexiFlow(settings, producer)
-      .asJava
-      .asInstanceOf[Flow[Envelope[K, V, PassThrough], Results[K, V, PassThrough], NotUsed]]
-
-  /**
-   * Create a flow to conditionally publish records to Kafka topics and then pass it on.
-   *
-   * It publishes records to Kafka topics conditionally:
-   *
-   * - [[akka.kafka.ProducerMessage.Message Message]] publishes a single message to its topic, and continues in the stream as [[akka.kafka.ProducerMessage.Result Result]]
-   *
-   * - [[akka.kafka.ProducerMessage.MultiMessage MultiMessage]] publishes all messages in its `records` field, and continues in the stream as [[akka.kafka.ProducerMessage.MultiResult MultiResult]]
-   *
-   * - [[akka.kafka.ProducerMessage.PassThroughMessage PassThroughMessage]] does not publish anything, and continues in the stream as [[akka.kafka.ProducerMessage.PassThroughResult PassThroughResult]]
-   *
-   * The messages support the possibility to pass through arbitrary data, which can for example be a [[ConsumerMessage.CommittableOffset CommittableOffset]]
-   * or [[ConsumerMessage.CommittableOffsetBatch CommittableOffsetBatch]] that can
-   * be committed later in the flow.
-   *
-   * Supports sharing a Kafka Producer instance provided by a `CompletionStage`.
-   */
-  def flexiFlow[K, V, PassThrough](
-      settings: ProducerSettings[K, V],
-      producer: CompletionStage[org.apache.kafka.clients.producer.Producer[K, V]]
-  ): Flow[Envelope[K, V, PassThrough], Results[K, V, PassThrough], NotUsed] =
-    scaladsl.Producer
-      .flexiFlow(settings, producer.toScala)
       .asJava
       .asInstanceOf[Flow[Envelope[K, V, PassThrough], Results[K, V, PassThrough], NotUsed]]
 
@@ -395,7 +364,10 @@ object Producer {
    * Supports sharing a Kafka Producer instance.
    *
    * @tparam C the flow context type
+   *
+   * @deprecated Pass in external or shared producer using `ProducerSettings.withProducerFactory` or `ProducerSettings.withProducer`, since 1.1.1
    */
+  @Deprecated
   @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/880")
   def flowWithContext[K, V, C](
       settings: ProducerSettings[K, V],

--- a/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
@@ -9,7 +9,7 @@ import akka.dispatch.ExecutionContexts
 import akka.annotation.ApiMayChange
 import akka.{Done, NotUsed}
 import akka.kafka.CommitterSettings
-import akka.kafka.ConsumerMessage.{Committable, CommittableOffset, CommittableOffsetBatch}
+import akka.kafka.ConsumerMessage.{Committable, CommittableOffsetBatch}
 import akka.stream.scaladsl.{Flow, FlowWithContext, Keep, Sink}
 
 import scala.concurrent.Future

--- a/core/src/main/scala/akka/kafka/scaladsl/Transactional.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Transactional.scala
@@ -17,7 +17,7 @@ import akka.{Done, NotUsed}
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.producer.ProducerConfig
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 /**
  * Akka Stream connector to support transactions between Kafka topics.
@@ -86,6 +86,7 @@ object Transactional {
       transactionalId: String
   ): Flow[Envelope[K, V, ConsumerMessage.PartitionOffset], Results[K, V, ConsumerMessage.PartitionOffset], NotUsed] = {
     require(transactionalId != null && transactionalId.length > 0, "You must define a Transactional id.")
+    require(settings.producerFactorySync.isEmpty, "You cannot use a shared or external producer factory.")
 
     val txSettings = settings.withProperties(
       ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG -> true.toString,
@@ -95,12 +96,7 @@ object Transactional {
 
     val flow = Flow
       .fromGraph(
-        new TransactionalProducerStage[K, V, ConsumerMessage.PartitionOffset](
-          txSettings.closeTimeout,
-          closeProducerOnStop = true,
-          producerProvider = (ec: ExecutionContext) => txSettings.createKafkaProducerAsync()(ec),
-          settings.eosCommitInterval
-        )
+        new TransactionalProducerStage[K, V, ConsumerMessage.PartitionOffset](txSettings)
       )
       .mapAsync(txSettings.parallelism)(identity)
 

--- a/docs/src/main/paradox/producer.md
+++ b/docs/src/main/paradox/producer.md
@@ -15,33 +15,34 @@ Alpakka Kafka offers producer flows and sinks that connect to Kafka and write da
 
 These factory methods are part of the @scala[@scaladoc[Producer API](akka.kafka.scaladsl.Producer$)]@java[@scaladoc[Producer API](akka.kafka.javadsl.Producer$)].
 
-| Shared producer | Factory method    | Stream element type | Pass-through | Context |
-|-----------------|-------------------|---------------------|--------------|---------|
-| Available       | `plainSink`       | `ProducerRecord`    | N/A          | N/A     |
-| Available       | `flexiFlow`       | `Envelope`          | Any          | N/A     |
-| Available       | `flowWithContext` | `Envelope`          | No           | Any     |
+| Factory method    | May use shared producer | Stream element type | Pass-through | Context |
+|-------------------|-------------------------|---------------------|--------------|---------|
+| `plainSink`       | Yes                     | `ProducerRecord`    | N/A          | N/A     |
+| `flexiFlow`       | Yes                     | `Envelope`          | Any          | N/A     |
+| `flowWithContext` | Yes                     | `Envelope`          | No           | Any     |
 
 ### Committing producer sinks
 
 These producers produce messages to Kafka and commit the offsets of incoming messages regularly.
 
-| Shared producer | Factory method                     | Stream element type | Pass-through  | Context       |
-|-----------------|------------------------------------|---------------------|---------------|---------------|
-| Available       | `committableSink`                  | `Envelope`          | `Committable` | N/A           |
-| Available       | `committableSinkWithOffsetContext` | `Envelope`          | Any           | `Committable` |
+| Factory method                     | May use shared producer | Stream element type | Pass-through  | Context       |
+|------------------------------------|-------------------------|---------------------|---------------|---------------|
+| `committableSink`                  | Yes                     | `Envelope`          | `Committable` | N/A           |
+| `committableSinkWithOffsetContext` | Yes                     | `Envelope`          | Any           | `Committable` |
 
 For details about the batched committing see @ref:[Consumer: Offset Storage in Kafka - committing](consumer.md#offset-storage-in-kafka-committing).
 
 ### Transactional producers
 
 These factory methods are part of the @scala[@scaladoc[Transactional API](akka.kafka.scaladsl.Transactional$)]@java[@scaladoc[Transactional API](akka.kafka.javadsl.Transactional$)]. For details see @ref[Transactions](transactions.md).
+Alpakka Kafka must manage the producer when using transactions.
 
-| Shared producer | Factory method          | Stream element type | Pass-through |
-|-----------------|-------------------------|---------------------|--------------|
-| No              | `sink`                  | `Envelope`          | N/A  |
-| No              | `flow`                  | `Envelope`          | No   |
-| No              | `sinkWithOffsetContext` | `Envelope`          | N/A  |
-| No              | `flowWithOffsetContext` | `Envelope`          | No   |
+| Factory method          | May use shared producer | Stream element type | Pass-through |
+|-------------------------|-------------------------|---------------------|--------------|
+| `sink`                  | No                      | `Envelope`          | N/A          |
+| `flow`                  | No                      | `Envelope`          | No           |
+| `sinkWithOffsetContext` | No                      | `Envelope`          | N/A          |
+| `flowWithOffsetContext` | No                      | `Envelope`          | No           |
 
 
 ## Settings
@@ -171,6 +172,7 @@ Java
 ## Sharing the KafkaProducer instance
 
 The underlying `KafkaProducer` (@javadoc[Kafka API](org.apache.kafka.clients.producer.KafkaProducer)) is thread safe and sharing a single producer instance across streams will generally be faster than having multiple instances.
+You cannot share `KafkaProducer` with the Transactional flows and sinks.
 
 To create a `KafkaProducer` from the Kafka connector settings described [above](#settings), the `ProducerSettings` contains the factory methods @scala[`createKafkaProducerAsync`]@java[`createKafkaProducerCompletionStage`] and `createKafkaProducer` (blocking for asynchronous enriching).
 
@@ -180,7 +182,7 @@ Scala
 Java
 : @@ snip [snip](/tests/src/test/java/docs/javadsl/ProducerExampleTest.java) { #producer }
 
-The `KafkaProducer` instance (or @scala[Future]@java[CompletionStage]) is passed as a parameter to the `Producer` factory methods.
+The `KafkaProducer` instance (or @scala[Future]@java[CompletionStage]) is passed as a parameter to `ProducerSettings` (@scaladoc[API](akka.kafka.ProducerSettings)) using the methods `withProducer` and `withProducerFactory`.
 
 Scala
 : @@ snip [snip](/tests/src/test/scala/docs/scaladsl/ProducerExample.scala) { #plainSinkWithProducer }

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
@@ -146,7 +146,7 @@ abstract class KafkaSpec(_kafkaPort: Int, val zooKeeperPort: Int, actorSystem: A
     // using a hash of the key. If neither key nor partition is present a partition
     // will be assigned in a round-robin fashion.
       .map(n => new ProducerRecord(topic, partition, DefaultKey, n))
-      .runWith(Producer.plainSink(producerDefaults, testProducer))
+      .runWith(Producer.plainSink(producerDefaults.withProducer(testProducer)))
 
   /**
    * Produce messages to topic using specified range and return
@@ -162,7 +162,7 @@ abstract class KafkaSpec(_kafkaPort: Int, val zooKeeperPort: Int, actorSystem: A
       .map {
         case (n, ts) => new ProducerRecord(topic, partition0, ts, DefaultKey, n.toString)
       }
-      .runWith(Producer.plainSink(producerDefaults, testProducer))
+      .runWith(Producer.plainSink(producerDefaults.withProducer(testProducer)))
 
   /**
    * Produce batches over several topics.

--- a/tests/src/it/resources/logback-test.xml
+++ b/tests/src/it/resources/logback-test.xml
@@ -14,6 +14,7 @@
 
     <logger name="akka" level="WARN"/>
     <logger name="akka.kafka" level="DEBUG"/>
+    <logger name="docs.scaladsl" levle="DEBUG"/>
 
     <logger name="org.apache.zookeeper" level="WARN"/>
     <logger name="org.I0Itec.zkclient" level="WARN"/>

--- a/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
@@ -86,43 +86,57 @@ class ProducerSpec(_system: ActorSystem)
   }
 
   val settings =
-    ProducerSettings(system, new StringSerializer, new StringSerializer).withEosCommitInterval(10.milliseconds)
+    ProducerSettings(system, new StringSerializer, new StringSerializer)
+      .withEosCommitInterval(10.milliseconds)
 
   def testProducerFlow[P](mock: ProducerMock[K, V],
-                          closeOnStop: Boolean = true): Flow[Message[K, V, P], Result[K, V, P], NotUsed] =
+                          closeOnStop: Boolean = true): Flow[Message[K, V, P], Result[K, V, P], NotUsed] = {
+    val pSettings = settings.withProducer(mock.mock).withCloseProducerOnStop(closeOnStop)
     Flow
       .fromGraph(
-        new DefaultProducerStage[K, V, P, Message[K, V, P], Result[K, V, P]](settings.closeTimeout,
-                                                                             closeOnStop,
-                                                                             _ => Future.successful(mock.mock))
+        new DefaultProducerStage[K, V, P, Message[K, V, P], Result[K, V, P]](pSettings)
       )
       .mapAsync(1)(identity)
+  }
 
-  def testTransactionProducerFlow[P](mock: ProducerMock[K, V],
-                                     closeOnStop: Boolean = true): Flow[Envelope[K, V, P], Results[K, V, P], NotUsed] =
+  def testTransactionProducerFlow[P](
+      mock: ProducerMock[K, V],
+      closeOnStop: Boolean = true
+  ): Flow[Envelope[K, V, P], Results[K, V, P], NotUsed] = {
+    val pSettings = settings.withProducerFactory(_ => mock.mock).withCloseProducerOnStop(closeOnStop)
     Flow
       .fromGraph(
-        new TransactionalProducerStage[K, V, P](settings.closeTimeout,
-                                                closeOnStop,
-                                                _ => Future.successful(mock.mock),
-                                                settings.eosCommitInterval)
+        new TransactionalProducerStage[K, V, P](pSettings)
       )
       .mapAsync(1)(identity)
+  }
 
-  "Producer" should "not send messages when source is empty" in {
+  "Producer" should "send one message and shutdown the producer gracefully" in {
     assertAllStagesStopped {
-      val client = new ProducerMock[K, V](ProducerMock.handlers.fail)
+      val input = recordAndMetadata(1)
 
-      val probe = Source
-        .empty[Msg]
+      val client = {
+        val inputMap = Map(input)
+        new ProducerMock[K, V](ProducerMock.handlers.delayedMap(100.millis)(x => Try { inputMap(x) }))
+      }
+      val committer = new CommittedMarkerMock
+
+      val (source, sink) = TestSource
+        .probe[TxMsg]
         .via(testProducerFlow(client))
-        .runWith(TestSink.probe)
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
 
-      probe
-        .request(1)
-        .expectComplete()
+      val txMsg = toTxMessage(input, committer.mock)
+      source.sendNext(txMsg)
+      sink.requestNext()
 
-      client.verifySend(never())
+      // we must wait for the producer to be asynchronously assigned before observing interactions with the mock
+      awaitAssert(client.verifySend(times(1)))
+
+      source.sendComplete()
+      sink.expectComplete()
+
       client.verifyClosed()
       client.verifyNoMoreInteractions()
     }
@@ -134,7 +148,7 @@ class ProducerSpec(_system: ActorSystem)
 
       val mockProducer = new MockProducer[String, String](true, null, null)
 
-      val fut: Future[Done] = Source(input).runWith(Producer.plainSink(settings, mockProducer))
+      val fut: Future[Done] = Source(input).runWith(Producer.plainSink(settings.withProducer(mockProducer)))
 
       Await.result(fut, Duration.apply("1 second"))
       mockProducer.close()
@@ -357,18 +371,29 @@ class ProducerSpec(_system: ActorSystem)
 
   it should "initialize and begin a transaction when first run" in {
     assertAllStagesStopped {
-      val client = new ProducerMock[K, V](ProducerMock.handlers.fail)
+      val input = recordAndMetadata(1)
 
-      val probe = Source
-        .empty[Msg]
+      val client = {
+        val inputMap = Map(input)
+        new ProducerMock[K, V](ProducerMock.handlers.delayedMap(100.millis)(x => Try { inputMap(x) }))
+      }
+      val committer = new CommittedMarkerMock
+
+      val (source, sink) = TestSource
+        .probe[TxMsg]
         .via(testTransactionProducerFlow(client))
-        .runWith(TestSink.probe)
+        .toMat(TestSink.probe)(Keep.both)
+        .run()
 
-      probe
-        .request(1)
-        .expectComplete()
+      val txMsg = toTxMessage(input, committer.mock)
+      source.sendNext(txMsg)
+      sink.requestNext()
 
-      client.verifyTxInitialized()
+      // we must wait for the producer to be asynchronously assigned before observing interactions with the mock
+      awaitAssert(client.verifyTxInitialized())
+
+      source.sendComplete()
+      sink.expectComplete()
     }
   }
 

--- a/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
@@ -113,7 +113,7 @@ class CommittingSpec extends SpecBase with TestcontainersKafkaLike with Inside {
                        ),
                        NotUsed)
         }
-        .via(Producer.flexiFlow(producerDefaults, testProducer))
+        .via(Producer.flexiFlow(producerDefaults.withProducer(testProducer)))
         .runWith(Sink.ignore)
 
       // Subscribe to the topic (without demand)
@@ -197,7 +197,7 @@ class CommittingSpec extends SpecBase with TestcontainersKafkaLike with Inside {
                        ),
                        NotUsed)
         }
-        .via(Producer.flexiFlow(producerDefaults, testProducer))
+        .via(Producer.flexiFlow(producerDefaults.withProducer(testProducer)))
         .runWith(Sink.ignore)
 
       // Subscribe to the topic (without demand)
@@ -571,5 +571,5 @@ class CommittingSpec extends SpecBase with TestcontainersKafkaLike with Inside {
           immutable.Seq(new ProducerRecord(topic, partition0, DefaultKey, n),
                         new ProducerRecord(topic, partition1, DefaultKey, n))
       )
-      .runWith(Producer.plainSink(producerDefaults, testProducer))
+      .runWith(Producer.plainSink(producerDefaults.withProducer(testProducer)))
 }

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -85,7 +85,7 @@ class IntegrationSpec extends SpecBase with TestcontainersKafkaLike with Inside 
       def createAndRunProducer(elements: immutable.Iterable[Long]) =
         Source(elements)
           .map(n => new ProducerRecord(topic, (n % partitions).toInt, DefaultKey, n.toString))
-          .runWith(Producer.plainSink(producerDefaults, testProducer))
+          .runWith(Producer.plainSink(producerDefaults.withProducer(testProducer)))
 
       val control = createAndRunConsumer(subscription1)
 

--- a/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
@@ -119,7 +119,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
 
       val producer = Source(1L to totalMessages)
         .map(n => new ProducerRecord(topic, (n % partitions).toInt, DefaultKey, n.toString))
-        .runWith(Producer.plainSink(producerDefaults, testProducer))
+        .runWith(Producer.plainSink(producerDefaults.withProducer(testProducer)))
 
       producer.futureValue shouldBe Done
       sleep(2.seconds)
@@ -200,7 +200,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
           number
         }
         .map(n => new ProducerRecord(topic, (n % partitions).toInt, DefaultKey, n.toString))
-        .runWith(Producer.plainSink(producerDefaults, testProducer))
+        .runWith(Producer.plainSink(producerDefaults.withProducer(testProducer)))
 
       producer.futureValue shouldBe Done
 
@@ -286,7 +286,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
           number
         }
         .map(n => new ProducerRecord(topic, (n % partitions).toInt, DefaultKey, n.toString))
-        .runWith(Producer.plainSink(producerDefaults, testProducer))
+        .runWith(Producer.plainSink(producerDefaults.withProducer(testProducer)))
 
       producer.futureValue shouldBe Done
 
@@ -480,7 +480,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
       awaitProduce(
         Source(1L to totalMessages)
           .map(n => new ProducerRecord(topic, (n % partitions).toInt, DefaultKey, n.toString))
-          .runWith(Producer.plainSink(producerDefaults, testProducer))
+          .runWith(Producer.plainSink(producerDefaults.withProducer(testProducer)))
       )
       eventually {
         exceptionTriggered.get() shouldBe true

--- a/tests/src/test/scala/docs/scaladsl/ProducerExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/ProducerExample.scala
@@ -71,12 +71,14 @@ class ProducerExample extends DocsSpecBase with TestcontainersKafkaLike {
     val producerSettings = producerDefaults
     val topic = createTopic()
     // #plainSinkWithProducer
-    val kafkaProducer = producerSettings.createKafkaProducerAsync()
+    // create a producer
+    val kafkaProducer = producerSettings.createKafkaProducer()
+    val settingsWithProducer = producerSettings.withProducer(kafkaProducer)
 
     val done = Source(1 to 100)
       .map(_.toString)
       .map(value => new ProducerRecord[String, String](topic, value))
-      .runWith(Producer.plainSink(producerSettings, kafkaProducer))
+      .runWith(Producer.plainSink(settingsWithProducer))
     // #plainSinkWithProducer
     val (control2, result) = Consumer
       .plainSource(consumerSettings, Subscriptions.topics(topic))
@@ -89,7 +91,7 @@ class ProducerExample extends DocsSpecBase with TestcontainersKafkaLike {
     // #plainSinkWithProducer
 
     // close the producer after use
-    system.registerOnTermination(kafkaProducer.foreach(p => p.close()))
+    kafkaProducer.close()
     // #plainSinkWithProducer
   }
 


### PR DESCRIPTION
## Purpose

Pass the `ProducerSettings` object directly into producer stages so that the stage has full access to the producer factory helper methods.  It also saves on the number of parameters that need to be passed to these stages.

I also took the opportunity to add more producer factory options to `ProducerSettings` so that it's not necessary to maintain overloads to pass external or shared `KafkaProducer` instances to `Producer` flows and sinks.  I deprecated methods that take these overloads.

## References

* Preliminary work for asynchronous producer creation in #930 

## Changes

* Pass ProducerSettings to stage.
* Move producer factories to settings
* Deprecate flow/sink overloads that take producers
