### PR TITLE
Producer: remove unreleased variants; simplify producer passing

### DIFF
--- a/core/src/main/scala/akka/kafka/javadsl/Producer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Producer.scala
@@ -149,15 +149,11 @@ object Producer {
   def committableSinkWithOffsetContext[K, V, IN <: Envelope[K, V, _], C <: Committable](
       producerSettings: ProducerSettings[K, V],
       committerSettings: CommitterSettings
-  ): Sink[akka.japi.Pair[IN, C], CompletionStage[Done]] = {
-    val sink: Sink[Envelope[K, V, C], CompletionStage[Done]] = committableSink(producerSettings, committerSettings)
-    Flow
-      .create[akka.japi.Pair[IN, C]]
-      .map(new akka.japi.function.Function[japi.Pair[IN, C], Envelope[K, V, C]] {
+  ): Sink[akka.japi.Pair[IN, C], CompletionStage[Done]] =
+    committableSink(producerSettings, committerSettings)
+      .contramap(new akka.japi.function.Function[japi.Pair[IN, C], Envelope[K, V, C]] {
         override def apply(p: japi.Pair[IN, C]) = p.first.withPassThrough(p.second)
       })
-      .toMat(sink, Keep.right[NotUsed, CompletionStage[Done]])
-  }
 
   /**
    * Create a flow to publish records to Kafka topics and then pass it on.

--- a/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
@@ -145,12 +145,11 @@ object Producer {
       producerSettings: ProducerSettings[K, V],
       committerSettings: CommitterSettings
   ): Sink[(Envelope[K, V, _], Committable), Future[Done]] =
-    Flow[(Envelope[K, V, _], Committable)]
-      .map {
+    committableSink(producerSettings, committerSettings)
+      .contramap {
         case (env, offset) =>
           env.withPassThrough(offset)
       }
-      .toMat(committableSink(producerSettings, committerSettings))(Keep.right)
 
   /**
    * Create a flow to publish records to Kafka topics and then pass it on.

--- a/core/src/main/scala/akka/kafka/scaladsl/Transactional.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Transactional.scala
@@ -69,12 +69,11 @@ object Transactional {
       settings: ProducerSettings[K, V],
       transactionalId: String
   ): Sink[(Envelope[K, V, NotUsed], PartitionOffset), Future[Done]] =
-    Flow[(Envelope[K, V, NotUsed], PartitionOffset)]
-      .map {
+    sink(settings, transactionalId)
+      .contramap {
         case (env, offset) =>
           env.withPassThrough(offset)
       }
-      .toMat(sink(settings, transactionalId))(Keep.right)
 
   /**
    * Publish records to Kafka topics and then continue the flow. The flow can only be used with a [[Transactional.source]] that

--- a/tests/src/test/java/docs/javadsl/ProducerWithTestcontainersTest.java
+++ b/tests/src/test/java/docs/javadsl/ProducerWithTestcontainersTest.java
@@ -103,7 +103,8 @@ class ProducerWithTestcontainersTest extends TestcontainersKafkaTest {
     final org.apache.kafka.clients.producer.Producer<String, String> kafkaProducer =
         producerSettings.createKafkaProducer();
     // #plainSinkWithProducer
-    ProducerSettings<String, String> settingsWithProducer = producerSettings.withProducer(kafkaProducer);
+    ProducerSettings<String, String> settingsWithProducer =
+        producerSettings.withProducer(kafkaProducer);
 
     CompletionStage<Done> done =
         Source.range(1, 100)


### PR DESCRIPTION
## Purpose

The new `committableSink` variants are unreleased, so the variants passing a producer as a separate parameter can be removed.

## References

Follow up to https://github.com/akka/alpakka-kafka/pull/932 and https://github.com/akka/alpakka-kafka/pull/952

