### PR TITLE
Use akka.test.timefactor

### DIFF
--- a/tests/src/it/resources/reference.conf
+++ b/tests/src/it/resources/reference.conf
@@ -12,12 +12,7 @@ akka {
   }
 
   test {
-    # increase max time dilation to account for slow test environments like Travis and Jenkins.
-    # this is useful for tests that assert consistency where lots of client restarts occur that can cause congestion on the test broker
-    #
-    # i.e. transactional tests that use RestartSource to assert consistency for streams with transient failures
-    #
-    # https://doc.akka.io/docs/akka/current/testing.html#accounting-for-slow-test-systems
+    # https://github.com/akka/alpakka-kafka/pull/994
     timefactor = 3.0
     single-expect-default = 10s
   }

--- a/tests/src/it/resources/reference.conf
+++ b/tests/src/it/resources/reference.conf
@@ -12,6 +12,13 @@ akka {
   }
 
   test {
+    # increase max time dilation to account for slow test environments like Travis and Jenkins.
+    # this is useful for tests that assert consistency where lots of client restarts occur that can cause congestion on the test broker
+    #
+    # i.e. transactional tests that use RestartSource to assert consistency for streams with transient failures
+    #
+    # https://doc.akka.io/docs/akka/current/testing.html#accounting-for-slow-test-systems
+    timefactor = 3.0
     single-expect-default = 10s
   }
 

--- a/tests/src/test/resources/application.conf
+++ b/tests/src/test/resources/application.conf
@@ -9,6 +9,13 @@ akka {
   }
 
   test {
+    # increase max time dilation to account for slow test environments like Travis and Jenkins.
+    # this is useful for tests that assert consistency where lots of client restarts occur that can cause congestion on the test broker
+    #
+    # i.e. transactional tests that use RestartSource to assert consistency for streams with transient failures
+    #
+    # https://doc.akka.io/docs/akka/current/testing.html#accounting-for-slow-test-systems
+    timefactor = 3.0
     single-expect-default = 10s
   }
 

--- a/tests/src/test/resources/application.conf
+++ b/tests/src/test/resources/application.conf
@@ -9,12 +9,7 @@ akka {
   }
 
   test {
-    # increase max time dilation to account for slow test environments like Travis and Jenkins.
-    # this is useful for tests that assert consistency where lots of client restarts occur that can cause congestion on the test broker
-    #
-    # i.e. transactional tests that use RestartSource to assert consistency for streams with transient failures
-    #
-    # https://doc.akka.io/docs/akka/current/testing.html#accounting-for-slow-test-systems
+    # https://github.com/akka/alpakka-kafka/pull/994
     timefactor = 3.0
     single-expect-default = 10s
   }


### PR DESCRIPTION
## Purpose

Increase total time (max time dilation) for `expect` calls in akka streams testkit.  This will help reduce the number of timeout test failures in slow test environments like Travis and Jenkins.

This is useful for tests that assert consistency where lots of client restarts occur that can cause congestion on the test broker.

i.e). Transactional tests that use RestartSource to assert consistency for streams with transient failures

https://github.com/akka/alpakka-kafka/issues/826

## References

https://doc.akka.io/docs/akka/current/testing.html#accounting-for-slow-test-systems

## Changes

* Increase `akka.test.timefactor` for all tests

## Background Context

<!-- Why did you take this approach? -->
