### PR TITLE
Cleanup KafkaSpec before termination of embedded server

### DIFF
--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/EmbeddedKafkaLike.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/EmbeddedKafkaLike.scala
@@ -22,7 +22,7 @@ trait EmbeddedKafkaLike extends KafkaSpec {
   }
 
   override def cleanUp(): Unit = {
-    EmbeddedKafka.stop()
     super.cleanUp()
+    EmbeddedKafka.stop()
   }
 }


### PR DESCRIPTION
## Purpose

Fix sequence of clean up operations after test with EmbeddedKafka finished. Without this fix embedded Kafka is stopped but producer & adminClient are kept in polling state which produces WARN log messages. `akka.kafka.testkit.scaladsl.TestcontainersKafkaPerClassLike` already has order of operations fixed.

## Changes

- `EmbeddedKafkaLike` switched oprations of cleanup

## Background Context
