### PR TITLE
Scalafmt: don't remove redundant braces

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 2.0.1
+version = 2.1.0
 
 style = defaultWithAlign
 
@@ -9,5 +9,5 @@ danglingParentheses        = true
 docstrings                 = JavaDoc
 indentOperator             = spray
 maxColumn                  = 120
-rewrite.rules              = [RedundantBraces, RedundantParens, SortImports]
+rewrite.rules              = [RedundantParens, SortImports]
 unindentTopLevelOperators  = true

--- a/core/src/main/scala/akka/kafka/internal/CommittableSources.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommittableSources.scala
@@ -35,7 +35,7 @@ private[kafka] final class CommittableSource[K, V](settings: ConsumerSettings[K,
     ) {
   override protected def logic(shape: SourceShape[CommittableMessage[K, V]]): GraphStageLogic with Control =
     new SingleSourceLogic[K, V, CommittableMessage[K, V]](shape, settings, subscription)
-    with CommittableMessageBuilder[K, V] {
+      with CommittableMessageBuilder[K, V] {
       override def metadataFromRecord(record: ConsumerRecord[K, V]): String = _metadataFromRecord(record)
       override def groupId: String = settings.properties(ConsumerConfig.GROUP_ID_CONFIG)
       lazy val committer: KafkaAsyncConsumerCommitterRef = {
@@ -58,7 +58,7 @@ private[kafka] final class SourceWithOffsetContext[K, V](
       shape: SourceShape[(ConsumerRecord[K, V], CommittableOffset)]
   ): GraphStageLogic with Control =
     new SingleSourceLogic[K, V, (ConsumerRecord[K, V], CommittableOffset)](shape, settings, subscription)
-    with OffsetContextBuilder[K, V] {
+      with OffsetContextBuilder[K, V] {
       override def metadataFromRecord(record: ConsumerRecord[K, V]): String = _metadataFromRecord(record)
       override def groupId: String = settings.properties(ConsumerConfig.GROUP_ID_CONFIG)
       lazy val committer: KafkaAsyncConsumerCommitterRef = {
@@ -79,7 +79,7 @@ private[kafka] final class ExternalCommittableSource[K, V](consumer: ActorRef,
     ) {
   override protected def logic(shape: SourceShape[CommittableMessage[K, V]]): GraphStageLogic with Control =
     new ExternalSingleSourceLogic[K, V, CommittableMessage[K, V]](shape, consumer, subscription)
-    with CommittableMessageBuilder[K, V] {
+      with CommittableMessageBuilder[K, V] {
       override def metadataFromRecord(record: ConsumerRecord[K, V]): String = OffsetFetchResponse.NO_METADATA
       override def groupId: String = _groupId
       lazy val committer: KafkaAsyncConsumerCommitterRef = {
@@ -104,7 +104,8 @@ private[kafka] final class CommittableSubSource[K, V](
       shape: SourceShape[(TopicPartition, Source[CommittableMessage[K, V], NotUsed])]
   ): GraphStageLogic with Control =
     new SubSourceLogic[K, V, CommittableMessage[K, V]](shape, settings, subscription, getOffsetsOnAssign, onRevoke)
-    with CommittableMessageBuilder[K, V] with MetricsControl {
+      with CommittableMessageBuilder[K, V]
+      with MetricsControl {
       override def metadataFromRecord(record: ConsumerRecord[K, V]): String = _metadataFromRecord(record)
       override def groupId: String = settings.properties(ConsumerConfig.GROUP_ID_CONFIG)
       lazy val committer: KafkaAsyncConsumerCommitterRef = {

--- a/core/src/main/scala/akka/kafka/internal/PlainSources.scala
+++ b/core/src/main/scala/akka/kafka/internal/PlainSources.scala
@@ -33,7 +33,8 @@ private[kafka] final class ExternalPlainSource[K, V](consumer: ActorRef, subscri
     ) {
   override protected def logic(shape: SourceShape[ConsumerRecord[K, V]]): GraphStageLogic with Control =
     new ExternalSingleSourceLogic[K, V, ConsumerRecord[K, V]](shape, consumer, subscription)
-    with PlainMessageBuilder[K, V] with MetricsControl
+      with PlainMessageBuilder[K, V]
+      with MetricsControl
 }
 
 /**
@@ -52,5 +53,6 @@ private[kafka] final class PlainSubSource[K, V](
       shape: SourceShape[(TopicPartition, Source[ConsumerRecord[K, V], NotUsed])]
   ): GraphStageLogic with Control =
     new SubSourceLogic[K, V, ConsumerRecord[K, V]](shape, settings, subscription, getOffsetsOnAssign, onRevoke)
-    with PlainMessageBuilder[K, V] with MetricsControl
+      with PlainMessageBuilder[K, V]
+      with MetricsControl
 }

--- a/core/src/main/scala/akka/kafka/internal/TransactionalSource.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalSource.scala
@@ -38,7 +38,7 @@ private[kafka] final class TransactionalSource[K, V](consumerSettings: ConsumerS
 
   override protected def logic(shape: SourceShape[TransactionalMessage[K, V]]): GraphStageLogic with Control =
     new TransactionalSourceLogic(shape, TransactionalSource.txConsumerSettings(consumerSettings), subscription)
-    with TransactionalMessageBuilder[K, V]
+      with TransactionalMessageBuilder[K, V]
 
 }
 
@@ -74,7 +74,7 @@ private[kafka] final class TransactionalSourceWithOffsetContext[K, V](consumerSe
       shape: SourceShape[(ConsumerRecord[K, V], PartitionOffset)]
   ): GraphStageLogic with Control =
     new TransactionalSourceLogic(shape, TransactionalSource.txConsumerSettings(consumerSettings), subscription)
-    with TransactionalOffsetContextBuilder[K, V]
+      with TransactionalOffsetContextBuilder[K, V]
 
 }
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.0.0")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.4")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.2.1")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.4.4")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.2.0")


### PR DESCRIPTION
## Purpose

Don't let Scalafmt remove braces that are not strictly necessary (eg. around one-expression methods).

## References

Aligned with https://github.com/akka/alpakka/pull/2016

## Changes

* Use the latest sbt-plugin
* Up the version in the config to 2.1.0 (triggered a little reindentation)
* Remove `RedundantBraces` rewriting

## Background Context

The removing of braces has annoyed me for some time...