### PR TITLE
Stage ID traceability

### DIFF
--- a/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
@@ -6,14 +6,18 @@
 package akka.kafka
 
 import akka.actor.{ActorRef, NoSerializationVerificationNeeded, Props}
+import akka.annotation.InternalApi
 import akka.kafka.internal.{KafkaConsumerActor => InternalKafkaConsumerActor}
 
 object KafkaConsumerActor {
 
+  @InternalApi
+  private[kafka] trait StopLike
+
   /**
    * Message to send for stopping the Kafka consumer actor.
    */
-  case object Stop extends NoSerializationVerificationNeeded
+  case object Stop extends NoSerializationVerificationNeeded with StopLike
 
   /**
    * Java API:

--- a/core/src/main/scala/akka/kafka/internal/BaseSingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/BaseSingleSourceLogic.scala
@@ -44,7 +44,7 @@ import scala.concurrent.{ExecutionContext, Future}
     super.preStart()
 
     sourceActor = getStageActor(messageHandling)
-    log.debug("Starting {}", sourceActor.ref)
+    log.info("Starting. StageActor {}", sourceActor.ref)
     consumerActor = createConsumerActor()
     sourceActor.watch(consumerActor)
 
@@ -122,6 +122,6 @@ import scala.concurrent.{ExecutionContext, Future}
     super.postStop()
   }
 
-  def performShutdown(): Unit
-
+  def performShutdown(): Unit =
+    log.info("Completing. StageActor {}", sourceActor.ref)
 }

--- a/core/src/main/scala/akka/kafka/internal/BaseSingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/BaseSingleSourceLogic.scala
@@ -44,6 +44,7 @@ import scala.concurrent.{ExecutionContext, Future}
     super.preStart()
 
     sourceActor = getStageActor(messageHandling)
+    log.debug("Starting {}", sourceActor.ref)
     consumerActor = createConsumerActor()
     sourceActor.watch(consumerActor)
 

--- a/core/src/main/scala/akka/kafka/internal/BaseSingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/BaseSingleSourceLogic.scala
@@ -123,5 +123,5 @@ import scala.concurrent.{ExecutionContext, Future}
   }
 
   def performShutdown(): Unit =
-    log.info("Completing. StageActor {}", sourceActor.ref)
+    log.info("Completing")
 }

--- a/core/src/main/scala/akka/kafka/internal/ExternalSingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/ExternalSingleSourceLogic.scala
@@ -32,7 +32,9 @@ import scala.concurrent.Future
   final def configureSubscription(): Unit =
     configureManualSubscription(subscription)
 
-  final def performShutdown(): Unit =
+  final override def performShutdown(): Unit = {
+    super.performShutdown()
     completeStage()
+  }
 
 }

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -685,7 +685,7 @@ import scala.util.control.NonFatal
 
   private def stopFromMessage(msg: StopLike) = msg match {
     case Stop => sender()
-    case StopFromStage(sourceStageId) => s"${sender()}, StageId [$sourceStageId]"
+    case StopFromStage(sourceStageId) => s"StageId [$sourceStageId]"
   }
 
   /**

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -24,7 +24,7 @@ import akka.actor.{
 import akka.annotation.InternalApi
 import akka.util.JavaDurationConverters._
 import akka.event.LoggingReceive
-import akka.kafka.KafkaConsumerActor.StoppingException
+import akka.kafka.KafkaConsumerActor.{StopLike, StoppingException}
 import akka.kafka._
 import akka.kafka.scaladsl.PartitionAssignmentHandler
 import org.apache.kafka.clients.consumer._
@@ -62,6 +62,7 @@ import scala.util.control.NonFatal
     final case class RequestMessages(requestId: Int, topics: Set[TopicPartition])
         extends NoSerializationVerificationNeeded
     val Stop = akka.kafka.KafkaConsumerActor.Stop
+    final case class StopFromStage(stageId: String) extends StopLike
     final case class Commit(tp: TopicPartition, offsetAndMetadata: OffsetAndMetadata)
         extends NoSerializationVerificationNeeded
     final case class CommitWithoutReply(tp: TopicPartition, offsetAndMetadata: OffsetAndMetadata)
@@ -292,13 +293,14 @@ import scala.util.control.NonFatal
         poll()
       else requestDelayedPoll()
 
-    case Stop =>
+    case s: StopLike =>
+      val from = stopFromMessage(s)
       commitAggregatedOffsets()
       if (commitsInProgress == 0) {
-        log.debug("Received Stop from {}, stopping", sender())
+        log.debug("Received Stop from {}, stopping", from)
         context.stop(self)
       } else {
-        log.debug("Received Stop from {}, waiting for commitsInProgress={}", sender(), commitsInProgress)
+        log.debug("Received Stop from {}, waiting for commitsInProgress={}", from, commitsInProgress)
         stopInProgress = true
         context.become(stopping)
       }
@@ -331,8 +333,9 @@ import scala.util.control.NonFatal
       owner.foreach(_ ! Failure(e))
       throw e
 
-    case Stop =>
-      log.debug("Received Stop from {}, stopping", sender())
+    case s: StopLike =>
+      val from = stopFromMessage(s)
+      log.debug("Received Stop from {}, stopping", from)
       context.stop(self)
 
     case _ =>
@@ -406,7 +409,7 @@ import scala.util.control.NonFatal
   def stopping: Receive = LoggingReceive.withLabel("stopping") {
     case p: Poll[_, _] =>
       receivePoll(p)
-    case Stop =>
+    case _: StopLike =>
     case Terminated(ref) =>
       stageActors -= ref
     case _ @(_: Commit | _: RequestMessages) =>
@@ -417,6 +420,7 @@ import scala.util.control.NonFatal
 
   override def preStart(): Unit = {
     super.preStart()
+    log.debug("Starting {}", self)
     val updateSettings: Future[ConsumerSettings[K, V]] = _settings.enriched
     updateSettings.value match {
       case Some(Success(s)) => applySettings(s)
@@ -677,6 +681,11 @@ import scala.util.control.NonFatal
         Try { consumer.committed(partition, settings.getMetadataRequestTimeout) },
         partition
       )
+  }
+
+  private def stopFromMessage(msg: StopLike) = msg match {
+    case Stop => sender()
+    case StopFromStage(sourceStageId) => s"${sender()}, StageId [$sourceStageId]"
   }
 
   /**

--- a/core/src/main/scala/akka/kafka/internal/LoggingWithId.scala
+++ b/core/src/main/scala/akka/kafka/internal/LoggingWithId.scala
@@ -21,9 +21,10 @@ private[internal] trait InstanceId {
  */
 private[internal] trait StageIdLogging extends StageLogging with InstanceId { self: GraphStageLogic =>
   private[this] var _log: LoggingAdapter = _
+  protected def idLogPrefix: String = s"[$id] "
   override def log: LoggingAdapter = {
     if (_log eq null) {
-      _log = new LoggingAdapterWithId(super.log, id)
+      _log = new LoggingAdapterWithPrefix(super.log, idLogPrefix)
     }
     _log
   }
@@ -34,17 +35,17 @@ private[internal] trait StageIdLogging extends StageLogging with InstanceId { se
  */
 private[internal] trait ActorIdLogging extends ActorLogging with InstanceId { this: Actor =>
   private[this] var _log: LoggingAdapter = _
+  protected def idLogPrefix: String = s"[$id] "
   override def log: LoggingAdapter = {
     if (_log eq null) {
-      _log = new LoggingAdapterWithId(super.log, id)
+      _log = new LoggingAdapterWithPrefix(super.log, idLogPrefix)
     }
     _log
   }
 }
 
-private[internal] final class LoggingAdapterWithId(logger: LoggingAdapter, id: String) extends LoggingAdapter {
-  private val idPrefix: String = s"[$id] "
-  private def msgWithId(message: String): String = idPrefix + message
+private[internal] final class LoggingAdapterWithPrefix(logger: LoggingAdapter, prefix: String) extends LoggingAdapter {
+  private def msgWithId(message: String): String = prefix + message
 
   override protected def notifyError(message: String): Unit = logger.error(msgWithId(message))
   override protected def notifyError(cause: Throwable, message: String): Unit = logger.error(msgWithId(message), cause)

--- a/core/src/main/scala/akka/kafka/internal/LoggingWithId.scala
+++ b/core/src/main/scala/akka/kafka/internal/LoggingWithId.scala
@@ -13,7 +13,8 @@ import akka.stream.stage.{GraphStageLogic, StageLogging}
  * Generate a short random UID for something.
  */
 private[internal] trait InstanceId {
-  val id: String = java.util.UUID.randomUUID().toString.take(5)
+  private val instanceId = java.util.UUID.randomUUID().toString.take(5)
+  def id: String = instanceId
 }
 
 /**

--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -81,7 +81,8 @@ import scala.concurrent.{Future, Promise}
     super.postStop()
   }
 
-  final def performShutdown(): Unit = {
+  final override def performShutdown(): Unit = {
+    super.performShutdown()
     setKeepGoing(true)
     if (!isClosed(shape.out)) {
       complete(shape.out)

--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -77,7 +77,7 @@ import scala.concurrent.{Future, Promise}
   }
 
   final override def postStop(): Unit = {
-    consumerActor.tell(KafkaConsumerActor.Internal.Stop, sourceActor.ref)
+    consumerActor.tell(KafkaConsumerActor.Internal.StopFromStage(id), sourceActor.ref)
     super.postStop()
   }
 
@@ -99,7 +99,7 @@ import scala.concurrent.{Future, Promise}
   protected def stopConsumerActor(): Unit =
     materializer.scheduleOnce(settings.stopTimeout, new Runnable {
       override def run(): Unit =
-        consumerActor.tell(KafkaConsumerActor.Internal.Stop, sourceActor.ref)
+        consumerActor.tell(KafkaConsumerActor.Internal.StopFromStage(id), sourceActor.ref)
     })
 
   protected def partitionAssignedHandler(assignedTps: Set[TopicPartition]): Unit = {

--- a/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
@@ -84,7 +84,7 @@ private class SubSourceLogic[K, V, Msg](
       case (_, Terminated(ref)) if ref == consumerActor =>
         failStage(new ConsumerFailed)
     }
-    log.debug("Starting {}", sourceActor.ref)
+    log.info("Starting. StageActor {}", sourceActor.ref)
     consumerActor = {
       val extendedActorSystem = ActorMaterializerHelper.downcast(materializer).system.asInstanceOf[ExtendedActorSystem]
       extendedActorSystem.systemActorOf(akka.kafka.KafkaConsumerActor.props(sourceActor.ref, settings),
@@ -274,6 +274,7 @@ private class SubSourceLogic[K, V, Msg](
   }
 
   override def performShutdown(): Unit = {
+    log.info("Completing. Partitions [{}], StageActor {}", subSources.keys.mkString(","), sourceActor.ref)
     setKeepGoing(true)
     //todo we should wait for subsources to be shutdown and next shutdown main stage
     subSources.foreach {
@@ -397,7 +398,7 @@ private abstract class SubSourceStageLogic[K, V, Msg](
   override def preStart(): Unit = {
     super.preStart()
     subSourceActor = getStageActor(messageHandling)
-    log.debug("Starting SubSource. StageActor {}, partition {}", subSourceActor.ref, tp)
+    log.info("Starting. Partition {}, StageActor {}", tp, subSourceActor.ref)
     subSourceActor.watch(consumerActor)
     val controlAndActor = ControlAndStageActor(this.asInstanceOf[Control], subSourceActor.ref)
     subSourceStartedCb.invoke(tp -> controlAndActor)
@@ -441,7 +442,7 @@ private abstract class SubSourceStageLogic[K, V, Msg](
   )
 
   def performShutdown() = {
-    log.debug("Completing SubSource for partition {}", tp)
+    log.info("Completing. Partition {}, StageActor {}", tp, subSourceActor.ref)
     completeStage()
   }
 

--- a/tests/src/test/resources/logback-test.xml
+++ b/tests/src/test/resources/logback-test.xml
@@ -9,7 +9,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36} %X{akkaSource} %msg%n%rEx</pattern>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
         </encoder>
     </appender>
 

--- a/tests/src/test/resources/logback-test.xml
+++ b/tests/src/test/resources/logback-test.xml
@@ -9,7 +9,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36}  %msg%n%rEx</pattern>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%-20.20thread] %-36.36logger{36} %X{akkaSource} %msg%n%rEx</pattern>
         </encoder>
     </appender>
 

--- a/tests/src/test/resources/logback-test.xml
+++ b/tests/src/test/resources/logback-test.xml
@@ -20,6 +20,7 @@
     </logger>
 
     <logger name="akka" level="DEBUG"/>
+    <logger name="akka.actor.TimerScheduler" level="INFO"/>
     <logger name="akka.kafka" level="DEBUG"/>
 
     <logger name="org.apache.zookeeper" level="WARN"/>


### PR DESCRIPTION
## Purpose

Clean up log messages to make it easier to trace lifecycle events of stream stages and actors.

## References

* Exploration of options and continuation of work in #991

## Changes

* Log stage id of stage that sent request to stop KafkaConsumerActor
* Allow stage to override `idLogPrefix`
* Include KafkaConsumerActor number in `idLogPrefix` of sub sources
* Upgrade Starting and Shutdown logging to `INFO` and make more consistent


