### PR TITLE
Producer: some concurrency and naming improvements

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/DefaultProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/DefaultProducerStage.scala
@@ -105,7 +105,9 @@ private class DefaultProducerStageLogic[K, V, P, IN <: Envelope[K, V, P], OUT <:
   }
 
   val failStageCb: AsyncCallback[Throwable] = getAsyncCallback[Throwable] { ex =>
-    // the producer will be closed in `postStop`
+    // Discard unsent ProducerRecords after encountering a send-failure in ProducerStage
+    // https://github.com/akka/alpakka-kafka/pull/318
+    producer.close(0L, TimeUnit.MILLISECONDS)
     failStage(ex)
   }
 

--- a/core/src/main/scala/akka/kafka/internal/DefaultProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/DefaultProducerStage.scala
@@ -105,9 +105,11 @@ private class DefaultProducerStageLogic[K, V, P, IN <: Envelope[K, V, P], OUT <:
   }
 
   val failStageCb: AsyncCallback[Throwable] = getAsyncCallback[Throwable] { ex =>
-    // Discard unsent ProducerRecords after encountering a send-failure in ProducerStage
-    // https://github.com/akka/alpakka-kafka/pull/318
-    producer.close(0L, TimeUnit.MILLISECONDS)
+    if (producer != null) {
+      // Discard unsent ProducerRecords after encountering a send-failure in ProducerStage
+      // https://github.com/akka/alpakka-kafka/pull/318
+      producer.close(0L, TimeUnit.MILLISECONDS)
+    }
     failStage(ex)
   }
 


### PR DESCRIPTION
## Purpose

Solves slight concurrency glitches and moves code to named methods.

## Changes

* Create the `assignProducer` callback outside of the future callback (which was illegal)
* Defer the `producer.close` from the `sendCallback` to be called within the fail stage callback. Calling it from within the callback was not recommended:

https://github.com/apache/kafka/blob/6b905ade0cdc7a5f6f746727ecfe4e7a7463a200/clients/src/main/java/org/apache/kafka/clients/producer/KafkaProducer.java#L1189-L1193
