### PR TITLE
Committing producer sink: producer and committer in a sink stage

### DIFF
--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/AlpakkaCommittableProducer.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/AlpakkaCommittableProducer.scala
@@ -1,0 +1,46 @@
+package akka.kafka.benchmarks
+
+import akka.kafka.benchmarks.BenchmarksBase.{topic_100_100, topic_100_5000}
+import akka.kafka.benchmarks.Timed.runPerfTest
+import akka.kafka.benchmarks.app.RunTestCommand
+
+/**
+ * Compares the `CommittingProducerSinkStage` with the composed implementation of `Producer.flexiFlow` and `Committer.sink`.
+ */
+class AlpakkaCommittableProducer extends BenchmarksBase() {
+  it should "bench composed sink with 100b messages" in {
+    val cmd = RunTestCommand("alpakka-committable-producer-composed", bootstrapServers, topic_100_100)
+    runPerfTest(
+      cmd,
+      AlpakkaCommittableSinkFixtures.composedSink(cmd),
+      AlpakkaCommittableSinkBenchmarks.run
+    )
+  }
+
+  it should "bench composed sink with 5000b messages" in {
+    val cmd = RunTestCommand("alpakka-committable-producer-composed-5000b", bootstrapServers, topic_100_5000)
+    runPerfTest(
+      cmd,
+      AlpakkaCommittableSinkFixtures.composedSink(cmd),
+      AlpakkaCommittableSinkBenchmarks.run
+    )
+  }
+
+  it should "bench `Producer.committableSink` with 100b messages" in {
+    val cmd = RunTestCommand("alpakka-committable-producer", bootstrapServers, topic_100_100)
+    runPerfTest(
+      cmd,
+      AlpakkaCommittableSinkFixtures.producerSink(cmd),
+      AlpakkaCommittableSinkBenchmarks.run
+    )
+  }
+
+  it should "bench `Producer.committableSink` with 5000b messages" in {
+    val cmd = RunTestCommand("alpakka-committable-producer-5000b", bootstrapServers, topic_100_5000)
+    runPerfTest(
+      cmd,
+      AlpakkaCommittableSinkFixtures.producerSink(cmd),
+      AlpakkaCommittableSinkBenchmarks.run
+    )
+  }
+}

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/AlpakkaCommittableSinkFixtures.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/AlpakkaCommittableSinkFixtures.scala
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.benchmarks
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.kafka.ConsumerMessage.{Committable, CommittableMessage}
+import akka.kafka.ProducerMessage.Envelope
+import akka.kafka.benchmarks.app.RunTestCommand
+import akka.kafka.scaladsl.Consumer.{Control, DrainingControl}
+import akka.kafka.scaladsl.{Committer, Consumer, Producer}
+import akka.kafka._
+import akka.stream.Materializer
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import com.codahale.metrics.Meter
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.common.serialization.{
+  ByteArrayDeserializer,
+  ByteArraySerializer,
+  StringDeserializer,
+  StringSerializer
+}
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future, Promise}
+import scala.util.Success
+
+case class AlpakkaCommittableSinkTestFixture[SOut, FIn](sourceTopic: String,
+                                                        sinkTopic: String,
+                                                        msgCount: Int,
+                                                        source: Source[SOut, Control],
+                                                        sink: Sink[FIn, Future[Done]])
+
+object AlpakkaCommittableSinkFixtures extends PerfFixtureHelpers {
+  type Key = Array[Byte]
+  type Val = String
+  type Message = CommittableMessage[Key, Val]
+  type ProducerMessage = Envelope[Key, Val, Committable]
+
+  private def createConsumerSettings(kafkaHost: String)(implicit actorSystem: ActorSystem) =
+    ConsumerSettings(actorSystem, new ByteArrayDeserializer, new StringDeserializer)
+      .withBootstrapServers(kafkaHost)
+      .withGroupId(randomId())
+      .withClientId(randomId())
+      .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+
+  private def createProducerSettings(
+      kafkaHost: String
+  )(implicit actorSystem: ActorSystem): ProducerSettings[Array[Byte], String] =
+    ProducerSettings(actorSystem, new ByteArraySerializer, new StringSerializer)
+      .withBootstrapServers(kafkaHost)
+
+  def producerSink(c: RunTestCommand)(implicit actorSystem: ActorSystem) =
+    FixtureGen[AlpakkaCommittableSinkTestFixture[Message, ProducerMessage]](
+      c,
+      msgCount => {
+        fillTopic(c.filledTopic, c.kafkaHost)
+        val sinkTopic = randomId()
+
+        val source: Source[Message, Control] =
+          Consumer.committableSource(createConsumerSettings(c.kafkaHost), Subscriptions.topics(c.filledTopic.topic))
+
+        val sink: Sink[ProducerMessage, Future[Done]] =
+          Producer.committableSink(createProducerSettings(c.kafkaHost), CommitterSettings(actorSystem))
+
+        AlpakkaCommittableSinkTestFixture[Message, ProducerMessage](c.filledTopic.topic,
+                                                                    sinkTopic,
+                                                                    msgCount,
+                                                                    source,
+                                                                    sink)
+      }
+    )
+
+  def composedSink(c: RunTestCommand)(implicit actorSystem: ActorSystem) =
+    FixtureGen[AlpakkaCommittableSinkTestFixture[Message, ProducerMessage]](
+      c,
+      msgCount => {
+        fillTopic(c.filledTopic, c.kafkaHost)
+        val sinkTopic = randomId()
+
+        val source: Source[Message, Control] =
+          Consumer.committableSource(createConsumerSettings(c.kafkaHost), Subscriptions.topics(c.filledTopic.topic))
+
+        val sink: Sink[ProducerMessage, Future[Done]] =
+          Producer
+            .flexiFlow[Key, Val, Committable](createProducerSettings(c.kafkaHost))
+            .map(_.passThrough)
+            .toMat(Committer.sink(CommitterSettings(actorSystem)))(Keep.right)
+
+        AlpakkaCommittableSinkTestFixture[Message, ProducerMessage](c.filledTopic.topic,
+                                                                    sinkTopic,
+                                                                    msgCount,
+                                                                    source,
+                                                                    sink)
+      }
+    )
+}
+
+object AlpakkaCommittableSinkBenchmarks extends LazyLogging {
+  import AlpakkaCommittableSinkFixtures.{Message, ProducerMessage}
+
+  val streamingTimeout: FiniteDuration = 30.minutes
+  type Fixture = AlpakkaCommittableSinkTestFixture[Message, ProducerMessage]
+
+  def run(fixture: Fixture, meter: Meter)(implicit mat: Materializer): Unit = {
+    logger.debug("Creating and starting a stream")
+    val msgCount = fixture.msgCount
+    val sinkTopic = fixture.sinkTopic
+    val source = fixture.source
+
+    val promise = Promise[Unit]
+    val logPercentStep = 1
+    val loggedStep = if (msgCount > logPercentStep) 100 else 1
+
+    val control = source
+      .map { msg =>
+        ProducerMessage.single(new ProducerRecord[Array[Byte], String](sinkTopic, msg.record.value()),
+                               msg.committableOffset)
+      }
+      .map { msg =>
+        meter.mark()
+        val offset = msg.passThrough.partitionOffset.offset
+        if (offset % loggedStep == 0)
+          logger.info(s"Transformed $offset elements to Kafka (${100 * offset / msgCount}%)")
+        if (offset >= fixture.msgCount - 1)
+          promise.complete(Success(()))
+        msg
+      }
+      .toMat(fixture.sink)(Keep.both)
+      .mapMaterializedValue(DrainingControl.apply)
+      .run()
+
+    Await.result(promise.future, streamingTimeout)
+    control.drainAndShutdown()(mat.executionContext)
+    logger.debug("Stream finished")
+  }
+}

--- a/core/src/main/scala/akka/kafka/internal/CommittingProducerSinkStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommittingProducerSinkStage.scala
@@ -1,0 +1,282 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.internal
+
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.{AtomicInteger, AtomicLong}
+
+import akka.Done
+import akka.annotation.InternalApi
+import akka.dispatch.ExecutionContexts
+import akka.kafka.ConsumerMessage.{Committable, CommittableOffsetBatch}
+import akka.kafka.ProducerMessage._
+import akka.kafka.{CommitterSettings, ProducerSettings}
+import akka.stream.ActorAttributes.SupervisionStrategy
+import akka.stream.Supervision.Decider
+import akka.stream.stage._
+import akka.stream.{Attributes, Inlet, SinkShape, Supervision}
+import org.apache.kafka.clients.producer.{Callback, Producer, RecordMetadata}
+
+import scala.concurrent.{Future, Promise}
+import scala.util.control.NonFatal
+import scala.util.{Failure, Success, Try}
+
+/**
+ * INTERNAL API.
+ *
+ * Combined stage for producing, batching commits and committing.
+ */
+@InternalApi
+private[kafka] final class CommittingProducerSinkStage[K, V, IN <: Envelope[K, V, Committable]](
+    val producerSettings: ProducerSettings[K, V],
+    val committerSettings: CommitterSettings
+) extends GraphStageWithMaterializedValue[SinkShape[IN], Future[Done]] {
+
+  val in = Inlet[IN]("messages")
+  val shape: SinkShape[IN] = SinkShape(in)
+
+  override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Future[Done]) = {
+    val logic = new CommittingProducerSinkStageLogic(this, inheritedAttributes)
+    (logic, logic.streamCompletion.future)
+  }
+}
+
+private final class CommittingProducerSinkStageLogic[K, V, IN <: Envelope[K, V, Committable]](
+    stage: CommittingProducerSinkStage[K, V, IN],
+    inheritedAttributes: Attributes
+) extends TimerGraphStageLogic(stage.shape)
+    with StageLogging {
+
+  /** The promise behind the materialized future. */
+  final val streamCompletion = Promise[Done]
+
+  private lazy val decider: Decider =
+    inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
+
+  /** The Kafka producer may be created lazily, assigned via `preStart` in `assignProducer`. */
+  private var producer: Producer[K, V] = _
+
+  override protected def logSource: Class[_] = classOf[CommittingProducerSinkStage[_, _, _]]
+
+  private val failStageCb: AsyncCallback[Throwable] = getAsyncCallback[Throwable] { ex =>
+    if (producer != null) {
+      // Discard unsent ProducerRecords after encountering a send-failure in ProducerStage
+      // https://github.com/akka/alpakka-kafka/pull/318
+      producer.close(0L, TimeUnit.MILLISECONDS)
+    }
+    failStage(ex)
+  }
+
+  // ---- initialization
+  override def preStart(): Unit = {
+    super.preStart()
+    resolveProducer()
+  }
+
+  /** When the producer is set up, the sink pulls and schedules the first commit. */
+  private def assignProducer(p: Producer[K, V]): Unit = {
+    producer = p
+    tryPull(stage.in)
+    scheduleCommit()
+    log.debug("CommittingProducerSink initialized")
+  }
+
+  private def resolveProducer(): Unit = {
+    val producerFuture = stage.producerSettings.createKafkaProducerAsync()(materializer.executionContext)
+    producerFuture.value match {
+      case Some(Success(p)) => assignProducer(p)
+      case Some(Failure(e)) => failStage(e)
+      case None =>
+        val assign = getAsyncCallback(assignProducer)
+        producerFuture
+          .transform(
+            producer => assign.invoke(producer),
+            e => {
+              log.error(e, "producer creation failed")
+              failStageCb.invoke(e)
+              e
+            }
+          )(ExecutionContexts.sameThreadExecutionContext)
+    }
+  }
+
+  // ---- Producing
+  /** Counter for number of outstanding messages that are sent, but didn't get the callback, yet. */
+  private var awaitingProduceResult = 0L
+
+  /** Counter for number of outstanding messages that are sent, but the commit did not finish, yet. */
+  private var awaitingCommitResult = 0L
+
+  private def produce(in: Envelope[K, V, Committable]): Unit =
+    in match {
+      case msg: Message[K, V, Committable] =>
+        awaitingProduceResult += 1
+        awaitingCommitResult += 1
+        producer.send(msg.record, new SendCallback(msg.passThrough))
+
+      case multiMsg: MultiMessage[K, V, Committable] =>
+        val size = multiMsg.records.size
+        awaitingProduceResult += size
+        awaitingCommitResult += size
+        val cb = new SendMultiCallback(size, multiMsg.passThrough)
+        for {
+          record <- multiMsg.records
+        } producer.send(record, cb)
+
+      case msg: PassThroughMessage[K, V, Committable] =>
+        collectOffset(0, msg.passThrough)
+    }
+
+  /** Safe to be called async */
+  private def decide(exception: Throwable): Unit =
+    decider(exception) match {
+      case Supervision.Stop => failStageCb.invoke(exception)
+      case _ => log.warning("ignoring {}", exception)
+    }
+
+  /** send-callback for a single message. */
+  private final class SendCallback(offset: Committable) extends Callback {
+
+    override def onCompletion(metadata: RecordMetadata, exception: Exception): Unit =
+      if (exception == null) collectOffsetCB.invoke(offset)
+      else decide(exception) // TODO if we ignore it, should we commit it?
+  }
+
+  /** send-callback for a multi-message. */
+  private final class SendMultiCallback(count: Int, offset: Committable) extends Callback {
+    private val counter = new AtomicInteger(count)
+
+    override def onCompletion(metadata: RecordMetadata, exception: Exception): Unit =
+      if (exception == null) {
+        if (counter.decrementAndGet() == 0) collectOffsetMultiCB.invoke(count -> offset)
+      } else decide(exception) // TODO if we ignore it, should we commit it?
+  }
+
+  // ---- Committing
+  /** Batches offsets until a commit is triggered. */
+  private var offsetBatch: CommittableOffsetBatch = CommittableOffsetBatch.empty
+
+  private val collectOffsetCB: AsyncCallback[Committable] = getAsyncCallback[Committable] { offset =>
+    collectOffset(1, offset)
+  }
+
+  private val collectOffsetMultiCB: AsyncCallback[(Int, Committable)] = getAsyncCallback[(Int, Committable)] {
+    case (count, offset) =>
+      collectOffset(count, offset)
+  }
+
+  private def scheduleCommit(): Unit =
+    scheduleOnce(CommittingProducerSinkStage.CommitNow, stage.committerSettings.maxInterval)
+
+  override protected def onTimer(timerKey: Any): Unit = timerKey match {
+    case CommittingProducerSinkStage.CommitNow => commit("interval")
+  }
+
+  private def collectOffset(count: Int, offset: Committable): Unit = {
+    awaitingProduceResult -= count
+    offsetBatch = offsetBatch.updated(offset)
+    if (offsetBatch.batchSize >= stage.committerSettings.maxBatch) commit("batch size")
+    else if (isClosed(stage.in) && awaitingProduceResult == 0L) commit("upstream closed")
+  }
+
+  private def commit(triggeredBy: String): Unit = {
+    log.debug("commit triggered by {}", triggeredBy)
+    if (offsetBatch.batchSize != 0) {
+      val batchSize = offsetBatch.batchSize
+      offsetBatch
+        .commitScaladsl()
+        .onComplete(t => commitResultCB.invoke(batchSize -> t))(materializer.executionContext)
+      offsetBatch = CommittableOffsetBatch.empty
+    }
+    scheduleCommit()
+  }
+
+  private val commitResultCB: AsyncCallback[(Long, Try[Done])] = getAsyncCallback[(Long, Try[Done])] {
+    case (batchSize, Success(_)) =>
+      awaitingCommitResult -= batchSize
+      checkForCompletion()
+    case (batchSize, Failure(exception)) =>
+      awaitingCommitResult -= batchSize
+      decider(exception) match {
+        case Supervision.Stop =>
+          streamCompletion.failure(exception)
+          failStageCb.invoke(exception)
+        case _ => log.warning("ignoring {}", exception)
+      }
+      checkForCompletion()
+  }
+
+  // ---- handler and completion
+  /** Keeps track of upstream completion signals until this stage shuts down. */
+  private var upstreamCompletionState: Option[Try[Done]] = None
+
+  setHandler(
+    stage.in,
+    new InHandler {
+      override def onPush(): Unit = {
+        produce(grab(stage.in))
+        tryPull(stage.in)
+      }
+
+      override def onUpstreamFinish(): Unit =
+        if (awaitingCommitResult == 0) {
+          completeStage()
+          streamCompletion.success(Done)
+        } else {
+          commit("upstream finish")
+          setKeepGoing(true)
+          upstreamCompletionState = Some(Success(Done))
+        }
+
+      override def onUpstreamFailure(ex: Throwable): Unit =
+        if (awaitingCommitResult == 0) {
+          failStage(ex)
+          streamCompletion.failure(ex)
+        } else {
+          commit("upstream failure")
+          setKeepGoing(true)
+          upstreamCompletionState = Some(Failure(ex))
+        }
+    }
+  )
+
+  private def checkForCompletion(): Unit =
+    if (isClosed(stage.in) && awaitingCommitResult == 0) {
+      upstreamCompletionState match {
+        case Some(Success(_)) =>
+          completeStage()
+          streamCompletion.success(Done)
+        case Some(Failure(ex)) =>
+          failStage(ex)
+          streamCompletion.failure(ex)
+        case None =>
+          val illegal = new IllegalStateException("Stage completed, but there is no info about status")
+          failStage(illegal)
+          streamCompletion.failure(illegal)
+      }
+    }
+
+  override def postStop(): Unit = {
+    log.debug("CommittingProducerSink stopped")
+    closeProducer()
+    super.postStop()
+  }
+
+  private def closeProducer(): Unit =
+    if (producer != null && stage.producerSettings.closeProducerOnStop) {
+      try {
+        // we do not have to check if producer was already closed in send-callback as `flush()` and `close()` are effectively no-ops in this case
+        producer.flush()
+        producer.close(stage.producerSettings.closeTimeout.toMillis, TimeUnit.MILLISECONDS)
+      } catch {
+        case NonFatal(ex) => log.error(ex, "Problem occurred during producer close")
+      }
+    }
+}
+
+private object CommittingProducerSinkStage {
+  val CommitNow = "commit"
+}

--- a/core/src/main/scala/akka/kafka/internal/DeferredProducer.scala
+++ b/core/src/main/scala/akka/kafka/internal/DeferredProducer.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.internal
+
+import akka.annotation.InternalApi
+import akka.dispatch.ExecutionContexts
+import akka.kafka.ProducerSettings
+import akka.stream.stage._
+import akka.util.JavaDurationConverters._
+import org.apache.kafka.clients.producer.Producer
+
+import scala.util.control.NonFatal
+import scala.util.{Failure, Success}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[kafka] trait DeferredProducer[K, V] {
+  self: GraphStageLogic with StageLogging =>
+
+  /** The Kafka producer may be created lazily, assigned via `preStart` in `assignProducer`. */
+  protected var producer: Producer[K, V] = _
+
+  protected def producerSettings: ProducerSettings[K, V]
+  protected def producerAssigned(): Unit
+  protected def closeAndFailStageCb: AsyncCallback[Throwable]
+
+  private def assignProducer(p: Producer[K, V]): Unit = {
+    producer = p
+    producerAssigned()
+  }
+
+  final protected def resolveProducer(): Unit = {
+    val producerFuture = producerSettings.createKafkaProducerAsync()(materializer.executionContext)
+    producerFuture.value match {
+      case Some(Success(p)) => assignProducer(p)
+      case Some(Failure(e)) => failStage(e)
+      case None =>
+        val assign = getAsyncCallback(assignProducer)
+        producerFuture
+          .transform(
+            producer => assign.invoke(producer),
+            e => {
+              log.error(e, "producer creation failed")
+              closeAndFailStageCb.invoke(e)
+              e
+            }
+          )(ExecutionContexts.sameThreadExecutionContext)
+    }
+  }
+
+  protected def closeProducerImmediately(): Unit =
+    if (producer != null) {
+      // Discard unsent ProducerRecords after encountering a send-failure in ProducerStage
+      // https://github.com/akka/alpakka-kafka/pull/318
+      producer.close(java.time.Duration.ZERO)
+    }
+
+  protected def closeProducer(): Unit =
+    if (producerSettings.closeProducerOnStop && producer != null) {
+      try {
+        // we do not have to check if producer was already closed in send-callback as `flush()` and `close()` are effectively no-ops in this case
+        producer.flush()
+        producer.close(producerSettings.closeTimeout.asJava)
+        log.debug("Producer closed")
+      } catch {
+        case NonFatal(ex) => log.error(ex, "Problem occurred during producer close")
+      }
+    }
+
+}

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
@@ -201,7 +201,7 @@ abstract class KafkaSpec(_kafkaPort: Int, val zooKeeperPort: Int, actorSystem: A
 
 }
 
-private class Slf4jToAkkaLoggingAdapter(logger: Logger) extends LoggingAdapter {
+private[kafka] class Slf4jToAkkaLoggingAdapter(logger: Logger) extends LoggingAdapter {
   override def isErrorEnabled: Boolean = logger.isErrorEnabled
   override def isWarningEnabled: Boolean = logger.isWarnEnabled
   override def isInfoEnabled: Boolean = logger.isInfoEnabled

--- a/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
@@ -16,7 +16,6 @@ import akka.kafka.scaladsl.Producer
 import akka.kafka.testkit.ConsumerResultFactory
 import akka.kafka.testkit.scaladsl.{ConsumerControlFactory, Slf4jToAkkaLoggingAdapter}
 import akka.kafka.{CommitterSettings, ConsumerMessage, ProducerMessage, ProducerSettings}
-import akka.stream.ActorAttributes.SupervisionStrategy
 import akka.stream.{ActorAttributes, ActorMaterializer, Supervision}
 import akka.stream.scaladsl.{Keep, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped

--- a/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
@@ -1,0 +1,332 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.internal
+
+import java.util.concurrent.atomic.AtomicLong
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.event.LoggingAdapter
+import akka.kafka.internal.KafkaConsumerActor.Internal
+import akka.kafka.scaladsl.Consumer.DrainingControl
+import akka.kafka.scaladsl.Producer
+import akka.kafka.testkit.ConsumerResultFactory
+import akka.kafka.testkit.scaladsl.{ConsumerControlFactory, Slf4jToAkkaLoggingAdapter}
+import akka.kafka.{CommitterSettings, ConsumerMessage, ProducerMessage, ProducerSettings}
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{Keep, Source}
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
+import akka.testkit.{TestKit, TestProbe}
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.producer._
+import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.serialization.StringSerializer
+import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.slf4j.{Logger, LoggerFactory}
+
+import scala.collection.immutable
+import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
+
+class CommittingProducerSinkSpec(_system: ActorSystem)
+    extends TestKit(_system)
+    with FlatSpecLike
+    with Matchers
+    with BeforeAndAfterAll
+    with ScalaFutures
+    with IntegrationPatience
+    with Eventually {
+
+  import CommittingProducerSinkSpec.FakeConsumer
+
+  def this() = this(ActorSystem())
+
+  override def afterAll(): Unit = shutdown(system)
+
+  val log: Logger = LoggerFactory.getLogger(getClass)
+
+  // used by the .log(...) stream operator
+  implicit val adapter: LoggingAdapter = new Slf4jToAkkaLoggingAdapter(log)
+
+  implicit val materializer = ActorMaterializer()
+  implicit val ec = _system.dispatcher
+
+  val groupId = "group1"
+  val topic = "topic1"
+  val partition = 1
+
+  "committable producer sink" should "produce, and commit after interval" in assertAllStagesStopped {
+    val consumer = FakeConsumer(groupId, topic, startOffset = 1616L)
+
+    val elements = immutable.Seq(
+      consumer.message(partition, "value 1"),
+      consumer.message(partition, "value 2")
+    )
+
+    val producer = new MockProducer[String, String](true, new StringSerializer, new StringSerializer)
+    val producerSettings = ProducerSettings(system, new StringSerializer, new StringSerializer)
+      .withProducer(producer)
+    val commitInterval = 200.millis
+    val committerSettings = CommitterSettings(system).withMaxInterval(commitInterval)
+
+    val control = Source(elements)
+      .concat(Source.maybe) // keep the source alive
+      .viaMat(ConsumerControlFactory.controlFlow())(Keep.right)
+      .map { msg =>
+        ProducerMessage.single(
+          new ProducerRecord("targetTopic", msg.record.key, msg.record.value),
+          msg.committableOffset
+        )
+      }
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(Keep.both)
+      .mapMaterializedValue(DrainingControl.apply)
+      .run()
+
+    consumer.actor.expectNoMessage(commitInterval)
+    val commitMsg = consumer.actor.expectMsgClass(classOf[Internal.Commit])
+    commitMsg.tp shouldBe new TopicPartition(topic, partition)
+    commitMsg.offsetAndMetadata.offset() shouldBe (consumer.startOffset + 2)
+    consumer.actor.reply(Done)
+
+    eventually {
+      producer.history.asScala should have size (2)
+    }
+    control.drainAndShutdown().futureValue shouldBe Done
+  }
+
+  it should "produce, and commit when batch size is reached" in assertAllStagesStopped {
+    val consumer = FakeConsumer(groupId, topic, startOffset = 1616L)
+
+    val elements = immutable.Seq(
+      consumer.message(partition, "value 1"),
+      consumer.message(partition, "value 2")
+    )
+
+    val producer = new MockProducer[String, String](true, new StringSerializer, new StringSerializer)
+    val producerSettings = ProducerSettings(system, new StringSerializer, new StringSerializer)
+      .withProducer(producer)
+    val committerSettings = CommitterSettings(system).withMaxBatch(2L)
+
+    val control = Source(elements)
+      .concat(Source.maybe) // keep the source alive
+      .viaMat(ConsumerControlFactory.controlFlow())(Keep.right)
+      .map { msg =>
+        ProducerMessage.single(
+          new ProducerRecord("targetTopic", msg.record.key, msg.record.value),
+          msg.committableOffset
+        )
+      }
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(Keep.both)
+      .mapMaterializedValue(DrainingControl.apply)
+      .run()
+
+    val commitMsg = consumer.actor.expectMsgClass(500.millis, classOf[Internal.Commit])
+    commitMsg.tp shouldBe new TopicPartition(topic, partition)
+    commitMsg.offsetAndMetadata.offset() shouldBe (consumer.startOffset + 2)
+    consumer.actor.reply(Done)
+
+    eventually {
+      producer.history.asScala should have size (2)
+    }
+    control.drainAndShutdown().futureValue shouldBe Done
+  }
+
+  it should "produce, and commit on completion" in assertAllStagesStopped {
+    val consumer = FakeConsumer(groupId, topic, startOffset = 1616L)
+
+    val elements = immutable.Seq(
+      consumer.message(partition, "value 1"),
+      consumer.message(partition, "value 2")
+    )
+
+    val producer = new MockProducer[String, String](true, new StringSerializer, new StringSerializer)
+    val producerSettings = ProducerSettings(system, new StringSerializer, new StringSerializer)
+      .withProducer(producer)
+    val commitInterval = 5.seconds
+    val committerSettings = CommitterSettings(system).withMaxInterval(commitInterval)
+
+    val control = Source(elements)
+      .viaMat(ConsumerControlFactory.controlFlow())(Keep.right)
+      .map { msg =>
+        ProducerMessage.single(
+          new ProducerRecord("targetTopic", msg.record.key, msg.record.value),
+          msg.committableOffset
+        )
+      }
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(Keep.both)
+      .mapMaterializedValue(DrainingControl.apply)
+      .run()
+
+    val commitMsg = consumer.actor.expectMsgClass(1.second, classOf[Internal.Commit])
+    commitMsg.tp shouldBe new TopicPartition(topic, partition)
+    commitMsg.offsetAndMetadata.offset() shouldBe (consumer.startOffset + 2)
+    consumer.actor.reply(Done)
+
+    eventually {
+      producer.history.asScala should have size (2)
+    }
+    control.drainAndShutdown().futureValue shouldBe Done
+  }
+
+  it should "produce, and commit on delayed completion" in assertAllStagesStopped {
+    val consumer = FakeConsumer(groupId, topic, startOffset = 1616L)
+
+    val elements = immutable.Seq(
+      consumer.message(partition, "value 1"),
+      consumer.message(partition, "value 2")
+    )
+
+    val producer = new MockProducer[String, String](true, new StringSerializer, new StringSerializer)
+    val producerSettings = ProducerSettings(system, new StringSerializer, new StringSerializer)
+      .withProducer(producer)
+    val commitInterval = 5.seconds
+    val committerSettings = CommitterSettings(system).withMaxInterval(commitInterval)
+
+    val control = Source(elements)
+      .concat(Source.maybe) // keep the source alive
+      .idleTimeout(50.millis)
+      .recoverWithRetries(1, {
+        case _ => Source.empty
+      })
+      .viaMat(ConsumerControlFactory.controlFlow())(Keep.right)
+      .map { msg =>
+        ProducerMessage.single(
+          new ProducerRecord("targetTopic", msg.record.key, msg.record.value),
+          msg.committableOffset
+        )
+      }
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(Keep.both)
+      .mapMaterializedValue(DrainingControl.apply)
+      .run()
+
+    val commitMsg = consumer.actor.expectMsgClass(1.second, classOf[Internal.Commit])
+    commitMsg.tp shouldBe new TopicPartition(topic, partition)
+    commitMsg.offsetAndMetadata.offset() shouldBe (consumer.startOffset + 2)
+    consumer.actor.reply(Done)
+
+    eventually {
+      producer.history.asScala should have size (2)
+    }
+    control.drainAndShutdown().futureValue shouldBe Done
+  }
+
+  it should "produce, and commit on upstream failure" in assertAllStagesStopped {
+    val consumer = FakeConsumer(groupId, topic, startOffset = 1616L)
+
+    val elements = immutable.Seq(
+      consumer.message(partition, "value 1"),
+      consumer.message(partition, "value 2")
+    )
+
+    val producer = new MockProducer[String, String](true, new StringSerializer, new StringSerializer)
+    val producerSettings = ProducerSettings(system, new StringSerializer, new StringSerializer)
+      .withProducer(producer)
+    val commitInterval = 5.seconds
+    val committerSettings = CommitterSettings(system).withMaxInterval(commitInterval)
+
+    val control = Source(elements)
+      .concat(Source.maybe) // keep the source alive
+      .idleTimeout(50.millis)
+      .viaMat(ConsumerControlFactory.controlFlow())(Keep.right)
+      .map { msg =>
+        ProducerMessage.single(
+          new ProducerRecord("targetTopic", msg.record.key, msg.record.value),
+          msg.committableOffset
+        )
+      }
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(Keep.both)
+      .mapMaterializedValue(DrainingControl.apply)
+      .run()
+
+    val commitMsg = consumer.actor.expectMsgClass(1.second, classOf[Internal.Commit])
+    commitMsg.tp shouldBe new TopicPartition(topic, partition)
+    commitMsg.offsetAndMetadata.offset() shouldBe (consumer.startOffset + 2)
+    consumer.actor.reply(Done)
+
+    eventually {
+      producer.history.asScala should have size (2)
+    }
+    control.drainAndShutdown().failed.futureValue shouldBe a[java.util.concurrent.TimeoutException]
+  }
+
+  it should "fail for commit timeout" in assertAllStagesStopped {
+    val consumer = FakeConsumer(groupId, topic, startOffset = 1616L)
+
+    val elements = immutable.Seq(
+      consumer.message(partition, "value 1"),
+      consumer.message(partition, "value 2")
+    )
+
+    val producer = new MockProducer[String, String](true, new StringSerializer, new StringSerializer)
+    val producerSettings = ProducerSettings(system, new StringSerializer, new StringSerializer)
+      .withProducer(producer)
+    val committerSettings = CommitterSettings(system).withMaxBatch(2L)
+
+    val control = Source(elements)
+      .concat(Source.maybe)
+      .viaMat(ConsumerControlFactory.controlFlow())(Keep.right)
+      .map { msg =>
+        ProducerMessage.single(
+          new ProducerRecord("targetTopic", msg.record.key, msg.record.value),
+          msg.committableOffset
+        )
+      }
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(Keep.both)
+      .mapMaterializedValue(DrainingControl.apply)
+      .run()
+
+    val commitMsg = consumer.actor.expectMsgClass(classOf[Internal.Commit])
+    commitMsg.tp shouldBe new TopicPartition(topic, partition)
+    commitMsg.offsetAndMetadata.offset() shouldBe (consumer.startOffset + 2)
+
+    eventually {
+      producer.history.asScala should have size (2)
+    }
+    control.drainAndShutdown().failed.futureValue shouldBe an[akka.kafka.CommitTimeoutException]
+  }
+
+  it should "shut down without elements" in assertAllStagesStopped {
+    val producer = new MockProducer[String, String](true, new StringSerializer, new StringSerializer)
+    val producerSettings = ProducerSettings(system, new StringSerializer, new StringSerializer)
+      .withProducer(producer)
+    val committerSettings = CommitterSettings(system).withMaxInterval(1.second)
+
+    val control = Source
+      .maybe[ConsumerMessage.CommittableMessage[String, String]]
+      .viaMat(ConsumerControlFactory.controlFlow())(Keep.right)
+      .map { msg =>
+        ProducerMessage.single(
+          new ProducerRecord("targetTopic", msg.record.key, msg.record.value),
+          msg.committableOffset
+        )
+      }
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(Keep.both)
+      .mapMaterializedValue(DrainingControl.apply)
+      .run()
+
+    control.drainAndShutdown().futureValue shouldBe Done
+  }
+
+}
+
+object CommittingProducerSinkSpec {
+  final case class FakeConsumer(groupId: String, topic: String, startOffset: Long)(implicit system: ActorSystem) {
+    val offset = new AtomicLong(startOffset)
+    val actor = TestProbe("kafkaConsumerActor")
+    val fakeCommitter: KafkaAsyncConsumerCommitterRef =
+      new KafkaAsyncConsumerCommitterRef(actor.ref, 100.millis)(system.dispatcher)
+
+    def message(partition: Int, value: String): ConsumerMessage.CommittableMessage[String, String] =
+      ConsumerResultFactory.committableMessage(
+        new ConsumerRecord(topic, partition, startOffset, "key", value),
+        CommittableOffsetImpl(
+          ConsumerResultFactory.partitionOffset(groupId, topic, partition, offset.getAndIncrement()),
+          "metadata"
+        )(fakeCommitter)
+      )
+  }
+}

--- a/tests/src/test/scala/akka/kafka/scaladsl/CommittableSinkSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/CommittableSinkSpec.scala
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.scaladsl
+
+import akka.Done
+import akka.kafka._
+import akka.kafka.scaladsl.Consumer.DrainingControl
+import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
+import akka.stream.scaladsl.{Keep, Sink, Source}
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.scalatest.concurrent.IntegrationPatience
+
+import scala.collection.immutable
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+class CommittableSinkSpec extends SpecBase with TestcontainersKafkaLike with IntegrationPatience {
+
+  final val Numbers = (1 to 200).map(_.toString)
+  final val partition1 = 1
+
+  "Consumer to producer" must {
+
+    "commit after producing to the target topic" in assertAllStagesStopped {
+      val Messages = Numbers
+      val topic1 = createTopic(1)
+      val targetTopic = createTopic(2)
+      val group1 = createGroupId(1)
+
+      produceString(topic1, Messages)
+
+      val consumerSettings = consumerDefaults.withGroupId(group1)
+
+      val copying = Consumer
+        .sourceWithOffsetContext(consumerSettings, Subscriptions.topics(topic1))
+        .map { record =>
+          ProducerMessage.single(new ProducerRecord(targetTopic, record.key(), record.value()))
+        }
+        .toMat(Producer.committableSinkWithOffsetContext(producerDefaults, committerDefaults))(Keep.both)
+        .mapMaterializedValue(DrainingControl.apply)
+        .run()
+
+      // read copied messages
+      val (_, targetConsumer) = createProbe(consumerSettings, targetTopic)
+      val copied = targetConsumer
+        .request(Messages.size.toLong)
+        .expectNextN(Messages.size.toLong)
+      copied should contain theSameElementsInOrderAs Messages
+      targetConsumer.cancel()
+
+      copying.drainAndShutdown().futureValue shouldBe Done
+
+      // other consumer in the same group should not receive any
+      val (_, sourceConsumer) = createProbe(consumerSettings, topic1)
+      sourceConsumer.request(10).expectNoMessage(5.seconds)
+      sourceConsumer.cancel()
+    }
+
+    "with partitioned source copy all elements" in assertAllStagesStopped {
+      val Messages = Numbers
+      val partitions = 10
+      val topic1 = createTopic(1, partitions)
+      val targetTopic = createTopic(2)
+      val group1 = createGroupId(1)
+
+      produceStringRoundRobin(topic1, Messages)
+
+      val consumerSettings = consumerDefaults.withGroupId(group1)
+
+      val copying = Consumer
+        .committablePartitionedSource(consumerSettings, Subscriptions.topics(topic1))
+        .mapAsyncUnordered(parallelism = partitions) {
+          case (_, source) =>
+            source
+              .map { message =>
+                ProducerMessage.single(new ProducerRecord(targetTopic, message.record.key(), message.record.value()),
+                                       message.committableOffset)
+              }
+              .toMat(Producer.committableSink(producerDefaults, committerDefaults))(Keep.right)
+              .run()
+        }
+        .to(Sink.seq)
+        .run()
+
+      // read copied messages
+      val (_, targetConsumer) = createProbe(consumerSettings, targetTopic)
+      val copied = targetConsumer
+        .request(Messages.size.toLong)
+        .expectNextN(Messages.size.toLong)
+      copied should contain theSameElementsAs Messages
+      targetConsumer.cancel()
+
+      copying.shutdown().futureValue shouldBe Done
+
+      // other consumer in the same group should not receive any
+      val (_, sourceConsumer) = createProbe(consumerSettings, topic1)
+      sourceConsumer.request(10).expectNoMessage(5.seconds)
+      sourceConsumer.cancel()
+    }
+  }
+
+  def produceStringRoundRobin(topic: String, range: immutable.Seq[String]): Future[Done] =
+    Source(range)
+    // NOTE: If no partition is specified but a key is present a partition will be chosen
+    // using a hash of the key. If neither key nor partition is present a partition
+    // will be assigned in a round-robin fashion.
+      .map(n => new ProducerRecord[String, String](topic, n))
+      .runWith(Producer.plainSink(producerDefaults.withProducer(testProducer)))
+
+}

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -116,14 +116,14 @@ class IntegrationSpec extends SpecBase with TestcontainersKafkaLike with Inside 
       val assigned1 = rebalanceActor1.expectMsgClass(classOf[TopicPartitionsAssigned])
       val assigned2 = rebalanceActor2.expectMsgClass(classOf[TopicPartitionsAssigned])
 
-      val PartitionsAssignedMsg1 = TopicPartitionsAssigned(subscription1, Set(allTps(0), allTps(1)))
-      val PartitionsAssignedMsg2 = TopicPartitionsAssigned(subscription2, Set(allTps(2), allTps(3)))
-      (assigned1, assigned2) match {
-        case (PartitionsAssignedMsg1, PartitionsAssignedMsg2) =>
-        case (PartitionsAssignedMsg2, PartitionsAssignedMsg1) =>
-        case (receive1, receive2) =>
+      val Partitions1 = Set(allTps(0), allTps(1))
+      val Partitions2 = Set(allTps(2), allTps(3))
+      (assigned1.topicPartitions, assigned2.topicPartitions) match {
+        case (Partitions1, Partitions2) =>
+        case (Partitions2, Partitions1) =>
+        case (receivePartitions1, receivedPartitions2) =>
           fail(
-            s"The `TopicPartitionsAssigned` messages came differently than expected:\nrebalanceActor1: $receive1\nrebalanceActor2: $receive2"
+            s"The `TopicPartitionsAssigned` contained different topic partitions than expected:\nrebalanceActor1: $receivePartitions1\nrebalanceActor2: $receivedPartitions2"
           )
       }
 

--- a/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
@@ -317,7 +317,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
 
   "Flow per partition" should "Process each assigned partition separately" in assertAllStagesStopped {
     val consumerSettings = consumerDefaults.withGroupId(createGroupId()).withStopTimeout(10.millis)
-    val comitterSettings = committerDefaults
+    val committerSettings = committerDefaults
     val topic = createTopic()
     val maxPartitions = 100
     // #committablePartitionedSource-stream-per-partition
@@ -328,7 +328,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
           source
             .via(businessFlow)
             .map(_.committableOffset)
-            .runWith(Committer.sink(comitterSettings))
+            .runWith(Committer.sink(committerSettings))
       }
       .toMat(Sink.ignore)(Keep.both)
       .mapMaterializedValue(DrainingControl.apply)


### PR DESCRIPTION
## Purpose

Introduce a sink stage which produces to Kafka, batches commit offsets and commits.

## References

References https://github.com/akka/alpakka-kafka/pull/932

## Changes

* New `CommittingProducerSinkStage`
* Unit tests running without a Kafka instance
* Change some places to inject the producer via settings instead

## Background Context

Kafka to Kafka flows with a committable source, a producer and a committer are a quite common setup which became even simpler with the `Producer.committableSink`s added in #932. This new stage replaces that implementation with this all-in-one stage.
