### PR TITLE
Build: fail for unformatted Java sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,9 @@ script:
 jobs:
   include:
     - stage: check
-      script: sbt verifyCodeStyle
+      script:
+        - sbt verifyCodeStyle
+        - git diff --exit-code --color || { echo "[error] Unformatted code found. Please run 'verifyCodeStyle' and commit the reformatted code."; false; }
       name: "Code style check. Run locally with: sbt verifyCodeStyle"
     - env: CMD=";++2.11.12 Test/compile ;++2.11.12 It/compile"
       name: "Compile all code with fatal warnings for Scala 2.11. Run locally with: env CI=true sbt ';++2.11.12 Test/compile ;++2.11.12 It/compile'"

--- a/build.sbt
+++ b/build.sbt
@@ -44,8 +44,7 @@ resolvers in ThisBuild ++= Seq(
 )
 
 TaskKey[Unit]("verifyCodeStyle") := {
-  (testkit / Compile / javafmt).result.value
-  (tests / Test / javafmt).result.value
+  javafmt.?.all(ScopeFilter(inAnyProject, inAnyConfiguration)).result.value
   scalafmtCheckAll.all(ScopeFilter(inAnyProject)).result.value.toEither.left.foreach { _ =>
     throw new MessageOnlyException("Unformatted code found. Please run 'scalafmtAll' and commit the reformatted code")
   }

--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,8 @@ resolvers in ThisBuild ++= Seq(
 )
 
 TaskKey[Unit]("verifyCodeStyle") := {
+  (testkit / Compile / javafmt).result.value
+  (tests / Test / javafmt).result.value
   scalafmtCheckAll.all(ScopeFilter(inAnyProject)).result.value.toEither.left.foreach { _ =>
     throw new MessageOnlyException("Unformatted code found. Please run 'scalafmtAll' and commit the reformatted code")
   }

--- a/testkit/src/main/java/akka/kafka/testkit/javadsl/EmbeddedKafkaTest.java
+++ b/testkit/src/main/java/akka/kafka/testkit/javadsl/EmbeddedKafkaTest.java
@@ -22,6 +22,8 @@ import scala.collection.immutable.HashMap$;
  */
 public abstract class EmbeddedKafkaTest extends KafkaTest {
 
+
+
   private static EmbeddedKafkaConfig embeddedKafkaConfig(
       int kafkaPort, int zookeeperPort, int replicationFactor) {
     return EmbeddedKafkaConfig$.MODULE$.apply(

--- a/testkit/src/main/java/akka/kafka/testkit/javadsl/EmbeddedKafkaTest.java
+++ b/testkit/src/main/java/akka/kafka/testkit/javadsl/EmbeddedKafkaTest.java
@@ -22,8 +22,6 @@ import scala.collection.immutable.HashMap$;
  */
 public abstract class EmbeddedKafkaTest extends KafkaTest {
 
-
-
   private static EmbeddedKafkaConfig embeddedKafkaConfig(
       int kafkaPort, int zookeeperPort, int replicationFactor) {
     return EmbeddedKafkaConfig$.MODULE$.apply(


### PR DESCRIPTION
## Purpose

Make sure the build doesn't progress if Java sources get reformatted.

## References

#999