### PR TITLE
Temporary fix for #978: avoid ConcatIterator

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/BaseSingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/BaseSingleSourceLogic.scala
@@ -55,12 +55,7 @@ import scala.concurrent.{ExecutionContext, Future}
       // might be more than one in flight when we assign/revoke tps
       if (msg.requestId == requestId)
         requested = false
-      // do not use simple ++ because of https://issues.scala-lang.org/browse/SI-9766
-      if (buffer.hasNext) {
-        buffer = buffer ++ msg.messages
-      } else {
-        buffer = msg.messages
-      }
+      buffer = buffer ++ msg.messages
       pump()
     case (_, Status.Failure(e)) =>
       failStage(e)

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -32,7 +32,6 @@ import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
 
 import scala.jdk.CollectionConverters._
 import scala.collection.compat._
-import scala.collection.immutable.VectorIterator
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.{Success, Try}
@@ -604,7 +603,7 @@ import scala.util.control.NonFatal
             val tpMessages = rawResult.records(tp).asScala
             b ++= tpMessages
           }
-          val messages: VectorIterator[ConsumerRecord[K, V]] = b.result().iterator
+          val messages = b.result().iterator
           if (messages.nonEmpty) {
             stageActorRef ! Messages(req.requestId, messages)
             requests -= stageActorRef

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -32,6 +32,7 @@ import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
 
 import scala.jdk.CollectionConverters._
 import scala.collection.compat._
+import scala.collection.immutable.VectorIterator
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.{Success, Try}
@@ -595,12 +596,15 @@ import scala.util.control.NonFatal
       requests.foreach {
         case (stageActorRef, req) =>
           //gather all messages for ref
-          val messages = req.topics.foldLeft[Iterator[ConsumerRecord[K, V]]](Iterator.empty) {
-            case (acc, tp) =>
-              val tpMessages = rawResult.records(tp).asScala.iterator
-              if (acc.isEmpty) tpMessages
-              else acc ++ tpMessages
+          // See https://github.com/akka/alpakka-kafka/issues/978
+          // Temporary fix to avoid https://github.com/scala/bug/issues/11807
+          // Using `VectorIterator` avoids the error from `ConcatIterator`
+          val b = Vector.newBuilder[ConsumerRecord[K, V]]
+          req.topics.foreach { tp =>
+            val tpMessages = rawResult.records(tp).asScala
+            b ++= tpMessages
           }
+          val messages: VectorIterator[ConsumerRecord[K, V]] = b.result().iterator
           if (messages.nonEmpty) {
             stageActorRef ! Messages(req.requestId, messages)
             requests -= stageActorRef

--- a/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
@@ -397,12 +397,7 @@ private abstract class SubSourceStageLogic[K, V, Msg](
   protected def messageHandling: PartialFunction[(ActorRef, Any), Unit] = {
     case (_, msg: KafkaConsumerActor.Internal.Messages[K, V]) =>
       requested = false
-      // do not use simple ++ because of https://issues.scala-lang.org/browse/SI-9766
-      if (buffer.hasNext) {
-        buffer = buffer ++ msg.messages
-      } else {
-        buffer = msg.messages
-      }
+      buffer = buffer ++ msg.messages
       pump()
     case (_, Status.Failure(e)) =>
       failStage(e)


### PR DESCRIPTION
## Purpose

Use a `Vector` to collect `ConsumerRecords` requested by a stage so that the concatenation in the source logic can't hit the [bug in `ConcatIterator`](https://github.com/scala/bug/issues/11807). 

## References

Reported in https://github.com/akka/alpakka-kafka/issues/978
and https://github.com/scala/bug/issues/11807 (Scala 2.12.10 and 2.13.1).

## Changes

* Use a `Vector.newBuilder` and iterative adding instead of `foldLeft` over `Iterator`s.
* Retire the work-around for a historic bug in Scala iterators 
