### PR TITLE
Kafka 2.4 final

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,9 +38,7 @@ resolvers in ThisBuild ++= Seq(
   // for Embedded Kafka 2.4.0
   Resolver.bintrayRepo("seglo", "maven"),
   // for Jupiter interface (JUnit 5)
-  Resolver.jcenterRepo,
-  // for release candidate builds of Apache Kafka
-  "Apache Staging" at "https://repository.apache.org/content/groups/staging/"
+  Resolver.jcenterRepo
 )
 
 TaskKey[Unit]("verifyCodeStyle") := {
@@ -324,7 +322,7 @@ lazy val docs = project
         "extref.akka.base_url" -> s"https://doc.akka.io/docs/akka/$AkkaBinaryVersion/%s",
         "scaladoc.akka.base_url" -> s"https://doc.akka.io/api/akka/$AkkaBinaryVersion/",
         "javadoc.akka.base_url" -> s"https://doc.akka.io/japi/akka/$AkkaBinaryVersion/",
-        "javadoc.akka.link_style" -> "frames",
+        "javadoc.akka.link_style" -> "direct",
         "extref.akka-management.base_url" -> s"https://doc.akka.io/docs/akka-management/current/%s",
         // Kafka
         "kafka.version" -> kafkaVersion,

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -18,7 +18,7 @@ akka.kafka.testkit.testcontainers {
   # define this to select a different Kafka version by choosing the desired version of Confluent Platform
   # available Docker images: https://hub.docker.com/r/confluentinc/cp-kafka/tags
   # Kafka versions in Confluent Platform: https://docs.confluent.io/current/installation/versions-interoperability.html
-  confluent-platform-version = "5.2.1"
+  confluent-platform-version = "5.3.1"
 
   # the number of Kafka brokers to include in a test cluster
   num-brokers = 1


### PR DESCRIPTION
## Purpose

Use the Kafka 2.4.0 final client library.

## References

Fixes #915 
Fixes #983 

## Changes

* Removed the Apache staging repo
* Akka now deploys Javadoc without frames
* Fix use of API docs which hit multiple classes https://travis-ci.org/akka/alpakka-kafka/jobs/624053598#L1295
* Default to Confluent Platform 5.3.1 for Testcontainers in testkit

## Background

I dropped all Travis caches.
