### PR TITLE
Kafka 2.4.0-RC1

### DIFF
--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/PerfFixtureHelpers.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/PerfFixtureHelpers.scala
@@ -5,6 +5,7 @@
 
 package akka.kafka.benchmarks
 
+import java.time.Duration
 import java.util
 import java.util.concurrent.TimeUnit
 import java.util.{Arrays, Properties, UUID}
@@ -39,6 +40,8 @@ private[benchmarks] trait PerfFixtureHelpers extends LazyLogging {
 
   val producerTimeout = 6 minutes
   val logPercentStep = 25
+  val adminClientCloseTimeout = Duration.ofSeconds(5)
+  val producerCloseTimeout = adminClientCloseTimeout
 
   def randomId(): String = PerfFixtureHelpers.randomId()
 
@@ -50,7 +53,7 @@ private[benchmarks] trait PerfFixtureHelpers extends LazyLogging {
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaHost)
     val admin = AdminClient.create(props)
     val producer = createTopicAndFill(ft, props, admin)
-    admin.close(5, TimeUnit.SECONDS)
+    admin.close(adminClientCloseTimeout)
     producer
   }
 
@@ -64,9 +67,9 @@ private[benchmarks] trait PerfFixtureHelpers extends LazyLogging {
       logger.info(s"Reusing existing topic $ft")
     } else {
       val producer = createTopicAndFill(ft, props, admin)
-      producer.close(5, TimeUnit.SECONDS)
+      producer.close(producerCloseTimeout)
     }
-    admin.close(5, TimeUnit.SECONDS)
+    admin.close(adminClientCloseTimeout)
   }
 
   private def createTopicAndFill(ft: FilledTopic, props: Properties, admin: AdminClient) = {

--- a/core/src/main/scala/akka/kafka/javadsl/Producer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Producer.scala
@@ -11,7 +11,7 @@ import akka.annotation.ApiMayChange
 import akka.kafka.ConsumerMessage.Committable
 import akka.kafka.ProducerMessage._
 import akka.kafka.{scaladsl, CommitterSettings, ConsumerMessage, ProducerSettings}
-import akka.stream.javadsl.{Flow, FlowWithContext, Keep, Sink}
+import akka.stream.javadsl.{Flow, FlowWithContext, Sink}
 import akka.{japi, Done, NotUsed}
 import org.apache.kafka.clients.producer.ProducerRecord
 

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
@@ -5,12 +5,12 @@
 
 package akka.kafka.testkit.internal
 
+import java.time.Duration
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.{Arrays, Properties}
 
 import scala.jdk.CollectionConverters._
-
 import akka.actor.ActorSystem
 import akka.kafka.testkit.KafkaTestkitSettings
 import akka.kafka.{CommitterSettings, ConsumerSettings, ProducerSettings}
@@ -111,7 +111,7 @@ trait KafkaTestKit {
    */
   def cleanUpAdminClient(): Unit =
     if (adminClientVar != null) {
-      adminClientVar.close(60, TimeUnit.SECONDS)
+      adminClientVar.close(Duration.ofSeconds(60))
       adminClientVar = null
     }
 

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
@@ -5,6 +5,7 @@
 
 package akka.kafka.testkit.scaladsl
 
+import java.time.Duration
 import java.util
 import java.util.concurrent.TimeUnit
 
@@ -56,7 +57,7 @@ abstract class KafkaSpec(_kafkaPort: Int, val zooKeeperPort: Int, actorSystem: A
   }
 
   def cleanUp(): Unit = {
-    if (testProducer ne null) testProducer.close(60, TimeUnit.SECONDS)
+    if (testProducer ne null) testProducer.close(Duration.ofSeconds(60))
     cleanUpAdminClient()
     TestKit.shutdownActorSystem(system)
   }

--- a/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java
@@ -532,9 +532,9 @@ class ConsumerExampleTest extends TestcontainersKafkaTest {
     assertDone(control.isShutdown());
     assertEquals(messageCount, resultOf(control.drainAndShutdown(executor)).size());
 
-    assertThat(revoked.get(), is(Collections.emptySet()));
     assertThat(assigned.get(), hasItem(tp));
     assertThat(stopped.get(), hasItem(tp));
+    assertThat(revoked.get(), hasItem(tp)); // revoke of partitions occurs after stop
   }
 
   @Test

--- a/tests/src/test/scala/akka/kafka/internal/ConsumerDummy.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConsumerDummy.scala
@@ -5,6 +5,8 @@
 
 package akka.kafka.internal
 
+import java.time.Duration
+import java.util
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -48,6 +50,7 @@ abstract class ConsumerDummy[K, V] extends Consumer[K, V] {
   override def commitAsync(offsets: java.util.Map[TopicPartition, OffsetAndMetadata],
                            callback: OffsetCommitCallback): Unit = ???
   override def seek(partition: TopicPartition, offset: Long): Unit = ???
+  override def seek(partition: TopicPartition, offsetAndMetadata: OffsetAndMetadata): Unit = ???
   override def seekToBeginning(partitions: java.util.Collection[TopicPartition]): Unit = ???
   override def seekToEnd(partitions: java.util.Collection[TopicPartition]): Unit = ???
   override def position(partition: TopicPartition): Long = ???
@@ -80,6 +83,10 @@ abstract class ConsumerDummy[K, V] extends Consumer[K, V] {
   override def commitSync(offsets: java.util.Map[TopicPartition, OffsetAndMetadata],
                           timeout: java.time.Duration): Unit = ???
   override def committed(partition: TopicPartition, timeout: java.time.Duration): OffsetAndMetadata = ???
+  override def committed(partitions: util.Set[TopicPartition]): util.Map[TopicPartition, OffsetAndMetadata] = ???
+  override def committed(partitions: util.Set[TopicPartition],
+                         timeout: Duration): util.Map[TopicPartition, OffsetAndMetadata] = ???
+
   override def partitionsFor(topic: String, timeout: java.time.Duration): java.util.List[PartitionInfo] = ???
   override def listTopics(timeout: java.time.Duration): java.util.Map[String, java.util.List[PartitionInfo]] = ???
   override def beginningOffsets(partitions: java.util.Collection[TopicPartition],
@@ -87,5 +94,4 @@ abstract class ConsumerDummy[K, V] extends Consumer[K, V] {
   override def endOffsets(partitions: java.util.Collection[TopicPartition],
                           timeout: java.time.Duration): java.util.Map[TopicPartition, java.lang.Long] = ???
   override def poll(timeout: java.time.Duration): ConsumerRecords[K, V] = ???
-
 }

--- a/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
@@ -736,7 +736,7 @@ object PartitionedSourceSpec {
       log.debug(s"seek($partition, $offset)")
       seeks = seeks.updated(partition, offset)
     }
-    def seek(partition: TopicPartition, offsetAndMeta: OffsetAndMetadata): Unit =
+    override def seek(partition: TopicPartition, offsetAndMeta: OffsetAndMetadata): Unit =
       seek(partition, offsetAndMeta.offset)
     override def paused(): java.util.Set[TopicPartition] = tpsPaused.asJava
     override def pause(partitions: java.util.Collection[TopicPartition]): Unit = {

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -94,7 +94,6 @@ class IntegrationSpec extends SpecBase with TestcontainersKafkaLike with Inside 
         case singleConsumer :: Nil => singleConsumer.assignment.topicPartitions.size == partitions
       }
 
-      rebalanceActor1.expectMsg(TopicPartitionsRevoked(subscription1, Set.empty))
       rebalanceActor1.expectMsg(TopicPartitionsAssigned(subscription1, Set(allTps: _*)))
 
       createAndRunProducer(0L until totalMessages / 2).futureValue
@@ -111,7 +110,6 @@ class IntegrationSpec extends SpecBase with TestcontainersKafkaLike with Inside 
 
       rebalanceActor1.expectMsg(TopicPartitionsRevoked(subscription1, Set(allTps: _*)))
       rebalanceActor1.expectMsg(TopicPartitionsAssigned(subscription1, Set(allTps(0), allTps(1))))
-      rebalanceActor2.expectMsg(TopicPartitionsRevoked(subscription2, Set.empty))
       rebalanceActor2.expectMsg(TopicPartitionsAssigned(subscription2, Set(allTps(2), allTps(3))))
 
       sleep(4.seconds,

--- a/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
@@ -290,7 +290,6 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
 
       producer.futureValue shouldBe Done
 
-      rebalanceActor.expectMsg(TopicPartitionsRevoked(subscription1, Set.empty))
       rebalanceActor.expectMsg(TopicPartitionsAssigned(subscription1, Set(allTps: _*)))
 
       // waits until partitions are assigned across both consumers

--- a/tests/src/test/scala/akka/kafka/scaladsl/RebalanceSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/RebalanceSpec.scala
@@ -52,7 +52,6 @@ class RebalanceSpec extends SpecBase with TestcontainersKafkaLike with Inside {
         .run()
 
       // Await initial partition assignment
-      probe1rebalanceActor.expectMsgClass(classOf[TopicPartitionsRevoked])
       probe1rebalanceActor.expectMsg(
         TopicPartitionsAssigned(probe1subscription,
                                 Set(new TopicPartition(topic1, partition0), new TopicPartition(topic1, partition1)))
@@ -69,12 +68,11 @@ class RebalanceSpec extends SpecBase with TestcontainersKafkaLike with Inside {
         .toMat(TestSink.probe)(Keep.both)
         .run()
 
-      // Await a revoke to both consumers
+      // Await a revoke to consumer 1
       probe1rebalanceActor.expectMsg(
         TopicPartitionsRevoked(probe1subscription,
                                Set(new TopicPartition(topic1, partition0), new TopicPartition(topic1, partition1)))
       )
-      probe2rebalanceActor.expectMsgClass(classOf[TopicPartitionsRevoked])
 
       // the rebalance finishes
       probe1rebalanceActor.expectMsg(

--- a/tests/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
@@ -64,8 +64,8 @@ class RetentionPeriodSpec extends SpecBase with TestcontainersKafkaPerClassLike 
         .expectNextN(25)
         .toSet should be(Set(Done))
 
-      val longerThanRetentionPeriod = 70000L
-      Thread.sleep(longerThanRetentionPeriod)
+      val longerThanRetentionPeriod = 70.seconds
+      sleep(longerThanRetentionPeriod, "Waiting for retention to expire for probe1")
 
       probe1.cancel()
       Await.result(control.isShutdown, remainingOrDefault)
@@ -86,7 +86,7 @@ class RetentionPeriodSpec extends SpecBase with TestcontainersKafkaPerClassLike 
         .request(100)
         .expectNextN(expectedElements)
 
-      Thread.sleep(longerThanRetentionPeriod)
+      sleep(longerThanRetentionPeriod, "Waiting for retention to expire for probe2")
 
       probe2.cancel()
 

--- a/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
@@ -427,9 +427,9 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
     control.shutdown().futureValue shouldBe Done
     result.futureValue should have size 10
     // handler methods were called
-    revokedPromise.future.futureValue shouldBe Set.empty
     assignedPromise.future.futureValue shouldBe tpsSet
     stopPromise.future.futureValue shouldBe tpsSet
+    revokedPromise.future.futureValue shouldBe tpsSet // revoke of partitions occurs after stop
   }
 
   "Shutdown via Consumer.Control" should "work" in assertAllStagesStopped {


### PR DESCRIPTION
## Purpose

_WIP, current binary is RC1_

Update to Kafka client 2.4.0

## Details

* Scala 2.13 support with Embedded Kafka
* Update tests to accommodate new consumer group default assignment strategy
* Abort empty transaction on successful shutdown
* Uses upstream Embedded Kafka 2.4.0 draft PR: https://github.com/embeddedkafka/embedded-kafka/pull/98