### PR TITLE
Docs: remove duplicated producer tests

### DIFF
--- a/docs/src/main/paradox/producer.md
+++ b/docs/src/main/paradox/producer.md
@@ -57,7 +57,7 @@ Scala
 : @@ snip [snip](/tests/src/test/scala/docs/scaladsl/ProducerExample.scala) { #settings }
 
 Java
-: @@ snip [snip](/tests/src/test/java/docs/javadsl/ProducerExampleTest.java) { #settings }
+: @@ snip [snip](/tests/src/test/java/docs/javadsl/ProducerWithTestcontainersTest.java) { #settings }
 
 In addition to programmatic construction of the `ProducerSettings` (@scaladoc[API](akka.kafka.ProducerSettings)) it can also be created from configuration (`application.conf`). 
 
@@ -86,7 +86,7 @@ Scala
   The materialized value of the sink is a `Future[Done]` which is completed with `Done` when the stream completes, or with with an exception in case an error occurs.
 
 Java
-: @@ snip [snip](/tests/src/test/java/docs/javadsl/ProducerExampleTest.java) { #plainSink }
+: @@ snip [snip](/tests/src/test/java/docs/javadsl/ProducerWithTestcontainersTest.java) { #plainSink }
   The materialized value of the sink is a `CompletionStage<Done>` which is completed with `Done` when the stream completes, or with an exception in case an error occurs.
 
 
@@ -103,7 +103,7 @@ Scala
 : @@ snip [snip](/tests/src/test/scala/docs/scaladsl/ProducerExample.scala) { #singleMessage }
 
 Java
-: @@ snip [snip](/tests/src/test/java/docs/javadsl/ProducerExampleTest.java) { #singleMessage }
+: @@ snip [snip](/tests/src/test/java/docs/javadsl/ProducerWithTestcontainersTest.java) { #singleMessage }
 
 
 For flows the `ProducerMessage.Message`s continue as `ProducerMessage.Result` elements containing: 
@@ -121,7 +121,7 @@ Scala
 : @@ snip [snip](/tests/src/test/scala/docs/scaladsl/ProducerExample.scala) { #multiMessage }
 
 Java
-: @@ snip [snip](/tests/src/test/java/docs/javadsl/ProducerExampleTest.java) { #multiMessage }
+: @@ snip [snip](/tests/src/test/java/docs/javadsl/ProducerWithTestcontainersTest.java) { #multiMessage }
 
 For flows the `ProducerMessage.MultiMessage`s continue as `ProducerMessage.MultiResult` elements containing: 
  
@@ -140,7 +140,7 @@ Scala
 : @@ snip [snip](/tests/src/test/scala/docs/scaladsl/ProducerExample.scala) { #passThroughMessage }
 
 Java
-: @@ snip [snip](/tests/src/test/java/docs/javadsl/ProducerExampleTest.java) { #passThroughMessage }
+: @@ snip [snip](/tests/src/test/java/docs/javadsl/ProducerWithTestcontainersTest.java) { #passThroughMessage }
 
 
 For flows the `ProducerMessage.PassThroughMessage`s continue as `ProducerMessage.PassThroughResult` elements containing the `passThrough` data.  
@@ -155,7 +155,7 @@ Scala
 : @@ snip [snip](/tests/src/test/scala/docs/scaladsl/ProducerExample.scala) { #flow }
 
 Java
-: @@ snip [snip](/tests/src/test/java/docs/javadsl/ProducerExampleTest.java) { #flow }
+: @@ snip [snip](/tests/src/test/java/docs/javadsl/ProducerWithTestcontainersTest.java) { #flow }
 
 
 ## Connecting a Producer to a Consumer
@@ -180,7 +180,7 @@ Scala
 : @@ snip [snip](/tests/src/test/scala/docs/scaladsl/ProducerExample.scala) { #producer }
 
 Java
-: @@ snip [snip](/tests/src/test/java/docs/javadsl/ProducerExampleTest.java) { #producer }
+: @@ snip [snip](/tests/src/test/java/docs/javadsl/ProducerWithTestcontainersTest.java) { #producer }
 
 The `KafkaProducer` instance (or @scala[Future]@java[CompletionStage]) is passed as a parameter to `ProducerSettings` (@scaladoc[API](akka.kafka.ProducerSettings)) using the methods `withProducer` and `withProducerFactory`.
 
@@ -188,7 +188,7 @@ Scala
 : @@ snip [snip](/tests/src/test/scala/docs/scaladsl/ProducerExample.scala) { #plainSinkWithProducer }
 
 Java
-: @@ snip [snip](/tests/src/test/java/docs/javadsl/ProducerExampleTest.java) { #plainSinkWithProducer }
+: @@ snip [snip](/tests/src/test/java/docs/javadsl/ProducerWithTestcontainersTest.java) { #plainSinkWithProducer }
 
 
 ## Accessing KafkaProducer metrics
@@ -199,4 +199,4 @@ Scala
 : @@ snip [snip](/tests/src/test/scala/docs/scaladsl/ProducerExample.scala) { #producerMetrics }
 
 Java
-: @@ snip [snip](/tests/src/test/java/docs/javadsl/ProducerExampleTest.java) { #producerMetrics }
+: @@ snip [snip](/tests/src/test/java/docs/javadsl/ProducerWithTestcontainersTest.java) { #producerMetrics }

--- a/tests/src/test/java/docs/javadsl/ProducerExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/ProducerExampleTest.java
@@ -15,28 +15,21 @@ import akka.kafka.testkit.javadsl.EmbeddedKafkaTest;
 // #testkit
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
-import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 // #testkit
 import akka.testkit.javadsl.TestKit;
 // #testkit
-import com.typesafe.config.Config;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.clients.producer.RecordMetadata;
-import org.apache.kafka.common.serialization.StringSerializer;
 // #testkit
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 // #testkit
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.*;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 
 // #testkit
 
@@ -64,33 +57,13 @@ class ProducerExampleTest extends EmbeddedKafkaTest {
 
   // #testkit
   @Test
-  void createProducer() throws InterruptedException, ExecutionException, TimeoutException {
-    // #producer
-    // #settings
-    final Config config = system.settings().config().getConfig("akka.kafka.producer");
-    final ProducerSettings<String, String> producerSettings =
-        ProducerSettings.create(config, new StringSerializer(), new StringSerializer())
-            .withBootstrapServers("localhost:9092");
-    // #settings
-    final CompletionStage<org.apache.kafka.clients.producer.Producer<String, String>>
-        kafkaProducer = producerSettings.createKafkaProducerCompletionStage(executor);
-
-    // using the kafka producer
-
-    kafkaProducer.thenAccept(p -> p.close());
-    // #producer
-  }
-
-  @Test
   void plainSink() throws Exception {
     String topic = createTopic();
-    // #plainSink
     CompletionStage<Done> done =
         Source.range(1, 100)
             .map(number -> number.toString())
             .map(value -> new ProducerRecord<String, String>(topic, value))
             .runWith(Producer.plainSink(producerSettings), materializer);
-    // #plainSink
 
     Consumer.DrainingControl<List<ConsumerRecord<String, String>>> control =
         consumeString(topic, 100);
@@ -101,148 +74,6 @@ class ProducerExampleTest extends EmbeddedKafkaTest {
     assertEquals(100, resultOf(result).size());
   }
 
-  @Test
-  void plainSinkWithSharedProducer() throws Exception {
-    String topic = createTopic();
-    // #plainSinkWithProducer
-    // create a producer
-    final org.apache.kafka.clients.producer.Producer<String, String> kafkaProducer =
-        producerSettings.createKafkaProducer();
-    final ProducerSettings<String, String> settingsWithProducer =
-        producerSettings.withProducer(kafkaProducer);
-
-    CompletionStage<Done> done =
-        Source.range(1, 100)
-            .map(number -> number.toString())
-            .map(value -> new ProducerRecord<String, String>(topic, value))
-            .runWith(Producer.plainSink(settingsWithProducer), materializer);
-    // #plainSinkWithProducer
-
-    Consumer.DrainingControl<List<ConsumerRecord<String, String>>> control =
-        consumeString(topic, 100);
-    assertEquals(Done.done(), resultOf(done));
-    assertEquals(Done.done(), resultOf(control.isShutdown()));
-    CompletionStage<List<ConsumerRecord<String, String>>> result =
-        control.drainAndShutdown(executor);
-    assertEquals(100, resultOf(result).size());
-
-    // #plainSinkWithProducer
-
-    // close the producer after use
-    kafkaProducer.close();
-    // #plainSinkWithProducer
-  }
-
-  @Test
-  void observeMetrics() throws Exception {
-    producerSettings
-        .createKafkaProducerCompletionStage(executor)
-        .thenAccept(
-            kafkaProducer -> {
-              // #producerMetrics
-              Map<org.apache.kafka.common.MetricName, ? extends org.apache.kafka.common.Metric>
-                  metrics = kafkaProducer.metrics(); // observe metrics
-              // #producerMetrics
-              assertFalse(metrics.isEmpty());
-              kafkaProducer.close();
-            });
-  }
-
-  <KeyType, ValueType, PassThroughType>
-      ProducerMessage.Envelope<KeyType, ValueType, PassThroughType> createMessage(
-          KeyType key, ValueType value, PassThroughType passThrough) {
-    // #singleMessage
-    ProducerMessage.Envelope<KeyType, ValueType, PassThroughType> message =
-        ProducerMessage.single(new ProducerRecord<>("topicName", key, value), passThrough);
-    // #singleMessage
-    return message;
-  }
-
-  <KeyType, ValueType, PassThroughType>
-      ProducerMessage.Envelope<KeyType, ValueType, PassThroughType> createMultiMessage(
-          KeyType key, ValueType value, PassThroughType passThrough) {
-    // #multiMessage
-    ProducerMessage.Envelope<KeyType, ValueType, PassThroughType> multiMessage =
-        ProducerMessage.multi(
-            Arrays.asList(
-                new ProducerRecord<>("topicName", key, value),
-                new ProducerRecord<>("anotherTopic", key, value)),
-            passThrough);
-    // #multiMessage
-    return multiMessage;
-  }
-
-  <KeyType, ValueType, PassThroughType>
-      ProducerMessage.Envelope<KeyType, ValueType, PassThroughType> createPassThroughMessage(
-          KeyType key, ValueType value, PassThroughType passThrough) {
-    // #passThroughMessage
-    ProducerMessage.Envelope<KeyType, ValueType, PassThroughType> ptm =
-        ProducerMessage.passThrough(passThrough);
-    // #passThroughMessage
-    return ptm;
-  }
-
-  @Test
-  void producerFlowExample() throws Exception {
-    String topic = createTopic();
-    // #flow
-    CompletionStage<Done> done =
-        Source.range(1, 100)
-            .map(
-                number -> {
-                  int partition = 0;
-                  String value = String.valueOf(number);
-                  ProducerMessage.Envelope<String, String, Integer> msg =
-                      ProducerMessage.single(
-                          new ProducerRecord<>(topic, partition, "key", value), number);
-                  return msg;
-                })
-            .via(Producer.flexiFlow(producerSettings))
-            .map(
-                result -> {
-                  if (result instanceof ProducerMessage.Result) {
-                    ProducerMessage.Result<String, String, Integer> res =
-                        (ProducerMessage.Result<String, String, Integer>) result;
-                    ProducerRecord<String, String> record = res.message().record();
-                    RecordMetadata meta = res.metadata();
-                    return meta.topic()
-                        + "/"
-                        + meta.partition()
-                        + " "
-                        + res.offset()
-                        + ": "
-                        + record.value();
-                  } else if (result instanceof ProducerMessage.MultiResult) {
-                    ProducerMessage.MultiResult<String, String, Integer> res =
-                        (ProducerMessage.MultiResult<String, String, Integer>) result;
-                    return res.getParts().stream()
-                        .map(
-                            part -> {
-                              RecordMetadata meta = part.metadata();
-                              return meta.topic()
-                                  + "/"
-                                  + meta.partition()
-                                  + " "
-                                  + part.metadata().offset()
-                                  + ": "
-                                  + part.record().value();
-                            })
-                        .reduce((acc, s) -> acc + ", " + s);
-                  } else {
-                    return "passed through";
-                  }
-                })
-            .runWith(Sink.foreach(System.out::println), materializer);
-    // #flow
-
-    Consumer.DrainingControl<List<ConsumerRecord<String, String>>> control =
-        consumeString(topic, 100L);
-    assertEquals(Done.done(), resultOf(done));
-    assertEquals(Done.done(), resultOf(control.isShutdown()));
-    CompletionStage<List<ConsumerRecord<String, String>>> result =
-        control.drainAndShutdown(executor);
-    assertEquals(100, resultOf(result).size());
-  }
   // #testkit
 }
 // #testkit


### PR DESCRIPTION
## Purpose

Remove tests from `ProducerExampleTest` which were duplicated in `ProducerWithTestcontainersTest` and use snippets from that file.
`ProducerExampleTest` is kept for snippets to illustrate the use of `EmbeddedKafkaTest` with JUnit 5.
