### PR TITLE
Stage Logic and Actor logging with ID

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/BaseSingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/BaseSingleSourceLogic.scala
@@ -11,7 +11,7 @@ import akka.kafka.Subscriptions.{Assignment, AssignmentOffsetsForTimes, Assignme
 import akka.kafka.{ConsumerFailed, ManualSubscription}
 import akka.stream.SourceShape
 import akka.stream.stage.GraphStageLogic.StageActor
-import akka.stream.stage.{GraphStageLogic, OutHandler, StageLogging}
+import akka.stream.stage.{GraphStageLogic, OutHandler}
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.TopicPartition
 
@@ -28,7 +28,7 @@ import scala.concurrent.{ExecutionContext, Future}
 ) extends GraphStageLogic(shape)
     with PromiseControl
     with MetricsControl
-    with StageLogging
+    with StageIdLogging
     with MessageBuilder[K, V, Msg] {
 
   override protected def executionContext: ExecutionContext = materializer.executionContext

--- a/core/src/main/scala/akka/kafka/internal/CommittingProducerSinkStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommittingProducerSinkStage.scala
@@ -47,7 +47,7 @@ private final class CommittingProducerSinkStageLogic[K, V, IN <: Envelope[K, V, 
     stage: CommittingProducerSinkStage[K, V, IN],
     inheritedAttributes: Attributes
 ) extends TimerGraphStageLogic(stage.shape)
-    with StageLogging
+    with StageIdLogging
     with DeferredProducer[K, V] {
 
   import CommittingProducerSinkStage._

--- a/core/src/main/scala/akka/kafka/internal/DefaultProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/DefaultProducerStage.scala
@@ -43,7 +43,7 @@ private class DefaultProducerStageLogic[K, V, P, IN <: Envelope[K, V, P], OUT <:
     stage: ProducerStage[K, V, P, IN, OUT],
     inheritedAttributes: Attributes
 ) extends TimerGraphStageLogic(stage.shape)
-    with StageLogging
+    with StageIdLogging
     with DeferredProducer[K, V]
     with MessageCallback[K, V, P]
     with ProducerCompletionState {

--- a/core/src/main/scala/akka/kafka/internal/DeferredProducer.scala
+++ b/core/src/main/scala/akka/kafka/internal/DeferredProducer.scala
@@ -20,7 +20,7 @@ import scala.util.{Failure, Success}
  */
 @InternalApi
 private[kafka] trait DeferredProducer[K, V] {
-  self: GraphStageLogic with StageLogging =>
+  self: GraphStageLogic with StageIdLogging =>
 
   /** The Kafka producer may be created lazily, assigned via `preStart` in `assignProducer`. */
   protected var producer: Producer[K, V] = _

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -13,7 +13,6 @@ import akka.Done
 import akka.actor.Status.Failure
 import akka.actor.{
   Actor,
-  ActorLogging,
   ActorRef,
   DeadLetterSuppression,
   NoSerializationVerificationNeeded,
@@ -205,7 +204,7 @@ import scala.util.control.NonFatal
 @InternalApi final private[kafka] class KafkaConsumerActor[K, V](owner: Option[ActorRef],
                                                                  _settings: ConsumerSettings[K, V])
     extends Actor
-    with ActorLogging
+    with ActorIdLogging
     with Timers
     with Stash {
   import KafkaConsumerActor.Internal._

--- a/core/src/main/scala/akka/kafka/internal/LoggingWithId.scala
+++ b/core/src/main/scala/akka/kafka/internal/LoggingWithId.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.internal
+
+import akka.actor.{Actor, ActorLogging}
+import akka.event.LoggingAdapter
+import akka.stream.stage.{GraphStageLogic, StageLogging}
+
+/**
+ * Generate a short random UID for something.
+ */
+private[internal] trait InstanceId {
+  val id: String = java.util.UUID.randomUUID().toString.take(5)
+}
+
+/**
+ * Override akka streams [[StageLogging]] to include an ID from [[InstanceId]] as a prefix to each logging statement.
+ */
+private[internal] trait StageIdLogging extends StageLogging with InstanceId { self: GraphStageLogic =>
+  private[this] var _log: LoggingAdapter = _
+  override def log: LoggingAdapter = {
+    if (_log eq null) {
+      _log = new LoggingAdapterWithId(super.log, id)
+    }
+    _log
+  }
+}
+
+/**
+ * Override akka classic [[ActorLogging]] to include an ID from [[InstanceId]] as a prefix to each logging statement.
+ */
+private[internal] trait ActorIdLogging extends ActorLogging with InstanceId { this: Actor =>
+  private[this] var _log: LoggingAdapter = _
+  override def log: LoggingAdapter = {
+    if (_log eq null) {
+      _log = new LoggingAdapterWithId(super.log, id)
+    }
+    _log
+  }
+}
+
+private[internal] final class LoggingAdapterWithId(logger: LoggingAdapter, id: String) extends LoggingAdapter {
+  private val idPrefix: String = s"[$id] "
+  private def msgWithId(message: String): String = idPrefix + message
+
+  override protected def notifyError(message: String): Unit = logger.error(msgWithId(message))
+  override protected def notifyError(cause: Throwable, message: String): Unit = logger.error(msgWithId(message), cause)
+  override protected def notifyWarning(message: String): Unit = logger.warning(msgWithId(message))
+  override protected def notifyInfo(message: String): Unit = logger.info(msgWithId(message))
+  override protected def notifyDebug(message: String): Unit = logger.debug(msgWithId(message))
+
+  override def isErrorEnabled: Boolean = logger.isErrorEnabled
+  override def isWarningEnabled: Boolean = logger.isWarningEnabled
+  override def isInfoEnabled: Boolean = logger.isInfoEnabled
+  override def isDebugEnabled: Boolean = logger.isDebugEnabled
+}

--- a/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
@@ -16,7 +16,7 @@ import akka.kafka.scaladsl.Consumer.Control
 import akka.pattern.{ask, AskTimeoutException}
 import akka.stream.scaladsl.Source
 import akka.stream.stage.GraphStageLogic.StageActor
-import akka.stream.stage.{StageLogging, _}
+import akka.stream.stage._
 import akka.stream.{ActorMaterializerHelper, Attributes, Outlet, SourceShape}
 import akka.util.Timeout
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -44,7 +44,7 @@ private abstract class SubSourceLogic[K, V, Msg](
     with PromiseControl
     with MetricsControl
     with MessageBuilder[K, V, Msg]
-    with StageLogging {
+    with StageIdLogging {
   import SubSourceLogic._
 
   val consumerPromise = Promise[ActorRef]
@@ -293,7 +293,7 @@ private final class SubSourceStage[K, V, Msg](
   val shape = new SourceShape(out)
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
-    new GraphStageLogic(shape) with PromiseControl with MetricsControl with StageLogging {
+    new GraphStageLogic(shape) with PromiseControl with MetricsControl with StageIdLogging {
       override def executionContext: ExecutionContext = materializer.executionContext
       override def consumerFuture: Future[ActorRef] = Future.successful(consumerActor)
       val shape = stage.shape

--- a/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
@@ -98,7 +98,7 @@ private final class TransactionalProducerStageLogic[K, V, P](
     stage: TransactionalProducerStage[K, V, P],
     inheritedAttributes: Attributes
 ) extends DefaultProducerStageLogic[K, V, P, Envelope[K, V, P], Results[K, V, P]](stage, inheritedAttributes)
-    with StageLogging
+    with StageIdLogging
     with MessageCallback[K, V, P]
     with ProducerCompletionState {
 


### PR DESCRIPTION
## Purpose

Prefix each Akka Stream graph stage logic and `KafkaConsumerActor` log statement with a 5 character UID to make it easier to troubleshoot logging when multiple streams or partitioned sources are being used.

## References

* Issue: #990 

## Changes

* Update all stage logics with `StageIdLogging`
* Update `KafkaConsumerActor` with `ActorIdLogging`

## Background Context

I used something like this to troubleshoot problems with partitioned sources and the transactional partitioned source PRs (#930)
