### PR TITLE
PartitionAssignmentHandler: add onLost

### DIFF
--- a/core/src/main/mima-filters/1.1.0.backwards.excludes/PR-986-partittionAssignmentHandler-onLost.excludes
+++ b/core/src/main/mima-filters/1.1.0.backwards.excludes/PR-986-partittionAssignmentHandler-onLost.excludes
@@ -1,0 +1,2 @@
+# The `PartitionAssignmentHandler` was not public API in 1.1.0
+ProblemFilters.exclude[ReversedMissingMethodProblem]("akka.kafka.scaladsl.PartitionAssignmentHandler.onLost")

--- a/core/src/main/scala/akka/kafka/Subscriptions.scala
+++ b/core/src/main/scala/akka/kafka/Subscriptions.scala
@@ -6,7 +6,7 @@
 package akka.kafka
 
 import akka.actor.ActorRef
-import akka.annotation.InternalApi
+import akka.annotation.{ApiMayChange, InternalApi}
 import akka.kafka.internal.PartitionAssignmentHelpers
 import akka.kafka.internal.PartitionAssignmentHelpers.EmptyPartitionAssignmentHandler
 import org.apache.kafka.common.TopicPartition
@@ -55,8 +55,10 @@ sealed trait AutoSubscription extends Subscription {
   /** Configure this actor ref to receive [[akka.kafka.ConsumerRebalanceEvent]] signals */
   def withRebalanceListener(ref: ActorRef): AutoSubscription
 
+  @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/985")
   def withPartitionAssignmentHandler(handler: scaladsl.PartitionAssignmentHandler): AutoSubscription
 
+  @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/985")
   def withPartitionAssignmentHandler(handler: javadsl.PartitionAssignmentHandler): AutoSubscription
 
   override protected def renderListener: String =
@@ -84,9 +86,11 @@ object Subscriptions {
     def withRebalanceListener(ref: ActorRef): TopicSubscription =
       copy(rebalanceListener = Some(ref))
 
+    @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/985")
     def withPartitionAssignmentHandler(handler: scaladsl.PartitionAssignmentHandler): AutoSubscription =
       copy(partitionAssignmentHandler = handler)
 
+    @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/985")
     def withPartitionAssignmentHandler(handler: javadsl.PartitionAssignmentHandler): AutoSubscription =
       copy(partitionAssignmentHandler = PartitionAssignmentHelpers.WrappedJava(handler))
 
@@ -104,9 +108,11 @@ object Subscriptions {
     def withRebalanceListener(ref: ActorRef): TopicSubscriptionPattern =
       copy(rebalanceListener = Some(ref))
 
+    @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/985")
     def withPartitionAssignmentHandler(handler: scaladsl.PartitionAssignmentHandler): AutoSubscription =
       copy(partitionAssignmentHandler = handler)
 
+    @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/985")
     def withPartitionAssignmentHandler(handler: javadsl.PartitionAssignmentHandler): AutoSubscription =
       copy(partitionAssignmentHandler = PartitionAssignmentHelpers.WrappedJava(handler))
 

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -694,6 +694,7 @@ import scala.util.control.NonFatal
       with NoSerializationVerificationNeeded {
     override def onPartitionsAssigned(partitions: java.util.Collection[TopicPartition]): Unit
     override def onPartitionsRevoked(partitions: java.util.Collection[TopicPartition]): Unit
+    override def onPartitionsLost(partitions: java.util.Collection[TopicPartition]): Unit
     def postStop(): Unit = ()
   }
 
@@ -730,6 +731,15 @@ import scala.util.control.NonFatal
       partitionAssignmentHandler.onRevoke(revokedTps, restrictedConsumer)
       checkDuration(startTime, "onRevoke")
       commitRefreshing.revoke(revokedTps)
+      rebalanceInProgress = true
+    }
+
+    override def onPartitionsLost(partitions: java.util.Collection[TopicPartition]): Unit = {
+      val lostTps = partitions.asScala.toSet
+      val startTime = System.nanoTime()
+      partitionAssignmentHandler.onLost(lostTps, restrictedConsumer)
+      checkDuration(startTime, "onLost")
+      commitRefreshing.revoke(lostTps)
       rebalanceInProgress = true
     }
 

--- a/core/src/main/scala/akka/kafka/internal/PartitionAssignmentHelpers.scala
+++ b/core/src/main/scala/akka/kafka/internal/PartitionAssignmentHelpers.scala
@@ -29,6 +29,8 @@ object PartitionAssignmentHelpers {
 
     override def onAssign(assignedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = ()
 
+    override def onLost(lostTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = ()
+
     override def onStop(revokedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = ()
 
     override def toString: String = "EmptyPartitionAssignmentHandler"
@@ -42,8 +44,13 @@ object PartitionAssignmentHelpers {
     override def onAssign(assignedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit =
       handler.onAssign(assignedTps.asJava, consumer)
 
+    override def onLost(lostTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit =
+      handler.onLost(lostTps.asJava, consumer)
+
     override def onStop(currentTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit =
       handler.onStop(currentTps.asJava, consumer)
+
+    override def toString: String = s"WrappedJava($handler)"
   }
 
   @InternalApi
@@ -71,6 +78,9 @@ object PartitionAssignmentHelpers {
       }
     }
 
+    override def onLost(lostTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit =
+      onRevoke(lostTps, consumer)
+
     override def onStop(revokedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = ()
 
     override def toString: String = s"AsyncCallbacks($subscription, $sourceActor)"
@@ -87,6 +97,11 @@ object PartitionAssignmentHelpers {
     override def onAssign(assignedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = {
       handler1.onAssign(assignedTps, consumer)
       handler2.onAssign(assignedTps, consumer)
+    }
+
+    override def onLost(lostTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = {
+      handler1.onLost(lostTps, consumer)
+      handler2.onLost(lostTps, consumer)
     }
 
     override def onStop(revokedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = {

--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -127,6 +127,9 @@ import scala.concurrent.{Future, Promise}
       override def onAssign(assignedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit =
         filterRevokedPartitions(lastRevoked -- assignedTps)
 
+      override def onLost(lostTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit =
+        filterRevokedPartitions(lostTps)
+
       override def onStop(revokedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = ()
     }
     new PartitionAssignmentHelpers.Chain(handler, flushMessagesOfRevokedPartitions)

--- a/core/src/main/scala/akka/kafka/internal/TransactionalSources.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalSources.scala
@@ -166,6 +166,9 @@ private[internal] abstract class TransactionalSourceLogic[K, V, Msg](shape: Sour
           consumerActor.tell(KafkaConsumerActor.Internal.Stop, consumerActor)
         }
 
+      override def onLost(lostTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit =
+        onRevoke(lostTps, consumer)
+
       override def onStop(revokedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = ()
     }
     new PartitionAssignmentHelpers.Chain(handler, blockingRevokedCall)

--- a/core/src/main/scala/akka/kafka/internal/TransactionalSources.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalSources.scala
@@ -250,6 +250,9 @@ private[kafka] final class TransactionalSubSource[K, V](
               consumerActor.tell(KafkaConsumerActor.Internal.Stop, stageActor.ref)
             }
 
+          override def onLost(lostTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit =
+            onRevoke(lostTps, consumer)
+
           override def onStop(revokedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = ()
         }
         new PartitionAssignmentHelpers.Chain(handler, blockingRevokedCall)

--- a/core/src/main/scala/akka/kafka/javadsl/PartitionAssignmentHandler.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/PartitionAssignmentHandler.scala
@@ -42,10 +42,10 @@ trait PartitionAssignmentHandler {
   def onAssign(assignedTps: java.util.Set[TopicPartition], consumer: RestrictedConsumer): Unit
 
   /**
-   * Called when partitions have been reassigned to a different consumer.
+   * Called when partition metadata has changed and partitions no longer exist.  This can occur if a topic is deleted or if the leader's metadata is stale.
    * See [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener#onPartitionsLost]]
    *
-   * @param lostTps The list of partitions that used to be assigned to this consumer but now get assigned to a different consumer
+   * @param lostTps The list of partitions that are no longer valid
    * @param consumer The [[akka.kafka.RestrictedConsumer]] gives some access to the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
    */
   def onLost(lostTps: java.util.Set[TopicPartition], consumer: RestrictedConsumer): Unit

--- a/core/src/main/scala/akka/kafka/javadsl/PartitionAssignmentHandler.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/PartitionAssignmentHandler.scala
@@ -22,7 +22,7 @@ import org.apache.kafka.common.TopicPartition
  * This complements the methods of Kafka's [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener ConsumerRebalanceListener]] with
  * an `onStop` callback which is called before `Consumer.close`.
  */
-@ApiMayChange
+@ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/985")
 trait PartitionAssignmentHandler {
 
   /**
@@ -40,6 +40,15 @@ trait PartitionAssignmentHandler {
    * @param consumer The [[akka.kafka.RestrictedConsumer]] gives some access to the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
    */
   def onAssign(assignedTps: java.util.Set[TopicPartition], consumer: RestrictedConsumer): Unit
+
+  /**
+   * Called when partitions have been reassigned to a different consumer.
+   * See [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener#onPartitionsLost]]
+   *
+   * @param lostTps The list of partitions that used to be assigned to this consumer but now get assigned to a different consumer
+   * @param consumer The [[akka.kafka.RestrictedConsumer]] gives some access to the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
+   */
+  def onLost(lostTps: java.util.Set[TopicPartition], consumer: RestrictedConsumer): Unit
 
   /**
    * Called before a consumer is closed.

--- a/core/src/main/scala/akka/kafka/scaladsl/PartitionAssignmentHandler.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/PartitionAssignmentHandler.scala
@@ -42,10 +42,10 @@ trait PartitionAssignmentHandler {
   def onAssign(assignedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit
 
   /**
-   * Called when partitions have been reassigned to a different consumer.
+   * Called when partition metadata has changed and partitions no longer exist.  This can occur if a topic is deleted or if the leader's metadata is stale.
    * See [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener#onPartitionsLost]]
    *
-   * @param lostTps The list of partitions that used to be assigned to this consumer but now get assigned to a different consumer
+   * @param lostTps The list of partitions that are no longer valid
    * @param consumer The [[akka.kafka.RestrictedConsumer]] gives some access to the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
    */
   def onLost(lostTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit

--- a/core/src/main/scala/akka/kafka/scaladsl/PartitionAssignmentHandler.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/PartitionAssignmentHandler.scala
@@ -22,7 +22,7 @@ import org.apache.kafka.common.TopicPartition
  * This complements the methods of Kafka's [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener ConsumerRebalanceListener]] with
  * an `onStop` callback which is called before `Consumer.close`.
  */
-@ApiMayChange
+@ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/985")
 trait PartitionAssignmentHandler {
 
   /**
@@ -40,6 +40,15 @@ trait PartitionAssignmentHandler {
    * @param consumer The [[akka.kafka.RestrictedConsumer]] gives some access to the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
    */
   def onAssign(assignedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit
+
+  /**
+   * Called when partitions have been reassigned to a different consumer.
+   * See [[org.apache.kafka.clients.consumer.ConsumerRebalanceListener#onPartitionsLost]]
+   *
+   * @param lostTps The list of partitions that used to be assigned to this consumer but now get assigned to a different consumer
+   * @param consumer The [[akka.kafka.RestrictedConsumer]] gives some access to the internally used [[org.apache.kafka.clients.consumer.Consumer Consumer]]
+   */
+  def onLost(lostTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit
 
   /**
    * Called before a consumer is closed.

--- a/docs/src/main/paradox/consumer-rebalance.md
+++ b/docs/src/main/paradox/consumer-rebalance.md
@@ -12,10 +12,17 @@ Alpakka Kafka allows to react to the Kafka broker's balancing of partitions with
 
 Kafka balances partitions between all consumers within a consumer group. When new consumers join or leave the group partitions are revoked from and assigned to those consumers.
 
-Alpakka Kafka's @apidoc[PartitionAssignmentHandler] expects three callbacks to be implemented, all are called with a set of @javadoc[TopicPartition](org.apache.kafka.common.TopicPartition)s and a reference to the @apidoc[RestrictedConsumer] which allows some access to the Kafka @javadoc[Consumer](org.apache.kafka.clients.consumer.Consumer) instance used internally by Alpakka Kafka.
+@@@ note { title="API may change" }
+This @apidoc[PartitionAssignmentHandler] API was introduced in Alpakka Kafka 2.0.0 and may still be subject to change.
+
+Please give input on its usefulness in [Issue #985](https://github.com/akka/alpakka-kafka/issues/985).
+@@@
+
+Alpakka Kafka's @apidoc[PartitionAssignmentHandler] expects callbacks to be implemented, all are called with a set of @javadoc[TopicPartition](org.apache.kafka.common.TopicPartition)s and a reference to the @apidoc[RestrictedConsumer] which allows some access to the Kafka @javadoc[Consumer](org.apache.kafka.clients.consumer.Consumer) instance used internally by Alpakka Kafka.
 
 1. `onRevoke` is called when the Kafka broker revokes partitions from this consumer
 1. `onAssign` is called when the Kafka broker assigns partitions to this consumer
+1. `onLost` is called when the Kafka broker has revoked partitions and already assigned them to a different consumer
 1. `onStop` is called when the Alpakka Kafka consumer source is about to stop
 
 Rebalancing starts with revoking partitions from all consumers in a consumer group and assigning all partitions to consumers in a second phase. During rebalance no consumer within that consumer group receives any messages.

--- a/docs/src/main/paradox/consumer-rebalance.md
+++ b/docs/src/main/paradox/consumer-rebalance.md
@@ -22,7 +22,7 @@ Alpakka Kafka's @apidoc[PartitionAssignmentHandler] expects callbacks to be impl
 
 1. `onRevoke` is called when the Kafka broker revokes partitions from this consumer
 1. `onAssign` is called when the Kafka broker assigns partitions to this consumer
-1. `onLost` is called when the Kafka broker has revoked partitions and already assigned them to a different consumer
+1. `onLost` is called when partition metadata has changed and partitions no longer exist.  This can occur if a topic is deleted or if the leader's metadata is stale.
 1. `onStop` is called when the Alpakka Kafka consumer source is about to stop
 
 Rebalancing starts with revoking partitions from all consumers in a consumer group and assigning all partitions to consumers in a second phase. During rebalance no consumer within that consumer group receives any messages.

--- a/docs/src/main/paradox/consumer-rebalance.md
+++ b/docs/src/main/paradox/consumer-rebalance.md
@@ -22,7 +22,7 @@ Alpakka Kafka's @apidoc[PartitionAssignmentHandler] expects callbacks to be impl
 
 1. `onRevoke` is called when the Kafka broker revokes partitions from this consumer
 1. `onAssign` is called when the Kafka broker assigns partitions to this consumer
-1. `onLost` is called when partition metadata has changed and partitions no longer exist.  This can occur if a topic is deleted or if the leader's metadata is stale.
+1. `onLost` is called when partition metadata has changed and partitions no longer exist.  This can occur if a topic is deleted or if the leader's metadata is stale. For details see [KIP-429 Incremental Rebalance Protocol](https://cwiki.apache.org/confluence/display/KAFKA/KIP-429%3A+Kafka+Consumer+Incremental+Rebalance+Protocol).
 1. `onStop` is called when the Alpakka Kafka consumer source is about to stop
 
 Rebalancing starts with revoking partitions from all consumers in a consumer group and assigning all partitions to consumers in a second phase. During rebalance no consumer within that consumer group receives any messages.

--- a/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java
@@ -511,6 +511,8 @@ class ConsumerExampleTest extends TestcontainersKafkaTest {
             // #partitionAssignmentHandler
           }
 
+          public void onLost(Set<TopicPartition> lostTps, RestrictedConsumer consumer) {}
+
           public void onStop(Set<TopicPartition> currentTps, RestrictedConsumer consumer) {
             // #partitionAssignmentHandler
             stopped.set(currentTps);

--- a/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
@@ -406,6 +406,11 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
         assignedPromise.success(assignedTps)
 
       // #partitionAssignmentHandler
+      override def onLost(lostTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = // ???
+        // #partitionAssignmentHandler
+        ???
+
+      // #partitionAssignmentHandler
       override def onStop(currentTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = // ???
         // #partitionAssignmentHandler
         stopPromise.success(currentTps)


### PR DESCRIPTION
## Purpose

Propagate the `ConsumerRebalanceListener.onPartitionsLost` introduced in the Kafka 2.4.0 client to Alpakka Kafka's `PartitionAssignementHandler`.

## References

References #982

## Changes

* add `onLost` to `PartitionAssignementHandler` (and its internal implementations)
* amend `PartitionAssignementHandler` with links to #985

