### PR TITLE
DrainingControl: expose failures on overwritten methods

### DIFF
--- a/tests/src/test/java/docs/javadsl/ProducerExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/ProducerExampleTest.java
@@ -106,8 +106,8 @@ class ProducerExampleTest extends EmbeddedKafkaTest {
     String topic = createTopic();
     // #plainSinkWithProducer
     // create a producer
-    final org.apache.kafka.clients.producer.Producer<String, String>
-        kafkaProducer = producerSettings.createKafkaProducer();
+    final org.apache.kafka.clients.producer.Producer<String, String> kafkaProducer =
+        producerSettings.createKafkaProducer();
     final ProducerSettings<String, String> settingsWithProducer =
         producerSettings.withProducer(kafkaProducer);
 

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -214,7 +214,7 @@ class IntegrationSpec extends SpecBase with TestcontainersKafkaLike with Inside 
           .mapMaterializedValue(DrainingControl.apply)
           .run()
 
-      control.isShutdown.futureValue
+      control.isShutdown.failed.futureValue shouldBe a[org.apache.kafka.common.errors.InvalidGroupIdException]
       control.drainAndShutdown().failed.futureValue shouldBe a[org.apache.kafka.common.errors.InvalidGroupIdException]
     }
 

--- a/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
@@ -50,7 +50,7 @@ class TransactionsExample extends DocsSpecBase with TestcontainersKafkaLike {
       .run()
 
     awaitProduce(produce(sourceTopic, 1 to 10))
-    control.shutdown().futureValue should be(Done)
+    control.drainAndShutdown().futureValue should be(Done)
     control2.shutdown().futureValue should be(Done)
     // #transactionalSink
     control.drainAndShutdown()
@@ -79,9 +79,8 @@ class TransactionsExample extends DocsSpecBase with TestcontainersKafkaLike {
       .run()
 
     awaitProduce(produce(sourceTopic, 1 to 10))
-    control.shutdown().futureValue shouldBe Done
-    control2.shutdown().futureValue shouldBe Done
     control.drainAndShutdown().futureValue shouldBe Done
+    control2.shutdown().futureValue shouldBe Done
     result.futureValue should have size 10
   }
 


### PR DESCRIPTION
## Purpose

Expose stream completion errors in the `DrainingControl` methods that override `Control`.

## References

Fixes #956

## Changes

* Update Scaladoc for `Control`
* Combine `shutdown` and `isShutdown` with the stream completion future to make it fail for any errors
* Mark `DrainingControl.shutdown` as deprecated as users should prefer the `drainAndShutdown` solution

## Background Context

`DrainingControl` inherits methods from `Control` and did not add any value over the finished future to those, even though it has knowledge of the stream's completion status.