### PR TITLE
Committable: deprecate commitJavadsl and commitScaladsl

### DIFF
--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaConsumerBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaConsumerBenchmarks.scala
@@ -77,7 +77,7 @@ object ReactiveKafkaConsumerBenchmarks extends LazyLogging {
       }
       .via(Committer.batchFlow(committerDefaults.withMaxBatch(batchSize.toLong).withParallelism(3)))
       .toMat(Sink.foreach {
-        _.offsets().values
+        _.offsets.values
           .filter(_ >= fixture.msgCount / fixture.numberOfPartitions - 1)
           .foreach(_ => if (counter.decrementAndGet() == 0) promise.complete(Success(())))
       })(Keep.left)
@@ -130,7 +130,7 @@ object ReactiveKafkaConsumerBenchmarks extends LazyLogging {
     val control = fixture.source
       .mapAsync(1) { m =>
         meter.mark()
-        m.committableOffset.commitScaladsl().map(_ => m)(ExecutionContexts.sameThreadExecutionContext)
+        m.committableOffset.commitInternal().map(_ => m)(ExecutionContexts.sameThreadExecutionContext)
       }
       .toMat(Sink.foreach { msg =>
         if (msg.committableOffset.partitionOffset.offset >= fixture.msgCount - 1)

--- a/core/src/main/mima-filters/1.1.0.backwards.excludes/PR959-committable-deprecations.excludes
+++ b/core/src/main/mima-filters/1.1.0.backwards.excludes/PR959-committable-deprecations.excludes
@@ -1,0 +1,2 @@
+# The trait had been marked "do not inherit" for a while
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.kafka.ConsumerMessage#Committable.commitInternal")

--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -53,7 +53,7 @@ object ConsumerMessage {
     def commitScaladsl(): Future[Done]
 
     /**
-     * @deprecated use `Committer.flow` or `Committer.sink` instead of direct usage, since 1.1.1
+     * @deprecated use `Committer.flow` or `Committer.sink` instead of direct usage, since 2.0.0
      */
     @java.lang.Deprecated
     @deprecated("use `Committer.flow` or `Committer.sink` instead of direct usage", "2.0.0")

--- a/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
+++ b/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
@@ -138,8 +138,9 @@ private[kafka] trait OffsetContextBuilder[K, V]
 )(
     val committer: KafkaAsyncConsumerCommitterRef
 ) extends CommittableOffsetMetadata {
-  override def commitScaladsl(): Future[Done] = committer.commitSingle(this)
-  override def commitJavadsl(): CompletionStage[Done] = commitScaladsl().toJava
+  override def commitScaladsl(): Future[Done] = commitInternal()
+  override def commitJavadsl(): CompletionStage[Done] = commitInternal().toJava
+  override def commitInternal(): Future[Done] = committer.commitSingle(this)
   override val batchSize: Long = 1
 }
 
@@ -218,10 +219,12 @@ private[kafka] final class CommittableOffsetBatchImpl(
   override def getOffsets(): java.util.Map[GroupTopicPartition, Long] =
     offsets.asJava
 
-  override def toString(): String =
+  override def toString: String =
     s"CommittableOffsetBatch(batchSize=$batchSize, ${offsets.mkString(", ")})"
 
-  override def commitScaladsl(): Future[Done] =
+  override def commitScaladsl(): Future[Done] = commitInternal()
+
+  override def commitInternal(): Future[Done] =
     if (batchSize == 0L)
       Future.successful(Done)
     else {
@@ -235,6 +238,6 @@ private[kafka] final class CommittableOffsetBatchImpl(
     this
   }
 
-  override def commitJavadsl(): CompletionStage[Done] = commitScaladsl().toJava
+  override def commitJavadsl(): CompletionStage[Done] = commitInternal().toJava
 
 }

--- a/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
@@ -35,7 +35,7 @@ object Committer {
       case WaitForAck =>
         offsetBatches
           .mapAsyncUnordered(settings.parallelism) { b =>
-            b.commitScaladsl().map(_ => b)(ExecutionContexts.sameThreadExecutionContext)
+            b.commitInternal().map(_ => b)(ExecutionContexts.sameThreadExecutionContext)
           }
       case SendAndForget =>
         offsetBatches

--- a/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
@@ -246,7 +246,7 @@ object Consumer {
   def atMostOnceSource[K, V](settings: ConsumerSettings[K, V],
                              subscription: Subscription): Source[ConsumerRecord[K, V], Control] =
     committableSource[K, V](settings, subscription).mapAsync(1) { m =>
-      m.committableOffset.commitScaladsl().map(_ => m.record)(ExecutionContexts.sameThreadExecutionContext)
+      m.committableOffset.commitInternal().map(_ => m.record)(ExecutionContexts.sameThreadExecutionContext)
     }
 
   /**

--- a/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
@@ -76,7 +76,7 @@ object Producer {
       settings: ProducerSettings[K, V]
   ): Sink[Envelope[K, V, ConsumerMessage.Committable], Future[Done]] =
     flexiFlow[K, V, ConsumerMessage.Committable](settings)
-      .mapAsync(settings.parallelism)(_.passThrough.commitScaladsl())
+      .mapAsync(settings.parallelism)(_.passThrough.commitInternal())
       .toMat(Sink.ignore)(Keep.right)
 
   /**
@@ -104,7 +104,7 @@ object Producer {
       producer: org.apache.kafka.clients.producer.Producer[K, V]
   ): Sink[Envelope[K, V, ConsumerMessage.Committable], Future[Done]] =
     flexiFlow[K, V, ConsumerMessage.Committable](settings, producer)
-      .mapAsync(settings.parallelism)(_.passThrough.commitScaladsl())
+      .mapAsync(settings.parallelism)(_.passThrough.commitInternal())
       .toMat(Sink.ignore)(Keep.right)
 
   /**

--- a/docs/src/main/paradox/consumer.md
+++ b/docs/src/main/paradox/consumer.md
@@ -263,12 +263,6 @@ Java
 : @@ snip [snip](/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java) { #committablePartitionedSource-stream-per-partition }
 
 
-Join flows based on automatically assigned partitions:
-
-Scala
-: @@ snip [snip](/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala) { #committablePartitionedSource3 }
-
-
 ## Sharing the KafkaConsumer instance
 
 If you have many streams it can be more efficient to share the underlying `KafkaConsumer` (@javadoc[Kafka API](org.apache.kafka.clients.consumer.KafkaConsumer)) instance. It is shared by creating a `KafkaConsumerActor` (@scaladoc[API](akka.kafka.KafkaConsumerActor$)). You need to create the actor and stop it by sending `KafkaConsumerActor.Stop` when it is not needed any longer. You pass the `ActorRef` as a parameter to the `Consumer` 

--- a/tests/src/test/java/docs/javadsl/ProducerWithTestcontainersTest.java
+++ b/tests/src/test/java/docs/javadsl/ProducerWithTestcontainersTest.java
@@ -103,11 +103,13 @@ class ProducerWithTestcontainersTest extends TestcontainersKafkaTest {
     final org.apache.kafka.clients.producer.Producer<String, String> kafkaProducer =
         producerSettings.createKafkaProducer();
     // #plainSinkWithProducer
+    ProducerSettings<String, String> settingsWithProducer = producerSettings.withProducer(kafkaProducer);
+
     CompletionStage<Done> done =
         Source.range(1, 100)
             .map(number -> number.toString())
             .map(value -> new ProducerRecord<String, String>(topic, value))
-            .runWith(Producer.plainSink(producerSettings, kafkaProducer), materializer);
+            .runWith(Producer.plainSink(settingsWithProducer), materializer);
     // #plainSinkWithProducer
 
     Consumer.DrainingControl<List<ConsumerRecord<String, String>>> control =

--- a/tests/src/test/scala/akka/kafka/internal/CommittingWithMockSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingWithMockSpec.scala
@@ -116,7 +116,7 @@ class CommittingWithMockSpec(_system: ActorSystem)
     mock.enqueue(List(toRecord(msg)))
 
     probe.request(100)
-    val done = probe.expectNext().committableOffset.commitScaladsl()
+    val done = probe.expectNext().committableOffset.commitInternal()
 
     awaitAssert {
       commitLog.calls should have size (1)
@@ -149,7 +149,7 @@ class CommittingWithMockSpec(_system: ActorSystem)
     mock.enqueue(List(toRecord(msg)))
 
     probe.request(100)
-    val done = probe.expectNext().committableOffset.commitScaladsl()
+    val done = probe.expectNext().committableOffset.commitInternal()
 
     awaitAssert {
       commitLog.calls should have size (1)
@@ -181,7 +181,7 @@ class CommittingWithMockSpec(_system: ActorSystem)
     mock.enqueue(List(toRecord(msg)))
 
     probe.request(100)
-    val done = probe.expectNext().committableOffset.commitScaladsl()
+    val done = probe.expectNext().committableOffset.commitInternal()
 
     awaitAssert {
       commitLog.calls should have size (1)
@@ -211,7 +211,7 @@ class CommittingWithMockSpec(_system: ActorSystem)
     mock.enqueue(msgs.map(toRecord))
 
     probe.request(count.toLong)
-    val done = Future.sequence(probe.expectNextN(count.toLong).map(_.committableOffset.commitScaladsl()))
+    val done = Future.sequence(probe.expectNextN(count.toLong).map(_.committableOffset.commitInternal()))
 
     withClue("the commits are aggregated to a low number of calls to commitAsync:") {
       awaitAssert {
@@ -248,7 +248,7 @@ class CommittingWithMockSpec(_system: ActorSystem)
       .map(_.committableOffset)
       .foldLeft(CommittableOffsetBatch.empty)(_.updated(_))
 
-    val done = batch.commitScaladsl()
+    val done = batch.commitInternal()
 
     awaitAssert {
       commitLog.calls should have size (1)
@@ -287,7 +287,7 @@ class CommittingWithMockSpec(_system: ActorSystem)
       .map(_.committableOffset)
       .foldLeft(CommittableOffsetBatch.empty)(_.updated(_))
 
-    val done = batch.commitScaladsl()
+    val done = batch.commitInternal()
 
     awaitAssert {
       commitLog.calls should have size (1)
@@ -330,7 +330,7 @@ class CommittingWithMockSpec(_system: ActorSystem)
       .map(_.foldLeft(CommittableOffsetBatch.empty)(_ updated _))
       .foldLeft(CommittableOffsetBatch.empty)(_ updated _)
 
-    val done = batch.commitScaladsl()
+    val done = batch.commitInternal()
 
     awaitAssert {
       commitLog.calls should have size (1)
@@ -387,7 +387,7 @@ class CommittingWithMockSpec(_system: ActorSystem)
       .map(_.committableOffset)
       .foldLeft(batch1)(_.updated(_))
 
-    val done2 = batch2.commitScaladsl()
+    val done2 = batch2.commitInternal()
 
     awaitAssert {
       commitLog1.calls should have size (1)

--- a/tests/src/test/scala/akka/kafka/internal/ConsumerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConsumerSpec.scala
@@ -238,7 +238,7 @@ class ConsumerSpec(_system: ActorSystem)
     mock.enqueue(msgs.map(toRecord))
 
     probe.request(100)
-    val done = probe.expectNext().committableOffset.commitScaladsl()
+    val done = probe.expectNext().committableOffset.commitInternal()
     probe.expectNextN(9)
 
     awaitAssert {
@@ -278,7 +278,7 @@ class ConsumerSpec(_system: ActorSystem)
     probe.expectComplete()
     Await.result(stopped, remainingOrDefault)
 
-    val done = first.committableOffset.commitScaladsl()
+    val done = first.committableOffset.commitInternal()
     intercept[CommitTimeoutException] {
       Await.result(done, remainingOrDefault)
     }
@@ -295,7 +295,7 @@ class ConsumerSpec(_system: ActorSystem)
     mock.enqueue(msgs.map(toRecord))
 
     probe.request(5)
-    val done = probe.expectNext().committableOffset.commitScaladsl()
+    val done = probe.expectNext().committableOffset.commitInternal()
     probe.expectNextN(4)
 
     awaitAssert {

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -156,7 +156,7 @@ class IntegrationSpec extends SpecBase with TestcontainersKafkaLike with Inside 
           .via(Producer.flexiFlow(producerDefaults))
           .map(_.passThrough)
           .batch(max = 10, CommittableOffsetBatch.apply)(_.updated(_))
-          .mapAsync(producerDefaults.parallelism)(_.commitScaladsl())
+          .mapAsync(producerDefaults.parallelism)(_.commitInternal())
 
         val probe = source.runWith(TestSink.probe)
 
@@ -195,7 +195,7 @@ class IntegrationSpec extends SpecBase with TestcontainersKafkaLike with Inside 
       val (control, res) =
         Consumer
           .committableSource(consumerDefaults.withGroupId(group1), Subscriptions.topics(topic1))
-          .mapAsync(1)(msg => msg.committableOffset.commitScaladsl().map(_ => msg.record.value))
+          .mapAsync(1)(msg => msg.committableOffset.commitInternal().map(_ => msg.record.value))
           .take(5)
           .toMat(Sink.seq)(Keep.both)
           .run()

--- a/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
@@ -454,7 +454,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
                 }
               }
               .log(s"subsource $tp pre commit")
-              .mapAsync(1)(_.committableOffset.commitScaladsl().andThen {
+              .mapAsync(1)(_.committableOffset.commitInternal().andThen {
                 case Failure(e) =>
                   log.error("commit failure", e)
                   commitFailures ::= tp -> e

--- a/tests/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
@@ -45,7 +45,7 @@ class RetentionPeriodSpec extends SpecBase(kafkaPort = KafkaPorts.RetentionPerio
       val (control, probe1) = Consumer
         .committableSource(consumerSettings, Subscriptions.topics(topic1))
         .mapAsync(10) { elem =>
-          elem.committableOffset.commitScaladsl().map { _ =>
+          elem.committableOffset.commitInternal().map { _ =>
             committedElements.add(elem.record.value.toInt)
             Done
           }


### PR DESCRIPTION
## Purpose

Deprecate `commitJavadsl` and `commitScaladsl` methods in the `Committable` trait.

## References

References #424 

## Changes

* Update scaladoc of `Committable`
* Introduce `commitInternal` as internal API
* Deprecate `commitJavadsl` and `CommitScaladsl` with all available annotations
* Mark `CommittableOffset` and `PartitionOffset` as `sealed`
* Remove the scala-only example with complex commit aggregation from `consumer.md` 
* Remove `()` from `offsets` and `getOffsets` from `CommittableOffsetBatch`

## Background Context

With the recommended use of `Committer` the direct use of the `commitJavadsl` and `commitScaladsl` can now be deprecated and be up for removal in later versions.