### PR TITLE
Make EmbeddedKafka a provided dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ val Scala212 = "2.12.10"
 val Scala213 = "2.13.1"
 val akkaVersion = if (Nightly) "2.6.0-RC1" else "2.5.23"
 val kafkaVersion = "2.1.1"
+val embeddedKafkaVersion = kafkaVersion
 val kafkaVersionForDocs = "21"
 val scalatestVersion = "3.0.8"
 val testcontainersVersion = "1.12.2"
@@ -170,9 +171,6 @@ lazy val `alpakka-kafka` =
             |  verifyCodeStyle
             |    checks if all of the code is formatted according to the configuration
             |
-            |  verifyCompilation
-            |    compiles all the code and checks for compilation warnings
-            |
             |  verifyDocs
             |    builds all of the docs
             |
@@ -227,10 +225,10 @@ lazy val testkit = project
         if (scalaBinaryVersion.value == "2.13") Seq()
         else
           Seq(
-            "org.apache.kafka" %% "kafka" % kafkaVersion exclude ("org.slf4j", "slf4j-log4j12"),
-            "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10", // Kafka pulls in jackson databind ApacheV2
-            "org.apache.commons" % "commons-compress" % "1.19", // embedded Kafka pulls in Avro which pulls in commons-compress 1.8.1
-            "io.github.embeddedkafka" %% "embedded-kafka" % kafkaVersion exclude ("log4j", "log4j")
+            "org.apache.kafka" %% "kafka" % kafkaVersion % Provided exclude ("org.slf4j", "slf4j-log4j12"),
+            "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.10" % Provided, // Kafka pulls in jackson databind ApacheV2
+            "org.apache.commons" % "commons-compress" % "1.19" % Provided, // embedded Kafka pulls in Avro which pulls in commons-compress 1.8.1
+            "io.github.embeddedkafka" %% "embedded-kafka" % embeddedKafkaVersion % Provided exclude ("log4j", "log4j")
           )
       },
     Compile / unmanagedSources / excludeFilter := {
@@ -334,6 +332,7 @@ lazy val docs = project
     paradoxProperties ++= Map(
         "akka.version" -> akkaVersion,
         "kafka.version" -> kafkaVersion,
+        "embeddedKafka.version" -> embeddedKafkaVersion,
         "confluent.version" -> confluentAvroSerializerVersion,
         "scalatest.version" -> scalatestVersion,
         "testcontainers.version" -> testcontainersVersion,

--- a/docs/src/main/paradox/testing.md
+++ b/docs/src/main/paradox/testing.md
@@ -15,6 +15,7 @@ To simplify testing of streaming integrations with Alpakka Kafka, it provides th
   group=com.typesafe.akka
   artifact=akka-stream-kafka-testkit_$scala.binary.version$
   version=$project.version$
+  scope=test
 }
 
 Note that Akka testkits do not promise binary compatibility. The API might be changed even between patch releases.
@@ -48,6 +49,15 @@ See the documentation for each for more details.
 ## Testing with an embedded Kafka server
 
 To test the Alpakka Kafka connector the [Embedded Kafka library](https://github.com/embeddedkafka/embedded-kafka) is an important tool as it helps to easily start and stop Kafka brokers from test cases.
+
+Add the Embedded Kafka to your test dependencies:
+
+@@dependency [Maven,sbt,Gradle] {
+  group=io.github.embeddedkafka
+  artifact=embedded-kafka_2.12
+  version=$embeddedKafka.version$
+  scope=test
+}
 
 @@@ note
 

--- a/tests/src/main/scala/akka/kafka/KafkaPorts.scala
+++ b/tests/src/main/scala/akka/kafka/KafkaPorts.scala
@@ -12,16 +12,13 @@ package akka.kafka
 object KafkaPorts {
 
   val RetentionPeriodSpec = 9012
-  val TransactionsSpec = 9022
   val ReconnectSpec = 9032
   val ReconnectSpecProxy = 9034
   val MultiConsumerSpec = 9042
   val ScalaPartitionExamples = 9052
-  val ScalaTransactionsExamples = 9062
   val ScalaAvroSerialization = 9072
   val AssignmentTest = 9082
   val SerializationTest = 9092
-  val JavaTransactionsExamples = 9102
   val ProducerExamplesTest = 9112
   val KafkaConnectionCheckerTest = 9122
   val PartitionAssignmentHandlerSpec = 9132

--- a/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java
@@ -11,7 +11,7 @@ import akka.actor.ActorSystem;
 import akka.kafka.*;
 import akka.kafka.javadsl.Consumer;
 import akka.kafka.javadsl.Transactional;
-import akka.kafka.testkit.javadsl.EmbeddedKafkaJunit4Test;
+import akka.kafka.testkit.javadsl.TestcontainersKafkaJunit4Test;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.javadsl.*;
@@ -29,7 +29,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.Assert.assertEquals;
 
-public class TransactionsExampleTest extends EmbeddedKafkaJunit4Test {
+public class TransactionsExampleTest extends TestcontainersKafkaJunit4Test {
 
   private static final ActorSystem system = ActorSystem.create("TransactionsExampleTest");
   private static final Materializer materializer = ActorMaterializer.create(system);
@@ -37,7 +37,7 @@ public class TransactionsExampleTest extends EmbeddedKafkaJunit4Test {
   private final ProducerSettings<String, String> producerSettings = producerDefaults();
 
   public TransactionsExampleTest() {
-    super(system, materializer, KafkaPorts.JavaTransactionsExamples());
+    super(system, materializer);
   }
 
   @AfterClass

--- a/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
@@ -11,7 +11,7 @@ import akka.Done
 import akka.kafka.ConsumerMessage.PartitionOffset
 import akka.kafka.{ProducerMessage, _}
 import akka.kafka.scaladsl.Consumer.Control
-import akka.kafka.testkit.scaladsl.EmbeddedKafkaLike
+import akka.kafka.testkit.scaladsl.{TestcontainersKafkaLike}
 import akka.stream.{Attributes, DelayOverflowStrategy, KillSwitches, UniqueKillSwitch}
 import akka.stream.scaladsl.{Flow, Keep, RestartSource, Sink, Source}
 import akka.stream.testkit.TestSubscriber
@@ -25,7 +25,7 @@ import scala.concurrent.{Await, Future, TimeoutException}
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
-class TransactionsSpec extends SpecBase(KafkaPorts.TransactionsSpec) with EmbeddedKafkaLike {
+class TransactionsSpec extends SpecBase with TestcontainersKafkaLike {
 
   "A consume-transform-produce cycle" must {
 

--- a/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
@@ -10,8 +10,8 @@ import java.util.concurrent.atomic.AtomicReference
 import akka.Done
 import akka.kafka.scaladsl.Consumer.{Control, DrainingControl}
 import akka.kafka.scaladsl.{Consumer, Transactional}
-import akka.kafka.testkit.scaladsl.EmbeddedKafkaLike
-import akka.kafka.{KafkaPorts, ProducerMessage, Subscriptions}
+import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
+import akka.kafka.{ProducerMessage, Subscriptions}
 import akka.stream.scaladsl.{Keep, RestartSource, Sink}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import org.apache.kafka.clients.producer.ProducerRecord
@@ -19,7 +19,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class TransactionsExample extends DocsSpecBase(KafkaPorts.ScalaTransactionsExamples) with EmbeddedKafkaLike {
+class TransactionsExample extends DocsSpecBase with TestcontainersKafkaLike {
 
   override def sleepAfterProduce: FiniteDuration = 10.seconds
 


### PR DESCRIPTION
## Purpose

Make EmbeddedKafka a provided dependency of the Testkit so that users don't get it if they don't need it.
Change some more of our tests to use Testcontainers instead.

## References

Fixes #929 
#950

