### PR TITLE
Tests: capture logging to show it for failed tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ val embeddedKafka = "io.github.seglo" %% "embedded-kafka" % embeddedKafkaVersion
 val embeddedKafkaSchemaRegistry = "5.1.1"
 val kafkaVersionForDocs = "24"
 val scalatestVersion = "3.0.8"
-val testcontainersVersion = "1.12.2"
+val testcontainersVersion = "1.12.4"
 val slf4jVersion = "1.7.26"
 val confluentAvroSerializerVersion = "5.0.3"
 
@@ -29,8 +29,8 @@ val confluentAvroSerializerVersion = "5.0.3"
 val silencer = {
   val Version = "1.4.4"
   Seq(
-    compilerPlugin("com.github.ghik" % "silencer-plugin" % Version cross CrossVersion.full),
-    "com.github.ghik" % "silencer-lib" % Version % Provided cross CrossVersion.full
+    compilerPlugin("com.github.ghik" % "silencer-plugin" % Version cross CrossVersion.patch),
+    "com.github.ghik" % "silencer-lib" % Version % Provided cross CrossVersion.patch
   )
 }
 
@@ -203,7 +203,7 @@ lazy val core = project
         "com.typesafe.akka" %% "akka-stream" % akkaVersion,
         "com.typesafe.akka" %% "akka-discovery" % akkaVersion % Provided,
         "org.apache.kafka" % "kafka-clients" % kafkaVersion,
-        "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.1"
+        "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.2"
       ) ++ silencer,
     Compile / compile / scalacOptions += "-P:silencer:globalFilters=[import scala.collection.compat._]",
     mimaPreviousArtifacts := Set(
@@ -221,6 +221,7 @@ lazy val testkit = project
   .settings(
     name := "akka-stream-kafka-testkit",
     AutomaticModuleName.settings("akka.stream.alpakka.kafka.testkit"),
+    JupiterKeys.junitJupiterVersion := "5.5.2",
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion,
         "org.testcontainers" % "kafka" % testcontainersVersion % Provided,

--- a/tests/src/it/resources/logback-test.xml
+++ b/tests/src/it/resources/logback-test.xml
@@ -12,7 +12,19 @@
         </encoder>
     </appender>
 
-    <logger name="akka" level="WARN"/>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="CapturingAppender" class="akka.kafka.tests.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
     <logger name="akka.kafka" level="DEBUG"/>
     <logger name="docs.scaladsl" levle="DEBUG"/>
 
@@ -21,6 +33,14 @@
 
     <logger name="kafka" level="WARN"/>
     <logger name="org.apache.kafka" level="WARN"/>
+    <!-- Useful log levels for debugging rebalancing
+    <logger name="org.apache.kafka" level="INFO"/>
+    <logger name="org.apache.kafka.clients.consumer" level="DEBUG"/>
+    <logger name="org.apache.kafka.clients.consumer.KafkaConsumer" level="INFO"/>
+    <logger name="org.apache.kafka.clients.consumer.internals" level="INFO"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" level="INFO"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.Fetcher" level="INFO"/>
+    -->
     <logger name="org.apache.kafka.common.utils.AppInfoParser" level="ERROR"/>
     <logger name="org.apache.kafka.clients.NetworkClient" level="ERROR"/>
 
@@ -28,7 +48,7 @@
     <logger name="org.testcontainers" level="INFO"/>
 
     <root level="DEBUG">
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
-        <!--appender-ref ref="STDOUT" /-->
     </root>
 </configuration>

--- a/tests/src/test/java/docs/javadsl/AssignmentTest.java
+++ b/tests/src/test/java/docs/javadsl/AssignmentTest.java
@@ -17,6 +17,7 @@ import akka.kafka.javadsl.Consumer;
 import akka.kafka.testkit.javadsl.EmbeddedKafkaJunit4Test;
 // #testkit
 import akka.kafka.javadsl.Producer;
+import akka.kafka.tests.javadsl.LogCapturingJunit4;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.javadsl.Sink;
@@ -29,6 +30,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 // #testkit
 import org.junit.AfterClass;
+import org.junit.Rule;
 import org.junit.Test;
 // #testkit
 
@@ -43,6 +45,8 @@ import static org.junit.Assert.assertEquals;
 // #testkit
 
 public class AssignmentTest extends EmbeddedKafkaJunit4Test {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static final ActorSystem sys = ActorSystem.create("AssignmentTest");
   private static final Materializer mat = ActorMaterializer.create(sys);

--- a/tests/src/test/java/docs/javadsl/AssignmentWithTestcontainersTest.java
+++ b/tests/src/test/java/docs/javadsl/AssignmentWithTestcontainersTest.java
@@ -16,6 +16,7 @@ import akka.kafka.javadsl.Consumer;
 import akka.kafka.testkit.javadsl.TestcontainersKafkaJunit4Test;
 // #testkit
 import akka.kafka.javadsl.Producer;
+import akka.kafka.tests.javadsl.LogCapturingJunit4;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.javadsl.Sink;
@@ -30,6 +31,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.junit.AfterClass;
 import org.junit.Test;
 // #testkit
+import org.junit.Rule;
 
 import java.util.Arrays;
 import java.util.List;
@@ -51,6 +53,8 @@ public class AssignmentWithTestcontainersTest extends TestcontainersKafkaJunit4T
   }
 
   // #testkit
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void mustConsumeFromTheSpecifiedSingleTopic() throws Exception {

--- a/tests/src/test/java/docs/javadsl/AtLeastOnceTest.java
+++ b/tests/src/test/java/docs/javadsl/AtLeastOnceTest.java
@@ -11,6 +11,7 @@ import static org.junit.Assert.*;
 import akka.NotUsed;
 import akka.actor.ActorSystem;
 import akka.kafka.testkit.javadsl.TestcontainersKafkaJunit4Test;
+import akka.kafka.tests.javadsl.LogCapturingJunit4;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.javadsl.Keep;
@@ -39,6 +40,8 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 // #oneToMany #oneToConditional
 
 public class AtLeastOnceTest extends TestcontainersKafkaJunit4Test {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static final ActorSystem system = ActorSystem.create("AtLeastOnceTest");
   private static final Materializer materializer = ActorMaterializer.create(system);

--- a/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java
@@ -18,6 +18,7 @@ import akka.kafka.javadsl.Consumer;
 import akka.kafka.javadsl.Producer;
 import akka.kafka.javadsl.PartitionAssignmentHandler;
 import akka.kafka.testkit.javadsl.TestcontainersKafkaTest;
+import akka.kafka.tests.javadsl.LogCapturingExtension;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.javadsl.*;
@@ -34,6 +35,7 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -47,12 +49,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-
 import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.*;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(LogCapturingExtension.class)
 class ConsumerExampleTest extends TestcontainersKafkaTest {
 
   private static final ActorSystem system = ActorSystem.create("ConsumerExampleTest");

--- a/tests/src/test/java/docs/javadsl/FetchMetadataTest.java
+++ b/tests/src/test/java/docs/javadsl/FetchMetadataTest.java
@@ -11,6 +11,7 @@ import akka.kafka.ConsumerSettings;
 import akka.kafka.KafkaConsumerActor;
 import akka.kafka.Metadata;
 import akka.kafka.testkit.javadsl.TestcontainersKafkaJunit4Test;
+import akka.kafka.tests.javadsl.LogCapturingJunit4;
 import akka.pattern.Patterns;
 import java.time.Duration;
 import java.util.List;
@@ -26,11 +27,14 @@ import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.testkit.javadsl.TestKit;
 import org.junit.AfterClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static junit.framework.TestCase.assertTrue;
 
 public class FetchMetadataTest extends TestcontainersKafkaJunit4Test {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static final ActorSystem sys = ActorSystem.create("FetchMetadataTest");
   private static final Materializer mat = ActorMaterializer.create(sys);

--- a/tests/src/test/java/docs/javadsl/MetadataClientTest.java
+++ b/tests/src/test/java/docs/javadsl/MetadataClientTest.java
@@ -15,6 +15,7 @@ import akka.stream.Materializer;
 import akka.testkit.javadsl.TestKit;
 import akka.util.Timeout;
 // #metadataClient
+import akka.kafka.tests.javadsl.LogCapturingJunit4;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.hamcrest.core.IsInstanceOf;
@@ -39,6 +40,9 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.core.Is.is;
 
 public class MetadataClientTest extends TestcontainersKafkaJunit4Test {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+
   private static final ActorSystem sys = ActorSystem.create("MetadataClientTest");
   private static final Materializer mat = ActorMaterializer.create(sys);
   private static final Executor executor = Executors.newSingleThreadExecutor();

--- a/tests/src/test/java/docs/javadsl/ProducerExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/ProducerExampleTest.java
@@ -13,6 +13,7 @@ import akka.kafka.javadsl.Producer;
 // #testkit
 import akka.kafka.testkit.javadsl.EmbeddedKafkaTest;
 // #testkit
+import akka.kafka.tests.javadsl.LogCapturingExtension;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.javadsl.Source;
@@ -24,6 +25,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 // #testkit
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
 // #testkit
 
 import java.util.List;
@@ -34,6 +36,9 @@ import static org.junit.Assert.assertEquals;
 // #testkit
 
 @TestInstance(Lifecycle.PER_CLASS)
+// #testkit
+@ExtendWith(LogCapturingExtension.class)
+// #testkit
 class ProducerExampleTest extends EmbeddedKafkaTest {
 
   private static final ActorSystem system = ActorSystem.create("ProducerExampleTest");

--- a/tests/src/test/java/docs/javadsl/ProducerWithTestcontainersTest.java
+++ b/tests/src/test/java/docs/javadsl/ProducerWithTestcontainersTest.java
@@ -13,6 +13,7 @@ import akka.kafka.javadsl.Producer;
 // #testkit
 import akka.kafka.testkit.javadsl.TestcontainersKafkaTest;
 // #testkit
+import akka.kafka.tests.javadsl.LogCapturingExtension;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.javadsl.Sink;
@@ -28,6 +29,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 // #testkit
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
+import org.junit.jupiter.api.extension.ExtendWith;
 // #testkit
 
 import java.util.Arrays;
@@ -41,6 +43,9 @@ import static org.junit.Assert.assertFalse;
 // #testkit
 
 @TestInstance(Lifecycle.PER_CLASS)
+// #testkit
+@ExtendWith(LogCapturingExtension.class)
+// #testkit
 class ProducerWithTestcontainersTest extends TestcontainersKafkaTest {
 
   private static final ActorSystem system = ActorSystem.create();

--- a/tests/src/test/java/docs/javadsl/TestkitSamplesTest.java
+++ b/tests/src/test/java/docs/javadsl/TestkitSamplesTest.java
@@ -14,6 +14,7 @@ import akka.kafka.ConsumerMessage;
 import akka.kafka.ProducerMessage;
 import akka.kafka.javadsl.Committer;
 import akka.kafka.javadsl.Consumer;
+import akka.kafka.tests.javadsl.LogCapturingJunit4;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.javadsl.Flow;
@@ -23,6 +24,7 @@ import akka.testkit.javadsl.TestKit;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.AfterClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import static org.junit.Assert.assertThat;
@@ -40,6 +42,8 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
 public class TestkitSamplesTest {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static final ActorSystem sys = ActorSystem.create("TestkitSamplesTest");
   private static final Materializer mat = ActorMaterializer.create(sys);

--- a/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java
@@ -12,6 +12,7 @@ import akka.kafka.*;
 import akka.kafka.javadsl.Consumer;
 import akka.kafka.javadsl.Transactional;
 import akka.kafka.testkit.javadsl.TestcontainersKafkaJunit4Test;
+import akka.kafka.tests.javadsl.LogCapturingJunit4;
 import akka.stream.ActorMaterializer;
 import akka.stream.Materializer;
 import akka.stream.javadsl.*;
@@ -19,6 +20,7 @@ import akka.testkit.javadsl.TestKit;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.AfterClass;
+import org.junit.Rule;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -31,6 +33,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.Assert.assertEquals;
 
 public class TransactionsExampleTest extends TestcontainersKafkaJunit4Test {
+
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static final ActorSystem system = ActorSystem.create("TransactionsExampleTest");
   private static final Materializer materializer = ActorMaterializer.create(system);

--- a/tests/src/test/resources/logback-test.xml
+++ b/tests/src/test/resources/logback-test.xml
@@ -13,7 +13,13 @@
         </encoder>
     </appender>
 
-    <logger name="akka" level="WARN"/>
+    <appender name="CapturingAppender" class="akka.kafka.tests.CapturingAppender"/>
+
+    <logger name="akka.kafka.tests.CapturingAppenderDelegate">
+        <appender-ref ref="STDOUT"/>
+    </logger>
+
+    <logger name="akka" level="DEBUG"/>
     <logger name="akka.kafka" level="DEBUG"/>
 
     <logger name="org.apache.zookeeper" level="WARN"/>
@@ -43,7 +49,7 @@
     <logger name="com.github.dockerjava" level="WARN"/>
 
     <root level="DEBUG">
-        <!-- appender-ref ref="STDOUT" /-->
+        <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
 

--- a/tests/src/test/resources/logback-test.xml
+++ b/tests/src/test/resources/logback-test.xml
@@ -42,15 +42,12 @@
     <logger name="org.jboss" level="WARN"/>
     <logger name="org.glassfish" level="WARN"/>
     <logger name="io.confluent" level="WARN"/>
-    <logger name="org.testcontainers" level="WARN"/>
-    <logger name="com.github.dockerjava" level="WARN"/>
 
-    <logger name="org.testcontainers" level="WARN"/>
-    <logger name="com.github.dockerjava" level="WARN"/>
+    <logger name="com.github.dockerjava" level="INFO"/>
+    <logger name="org.testcontainers" level="INFO"/>
 
     <root level="DEBUG">
         <appender-ref ref="CapturingAppender"/>
         <appender-ref ref="FILE" />
     </root>
-
 </configuration>

--- a/tests/src/test/scala/akka/kafka/ConfigSettingsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/ConfigSettingsSpec.scala
@@ -6,10 +6,11 @@
 package akka.kafka
 
 import akka.kafka.internal.ConfigSettings
+import akka.kafka.tests.scaladsl.LogCapturing
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{Matchers, WordSpecLike}
 
-class ConfigSettingsSpec extends WordSpecLike with Matchers {
+class ConfigSettingsSpec extends WordSpecLike with Matchers with LogCapturing {
 
   "ConfigSettings" must {
 

--- a/tests/src/test/scala/akka/kafka/ConsumerSettingsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/ConsumerSettingsSpec.scala
@@ -6,6 +6,7 @@
 package akka.kafka
 
 import akka.actor.ActorSystem
+import akka.kafka.tests.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import com.typesafe.config.ConfigFactory
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, StringDeserializer}
@@ -15,7 +16,7 @@ import org.scalatest.concurrent.ScalaFutures
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
-class ConsumerSettingsSpec extends WordSpecLike with Matchers with OptionValues with ScalaFutures {
+class ConsumerSettingsSpec extends WordSpecLike with Matchers with OptionValues with ScalaFutures with LogCapturing {
 
   implicit val patience = PatienceConfig(5.seconds, 10.millis)
 

--- a/tests/src/test/scala/akka/kafka/ProducerSettingsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/ProducerSettingsSpec.scala
@@ -6,13 +6,19 @@
 package akka.kafka
 
 import akka.actor.ActorSystem
+import akka.kafka.tests.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import com.typesafe.config.ConfigFactory
 import org.apache.kafka.common.serialization.{ByteArraySerializer, StringSerializer}
 import org.scalatest._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 
-class ProducerSettingsSpec extends WordSpecLike with Matchers with ScalaFutures with IntegrationPatience {
+class ProducerSettingsSpec
+    extends WordSpecLike
+    with Matchers
+    with ScalaFutures
+    with IntegrationPatience
+    with LogCapturing {
 
   "ProducerSettings" must {
 

--- a/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
@@ -15,6 +15,7 @@ import akka.kafka.scaladsl.Consumer.DrainingControl
 import akka.kafka.scaladsl.Producer
 import akka.kafka.testkit.ConsumerResultFactory
 import akka.kafka.testkit.scaladsl.{ConsumerControlFactory, Slf4jToAkkaLoggingAdapter}
+import akka.kafka.tests.scaladsl.LogCapturing
 import akka.kafka.{CommitterSettings, ConsumerMessage, ProducerMessage, ProducerSettings}
 import akka.stream.{ActorAttributes, ActorMaterializer, Supervision}
 import akka.stream.scaladsl.{Keep, Source}
@@ -39,7 +40,8 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
     with BeforeAndAfterAll
     with ScalaFutures
     with IntegrationPatience
-    with Eventually {
+    with Eventually
+    with LogCapturing {
 
   import CommittingProducerSinkSpec.FakeConsumer
 

--- a/tests/src/test/scala/akka/kafka/internal/CommittingWithMockSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingWithMockSpec.scala
@@ -11,6 +11,7 @@ import akka.kafka.ConsumerMessage._
 import akka.kafka.{internal, CommitterSettings, ConsumerSettings, Subscriptions}
 import akka.kafka.scaladsl.{Committer, Consumer}
 import akka.kafka.scaladsl.Consumer.Control
+import akka.kafka.tests.scaladsl.LogCapturing
 import akka.stream._
 import akka.stream.scaladsl._
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
@@ -51,7 +52,8 @@ class CommittingWithMockSpec(_system: ActorSystem)
     with FlatSpecLike
     with Matchers
     with BeforeAndAfterAll
-    with ScalaFutures {
+    with ScalaFutures
+    with LogCapturing {
 
   import CommittingWithMockSpec._
 
@@ -225,7 +227,6 @@ class CommittingWithMockSpec(_system: ActorSystem)
     commitLog.calls.foreach {
       case (offsets, callback) => callback.onComplete(offsets.asJava, null)
     }
-
     allCommits.futureValue should have size (count.toLong)
     control.shutdown().futureValue shouldBe Done
   }

--- a/tests/src/test/scala/akka/kafka/internal/ConnectionCheckerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConnectionCheckerSpec.scala
@@ -9,6 +9,7 @@ import akka.actor.{ActorRef, ActorSystem}
 import akka.kafka.Metadata
 import akka.kafka.ConnectionCheckerSettings
 import akka.kafka.KafkaConnectionFailed
+import akka.kafka.tests.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import com.typesafe.config.ConfigFactory
 import org.apache.kafka.common.errors.TimeoutException
@@ -20,7 +21,8 @@ import scala.util.{Failure, Success}
 class ConnectionCheckerSpec
     extends TestKit(ActorSystem("KafkaConnectionCheckerSpec", ConfigFactory.load()))
     with WordSpecLike
-    with Matchers {
+    with Matchers
+    with LogCapturing {
 
   "KafkaConnectionChecker" must {
 

--- a/tests/src/test/scala/akka/kafka/internal/ConsumerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConsumerSpec.scala
@@ -10,6 +10,7 @@ import akka.actor.ActorSystem
 import akka.kafka.ConsumerMessage._
 import akka.kafka.scaladsl.Consumer
 import akka.kafka.scaladsl.Consumer.Control
+import akka.kafka.tests.scaladsl.LogCapturing
 import akka.kafka.{CommitTimeoutException, ConsumerSettings, Subscriptions}
 import akka.stream._
 import akka.stream.scaladsl._
@@ -49,7 +50,8 @@ class ConsumerSpec(_system: ActorSystem)
     extends TestKit(_system)
     with FlatSpecLike
     with Matchers
-    with BeforeAndAfterAll {
+    with BeforeAndAfterAll
+    with LogCapturing {
 
   import ConsumerSpec._
 

--- a/tests/src/test/scala/akka/kafka/internal/EnhancedConfigSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/EnhancedConfigSpec.scala
@@ -5,12 +5,13 @@
 
 package akka.kafka.internal
 
+import akka.kafka.tests.scaladsl.LogCapturing
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{Matchers, WordSpecLike}
 
 import scala.concurrent.duration._
 
-class EnhancedConfigSpec extends WordSpecLike with Matchers {
+class EnhancedConfigSpec extends WordSpecLike with Matchers with LogCapturing {
 
   "EnhancedConfig" must {
 

--- a/tests/src/test/scala/akka/kafka/internal/OffsetAggregationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/OffsetAggregationSpec.scala
@@ -5,12 +5,13 @@
 
 package akka.kafka.internal
 
+import akka.kafka.tests.scaladsl.LogCapturing
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.requests.OffsetFetchResponse
 import org.scalatest.{Matchers, WordSpecLike}
 
-class OffsetAggregationSpec extends WordSpecLike with Matchers {
+class OffsetAggregationSpec extends WordSpecLike with Matchers with LogCapturing {
 
   val topicA = "topicA"
   val topicB = "topicB"

--- a/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
@@ -13,6 +13,7 @@ import akka.actor.ActorSystem
 import akka.kafka.ConsumerMessage._
 import akka.kafka.{ConsumerSettings, Subscriptions}
 import akka.kafka.scaladsl.Consumer
+import akka.kafka.tests.scaladsl.LogCapturing
 import akka.stream._
 import akka.stream.scaladsl._
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
@@ -36,7 +37,8 @@ class PartitionedSourceSpec(_system: ActorSystem)
     with BeforeAndAfterAll
     with OptionValues
     with ScalaFutures
-    with Eventually {
+    with Eventually
+    with LogCapturing {
 
   implicit val patience = PatienceConfig(4.seconds, 50.millis)
 

--- a/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
@@ -11,6 +11,7 @@ import akka.actor.ActorSystem
 import akka.kafka.ConsumerMessage.{GroupTopicPartition, PartitionOffset, PartitionOffsetCommittedMarker}
 import akka.kafka.ProducerMessage._
 import akka.kafka.scaladsl.Producer
+import akka.kafka.tests.scaladsl.LogCapturing
 import akka.kafka.{ConsumerMessage, ProducerMessage, ProducerSettings}
 import akka.stream.scaladsl.{Flow, Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
@@ -39,7 +40,8 @@ class ProducerSpec(_system: ActorSystem)
     extends TestKit(_system)
     with FlatSpecLike
     with Matchers
-    with BeforeAndAfterAll {
+    with BeforeAndAfterAll
+    with LogCapturing {
 
   def this() = this(ActorSystem())
 

--- a/tests/src/test/scala/akka/kafka/internal/SubscriptionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/SubscriptionsSpec.scala
@@ -7,12 +7,13 @@ package akka.kafka.internal
 
 import java.net.URLEncoder
 
+import akka.kafka.tests.scaladsl.LogCapturing
 import akka.kafka.{Subscription, Subscriptions}
 import akka.util.ByteString
 import org.apache.kafka.common.TopicPartition
 import org.scalatest.{Matchers, WordSpec}
 
-class SubscriptionsSpec extends WordSpec with Matchers {
+class SubscriptionsSpec extends WordSpec with Matchers with LogCapturing {
 
   "URL encoded subscription" should {
     "be readable for topics" in {

--- a/tests/src/test/scala/akka/kafka/javadsl/ControlSpec.scala
+++ b/tests/src/test/scala/akka/kafka/javadsl/ControlSpec.scala
@@ -11,6 +11,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import akka.Done
 import akka.kafka.internal.ConsumerControlAsJava
+import akka.kafka.tests.scaladsl.LogCapturing
 import org.apache.kafka.common.{Metric, MetricName}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Matchers, WordSpecLike}
@@ -36,7 +37,7 @@ object ControlSpec {
   }
 }
 
-class ControlSpec extends WordSpecLike with ScalaFutures with Matchers {
+class ControlSpec extends WordSpecLike with ScalaFutures with Matchers with LogCapturing {
   import ControlSpec._
 
   val ec = Executors.newCachedThreadPool()

--- a/tests/src/test/scala/akka/kafka/scaladsl/ConnectionCheckerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/ConnectionCheckerSpec.scala
@@ -7,6 +7,7 @@ package akka.kafka.scaladsl
 
 import akka.actor.ActorSystem
 import akka.event.{Logging, LoggingAdapter}
+import akka.kafka.tests.scaladsl.LogCapturing
 import akka.kafka.{ConnectionCheckerSettings, ConsumerSettings, KafkaConnectionFailed, KafkaPorts, Subscriptions}
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{Keep, Sink}
@@ -20,7 +21,7 @@ import org.scalatest.{Matchers, WordSpecLike}
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContextExecutor}
 
-class ConnectionCheckerSpec extends WordSpecLike with Matchers {
+class ConnectionCheckerSpec extends WordSpecLike with Matchers with LogCapturing {
 
   implicit val system: ActorSystem = ActorSystem("KafkaConnectionCheckerSpec")
   implicit val ec: ExecutionContextExecutor = system.dispatcher

--- a/tests/src/test/scala/akka/kafka/scaladsl/ControlSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/ControlSpec.scala
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 import akka.Done
 import akka.kafka.scaladsl.Consumer.DrainingControl
+import akka.kafka.tests.scaladsl.LogCapturing
 import org.apache.kafka.common.{Metric, MetricName}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Matchers, WordSpecLike}
@@ -32,7 +33,7 @@ object ControlSpec {
   }
 }
 
-class ControlSpec extends WordSpecLike with ScalaFutures with Matchers {
+class ControlSpec extends WordSpecLike with ScalaFutures with Matchers with LogCapturing {
   import ControlSpec._
 
   "Control" should {

--- a/tests/src/test/scala/akka/kafka/scaladsl/MisconfiguredConsumerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/MisconfiguredConsumerSpec.scala
@@ -6,6 +6,7 @@
 package akka.kafka.scaladsl
 
 import akka.actor.ActorSystem
+import akka.kafka.tests.scaladsl.LogCapturing
 import akka.kafka.{ConsumerSettings, Subscriptions}
 import akka.stream.scaladsl.Sink
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
@@ -23,7 +24,8 @@ class MisconfiguredConsumerSpec
     with WordSpecLike
     with Matchers
     with ScalaFutures
-    with Eventually {
+    with Eventually
+    with LogCapturing {
 
   implicit val materializer: Materializer = ActorMaterializer()
   implicit val patience = PatienceConfig(2.seconds, 20.millis)

--- a/tests/src/test/scala/akka/kafka/scaladsl/MisconfiguredProducerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/MisconfiguredProducerSpec.scala
@@ -7,6 +7,7 @@ package akka.kafka.scaladsl
 
 import akka.actor.ActorSystem
 import akka.kafka.ProducerSettings
+import akka.kafka.tests.scaladsl.LogCapturing
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.{ActorMaterializer, Materializer}
@@ -23,7 +24,8 @@ class MisconfiguredProducerSpec
     with WordSpecLike
     with Matchers
     with ScalaFutures
-    with Eventually {
+    with Eventually
+    with LogCapturing {
 
   implicit val materializer: Materializer = ActorMaterializer()
   implicit val patience = PatienceConfig(2.seconds, 20.millis)

--- a/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
@@ -7,6 +7,7 @@ package akka.kafka.scaladsl
 
 // #testkit
 import akka.kafka.testkit.scaladsl.ScalatestKafkaSpec
+import akka.kafka.tests.scaladsl.LogCapturing
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatest.{Matchers, WordSpecLike}
 
@@ -15,7 +16,8 @@ abstract class SpecBase(kafkaPort: Int)
     with WordSpecLike
     with Matchers
     with ScalaFutures
-    with Eventually {
+    with Eventually
+    with LogCapturing {
 
   protected def this() = this(kafkaPort = -1)
 }

--- a/tests/src/test/scala/akka/kafka/tests/CapturingAppender.scala
+++ b/tests/src/test/scala/akka/kafka/tests/CapturingAppender.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.tests
+
+import akka.annotation.InternalApi
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.AppenderBase
+
+/**
+ * See https://doc.akka.io/docs/akka/current/typed/testing-async.html#silence-logging-output-from-tests
+ *
+ * INTERNAL API
+ */
+@InternalApi private[akka] object CapturingAppender {
+  import LogbackUtil._
+
+  private val CapturingAppenderName = "CapturingAppender"
+
+  def get(loggerName: String): CapturingAppender = {
+    val logbackLogger = getLogbackLogger(loggerName)
+    logbackLogger.getAppender(CapturingAppenderName) match {
+      case null =>
+        throw new IllegalStateException(
+          s"$CapturingAppenderName not defined for [${loggerNameOrRoot(loggerName)}] in logback-test.xml"
+        )
+      case appender: CapturingAppender => appender
+      case other =>
+        throw new IllegalStateException(s"Unexpected $CapturingAppender: $other")
+    }
+  }
+
+}
+
+/**
+ * See https://doc.akka.io/docs/akka/current/typed/testing-async.html#silence-logging-output-from-tests
+ *
+ * INTERNAL API
+ *
+ * Logging from tests can be silenced by this appender. When there is a test failure
+ * the captured logging events are flushed to the appenders defined for the
+ * akka.actor.testkit.typed.internal.CapturingAppenderDelegate logger.
+ *
+ * The flushing on test failure is handled by [[akka.actor.testkit.typed.scaladsl.LogCapturing]]
+ * for ScalaTest and [[akka.actor.testkit.typed.javadsl.LogCapturing]] for JUnit.
+ *
+ * Use configuration like the following the logback-test.xml:
+ *
+ * {{{
+ *     <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />
+ *
+ *     <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate" >
+ *       <appender-ref ref="STDOUT"/>
+ *     </logger>
+ *
+ *     <root level="DEBUG">
+ *         <appender-ref ref="CapturingAppender"/>
+ *     </root>
+ * }}}
+ */
+@InternalApi private[akka] class CapturingAppender extends AppenderBase[ILoggingEvent] {
+  import LogbackUtil._
+
+  private var buffer: Vector[ILoggingEvent] = Vector.empty
+
+  // invocations are synchronized via doAppend in AppenderBase
+  override def append(event: ILoggingEvent): Unit = {
+    event.prepareForDeferredProcessing()
+    buffer :+= event
+  }
+
+  /**
+   * Flush buffered logging events to the output appenders
+   * Also clears the buffer..
+   */
+  def flush(): Unit = synchronized {
+    import scala.jdk.CollectionConverters._
+    val logbackLogger = getLogbackLogger(classOf[CapturingAppender].getName + "Delegate")
+    val appenders = logbackLogger.iteratorForAppenders().asScala.filterNot(_ == this).toList
+    for (event <- buffer; appender <- appenders) {
+      appender.doAppend(event)
+    }
+    clear()
+  }
+
+  /**
+   * Discards the buffered logging events without output.
+   */
+  def clear(): Unit = synchronized {
+    buffer = Vector.empty
+  }
+
+}

--- a/tests/src/test/scala/akka/kafka/tests/LogbackUtil.scala
+++ b/tests/src/test/scala/akka/kafka/tests/LogbackUtil.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.tests
+
+import akka.annotation.InternalApi
+import ch.qos.logback.classic.Level
+import org.slf4j.LoggerFactory
+
+/**
+ * See https://doc.akka.io/docs/akka/current/typed/testing-async.html#silence-logging-output-from-tests
+ *
+ * INTERNAL API
+ */
+@InternalApi private[akka] object LogbackUtil {
+  def loggerNameOrRoot(loggerName: String): String =
+    if (loggerName == "") org.slf4j.Logger.ROOT_LOGGER_NAME else loggerName
+
+  def getLogbackLogger(loggerName: String): ch.qos.logback.classic.Logger = {
+    LoggerFactory.getLogger(loggerNameOrRoot(loggerName)) match {
+      case logger: ch.qos.logback.classic.Logger => logger
+      case null =>
+        throw new IllegalArgumentException(s"Couldn't find logger for [$loggerName].")
+      case other =>
+        throw new IllegalArgumentException(
+          s"Requires Logback logger for [$loggerName], it was a [${other.getClass.getName}]"
+        )
+    }
+  }
+
+  def convertLevel(level: ch.qos.logback.classic.Level): Level = {
+    level.levelInt match {
+      case ch.qos.logback.classic.Level.TRACE_INT => Level.TRACE
+      case ch.qos.logback.classic.Level.DEBUG_INT => Level.DEBUG
+      case ch.qos.logback.classic.Level.INFO_INT => Level.INFO
+      case ch.qos.logback.classic.Level.WARN_INT => Level.WARN
+      case ch.qos.logback.classic.Level.ERROR_INT => Level.ERROR
+      case _ =>
+        throw new IllegalArgumentException("Level " + level.levelStr + ", " + level.levelInt + " is unknown.")
+    }
+  }
+}

--- a/tests/src/test/scala/akka/kafka/tests/javadsl/LogCapturingExtension.scala
+++ b/tests/src/test/scala/akka/kafka/tests/javadsl/LogCapturingExtension.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.tests.javadsl
+
+import akka.kafka.tests.CapturingAppender
+import org.junit.jupiter.api.extension.{AfterTestExecutionCallback, BeforeTestExecutionCallback, ExtensionContext}
+
+class LogCapturingExtension extends BeforeTestExecutionCallback with AfterTestExecutionCallback {
+
+  // eager access of CapturingAppender to fail fast if misconfigured
+  private val capturingAppender = CapturingAppender.get("")
+
+  override def beforeTestExecution(context: ExtensionContext): Unit = {
+    capturingAppender.clear()
+  }
+
+  override def afterTestExecution(context: ExtensionContext): Unit = {
+    if (context.getExecutionException.isPresent) {
+      val error = context.getExecutionException.get().toString
+      val method =
+        s"[${Console.BLUE}${context.getRequiredTestClass.getName}: ${context.getRequiredTestMethod.getName}${Console.RESET}]"
+      System.out.println(
+        s"--> $method Start of log messages of test that failed with $error"
+      )
+      capturingAppender.flush()
+      System.out.println(
+        s"<-- $method End of log messages of test that failed with $error"
+      )
+    }
+  }
+}

--- a/tests/src/test/scala/akka/kafka/tests/javadsl/LogCapturingJunit4.scala
+++ b/tests/src/test/scala/akka/kafka/tests/javadsl/LogCapturingJunit4.scala
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.tests.javadsl
+
+import akka.kafka.tests.CapturingAppender
+
+import scala.util.control.NonFatal
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import org.slf4j.LoggerFactory
+
+/**
+ * See https://doc.akka.io/docs/akka/current/typed/testing-async.html#silence-logging-output-from-tests
+ *
+ * JUnit `TestRule` to make log lines appear only when the test failed.
+ *
+ * Use this in test by adding a public field annotated with `@TestRule`:
+ * {{{
+ *   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+ * }}}
+ *
+ * Requires Logback and configuration like the following the logback-test.xml:
+ *
+ * {{{
+ *     <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />
+ *
+ *     <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate" >
+ *       <appender-ref ref="STDOUT"/>
+ *     </logger>
+ *
+ *     <root level="DEBUG">
+ *         <appender-ref ref="CapturingAppender"/>
+ *     </root>
+ * }}}
+ */
+final class LogCapturingJunit4 extends TestRule {
+  // eager access of CapturingAppender to fail fast if misconfigured
+  private val capturingAppender = CapturingAppender.get("")
+
+  private val myLogger = LoggerFactory.getLogger(classOf[LogCapturingJunit4])
+
+  override def apply(base: Statement, description: Description): Statement = {
+    new Statement {
+      override def evaluate(): Unit = {
+        try {
+          myLogger.info(s"Logging started for test [${description.getClassName}: ${description.getMethodName}]")
+          base.evaluate()
+          myLogger.info(
+            s"Logging finished for test [${description.getClassName}: ${description.getMethodName}] that was successful"
+          )
+        } catch {
+          case NonFatal(e) =>
+            println(
+              s"--> [${Console.BLUE}${description.getClassName}: ${description.getMethodName}${Console.RESET}] " +
+              s"Start of log messages of test that failed with ${e.getMessage}"
+            )
+            capturingAppender.flush()
+            println(
+              s"<-- [${Console.BLUE}${description.getClassName}: ${description.getMethodName}${Console.RESET}] " +
+              s"End of log messages of test that failed with ${e.getMessage}"
+            )
+            throw e
+        } finally {
+          capturingAppender.clear()
+        }
+      }
+    }
+  }
+}

--- a/tests/src/test/scala/akka/kafka/tests/javadsl/LogCapturingJunit4.scala
+++ b/tests/src/test/scala/akka/kafka/tests/javadsl/LogCapturingJunit4.scala
@@ -54,15 +54,11 @@ final class LogCapturingJunit4 extends TestRule {
           )
         } catch {
           case NonFatal(e) =>
-            println(
-              s"--> [${Console.BLUE}${description.getClassName}: ${description.getMethodName}${Console.RESET}] " +
-              s"Start of log messages of test that failed with ${e.getMessage}"
-            )
+            val method = s"[${Console.BLUE}${description.getClassName}: ${description.getMethodName}${Console.RESET}]"
+            val error = e.toString
+            System.out.println(s"--> $method Start of log messages of test that failed with $error")
             capturingAppender.flush()
-            println(
-              s"<-- [${Console.BLUE}${description.getClassName}: ${description.getMethodName}${Console.RESET}] " +
-              s"End of log messages of test that failed with ${e.getMessage}"
-            )
+            System.out.println(s"<-- $method End of log messages of test that failed with $error")
             throw e
         } finally {
           capturingAppender.clear()

--- a/tests/src/test/scala/akka/kafka/tests/scaladsl/LogCapturing.scala
+++ b/tests/src/test/scala/akka/kafka/tests/scaladsl/LogCapturing.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
+ * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.kafka.tests.scaladsl
+
+import akka.kafka.tests.CapturingAppender
+
+import scala.util.control.NonFatal
+
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.Outcome
+import org.scalatest.TestSuite
+import org.slf4j.LoggerFactory
+
+/**
+ * See https://doc.akka.io/docs/akka/current/typed/testing-async.html#silence-logging-output-from-tests
+ *
+ * Mixin this trait to a ScalaTest test to make log lines appear only when the test failed.
+ *
+ * Requires Logback and configuration like the following the logback-test.xml:
+ *
+ * {{{
+ *     <appender name="CapturingAppender" class="akka.actor.testkit.typed.internal.CapturingAppender" />
+ *
+ *     <logger name="akka.actor.testkit.typed.internal.CapturingAppenderDelegate" >
+ *       <appender-ref ref="STDOUT"/>
+ *     </logger>
+ *
+ *     <root level="DEBUG">
+ *         <appender-ref ref="CapturingAppender"/>
+ *     </root>
+ * }}}
+ */
+trait LogCapturing extends BeforeAndAfterAll { self: TestSuite =>
+
+  // eager access of CapturingAppender to fail fast if misconfigured
+  private val capturingAppender = CapturingAppender.get("")
+
+  private val myLogger = LoggerFactory.getLogger(classOf[LogCapturing])
+
+  override protected def afterAll(): Unit = {
+    try {
+      super.afterAll()
+    } catch {
+      case NonFatal(e) =>
+        myLogger.error("Exception from afterAll", e)
+        capturingAppender.flush()
+    } finally {
+      capturingAppender.clear()
+    }
+  }
+
+  abstract override def withFixture(test: NoArgTest): Outcome = {
+    myLogger.info(s"Logging started for test [${self.getClass.getName}: ${test.name}]")
+    val res = test()
+    myLogger.info(s"Logging finished for test [${self.getClass.getName}: ${test.name}] that [$res]")
+
+    if (!(res.isSucceeded || res.isPending)) {
+      println(
+        s"--> [${Console.BLUE}${self.getClass.getName}: ${test.name}${Console.RESET}] Start of log messages of test that [$res]"
+      )
+      capturingAppender.flush()
+      println(
+        s"<-- [${Console.BLUE}${self.getClass.getName}: ${test.name}${Console.RESET}] End of log messages of test that [$res]"
+      )
+    }
+
+    res
+  }
+}


### PR DESCRIPTION
## Purpose

Enable log capturing in tests so that the log for failed tests shows, but is suppressed for successful tests.

## References

Copied in from "akka-actor-testkit-typed" (when Alpakka Kafka drops Scala 2.11 our tests project could depend on it).

https://doc.akka.io/docs/akka/current/typed/testing-async.html#silence-logging-output-from-tests

## Background Context

This may help to identify the cause of test failures that appear on Travis.
