### PR TITLE
CommittingSpec: add logging

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/CommittableSources.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommittableSources.scala
@@ -190,8 +190,8 @@ private[kafka] class KafkaAsyncConsumerCommitterRef(private val consumerActor: A
       .ask(msg)(Timeout(commitTimeout))
       .map(_ => Done)(ec)
       .recoverWith {
-        case _: AskTimeoutException =>
-          Future.failed(new CommitTimeoutException(s"Kafka commit took longer than: $commitTimeout"))
+        case e: AskTimeoutException =>
+          Future.failed(new CommitTimeoutException(s"Kafka commit took longer than: $commitTimeout (${e.getMessage})"))
         case other => Future.failed(other)
       }(ec)
   }

--- a/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
@@ -452,7 +452,9 @@ class CommittingSpec extends SpecBase with TestcontainersKafkaLike with Inside {
           .map(_.committableOffset)
           .groupedWithin(20, 5.seconds)
           .map(CommittableOffsetBatch.apply)
+          .log("sending offset batch")
           .via(Committer.batchFlow(committerDefaults.withMaxBatch(1L)))
+          .log("offset batch done")
           .runWith(Sink.head)
 
       val batch = result.mapTo[CommittableOffsetBatchImpl].futureValue

--- a/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
@@ -435,7 +435,7 @@ class CommittingSpec extends SpecBase with TestcontainersKafkaLike with Inside {
     }
 
     // Illustration of https://github.com/akka/alpakka-kafka/issues/942
-    "merge multiple consumers` offsets for different partitions (#942)" in assertAllStagesStopped {
+    "merge multiple consumers' offsets for different partitions (#942)" in assertAllStagesStopped {
       val topic = createTopic(0, partitions = 2)
       val group = createGroupId()
 
@@ -443,14 +443,20 @@ class CommittingSpec extends SpecBase with TestcontainersKafkaLike with Inside {
       val consumerSettings = consumerDefaults.withGroupId(group)
       val result =
         Consumer
-          .committableSource(consumerSettings, Subscriptions.assignment(new TopicPartition(topic, partition0)))
+          .committableSource(
+            consumerSettings
+              .withStopTimeout(100.millis), // this consumer actor needs to stay around to receive the commit
+            Subscriptions.assignment(new TopicPartition(topic, partition0))
+          )
           .take(10)
+          // triggers commit timeout as the actor is terminated
+          .delay(50.millis)
           .concat(
             Consumer
               .committableSource(consumerSettings, Subscriptions.assignment(new TopicPartition(topic, partition1)))
           )
           .map(_.committableOffset)
-          .groupedWithin(20, 5.seconds)
+          .groupedWithin(20, 10.seconds)
           .map(CommittableOffsetBatch.apply)
           .log("sending offset batch")
           .via(Committer.batchFlow(committerDefaults.withMaxBatch(1L)))


### PR DESCRIPTION
* Log the ask timeout's message when failing a commit
* Introduce timings in `CommittingSpec` to keep it from failing

Intends to solve #957 