### PR TITLE
Message loss testcase of #1016

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/SourceLogicBuffer.scala
+++ b/core/src/main/scala/akka/kafka/internal/SourceLogicBuffer.scala
@@ -29,11 +29,14 @@ private[kafka] trait SourceLogicBuffer[K, V, Msg] {
 
   private def filterRevokedPartitions(topicPartitions: Set[TopicPartition]): Unit = {
     if (topicPartitions.nonEmpty) {
-      log.debug("filtering out messages from revoked partitions {}", topicPartitions)
+      log.debug("Filtering out messages from revoked partitions {}", topicPartitions)
       // as buffer is an Iterator the filtering will be applied during `pump`
       buffer = buffer.filterNot { record =>
         val tp = new TopicPartition(record.topic, record.partition)
-        topicPartitions.contains(tp)
+        val filtered = topicPartitions.contains(tp)
+        if (filtered)
+          log.debug("Filtering offset {} on topic partition {} value {}", record.offset(), tp, record.value())
+        filtered
       }
     }
   }

--- a/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
@@ -158,7 +158,7 @@ private class SubSourceLogic[K, V, Msg](
 
   override def onTimer(timerKey: Any): Unit = timerKey match {
     case CloseRevokedPartitions =>
-      if (log.isDebugEnabled) {
+      if (log.isDebugEnabled && partitionsToRevoke.nonEmpty) {
         log.debug("Closing SubSources for revoked partitions: {}", partitionsToRevoke.mkString(", "))
       }
       onRevoke(partitionsToRevoke)

--- a/message_loss.sh
+++ b/message_loss.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -x
+OUTFILEPRE=${0%.sh}; OUTFILEPRE=logs/${OUTFILEPRE#./}_${BASHPID}
+i=0
+while [[ ${i} -lt 100 ]] ; do
+ i=$((i+1))
+ echo "Starting test ${OUTFILEPRE}_${i}.txt"
+ sbt -no-colors 'tests/testOnly akka.kafka.scaladsl.RebalanceSpec -- -z "no message loss during partition revocation and re-subscription"' 2>&1 | tee ${OUTFILEPRE}_${i}.txt
+done

--- a/tests/src/test/resources/logback-test.xml
+++ b/tests/src/test/resources/logback-test.xml
@@ -36,7 +36,11 @@
     <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" level="INFO"/>
     <logger name="org.apache.kafka.clients.consumer.internals.Fetcher" level="INFO"/>
     -->
+<!--
+    <logger name="org.apache.kafka.clients.consumer.KafkaConsumer" level="DEBUG"/>
+    <logger name="org.apache.kafka.clients.consumer.internals.Fetcher" level="DEBUG"/>
     <logger name="org.apache.kafka.clients.producer" level="DEBUG"/>
+-->
 
     <logger name="org.apache.kafka.common.utils.AppInfoParser" level="ERROR"/>
     <logger name="org.apache.kafka.clients.NetworkClient" level="ERROR"/>

--- a/tests/src/test/resources/logback-test.xml
+++ b/tests/src/test/resources/logback-test.xml
@@ -36,6 +36,8 @@
     <logger name="org.apache.kafka.clients.consumer.internals.ConsumerCoordinator" level="INFO"/>
     <logger name="org.apache.kafka.clients.consumer.internals.Fetcher" level="INFO"/>
     -->
+    <logger name="org.apache.kafka.clients.producer" level="DEBUG"/>
+
     <logger name="org.apache.kafka.common.utils.AppInfoParser" level="ERROR"/>
     <logger name="org.apache.kafka.clients.NetworkClient" level="ERROR"/>
     <logger name="org.eclipse.jetty" level="WARN"/>

--- a/tests/src/test/scala/akka/kafka/scaladsl/RebalanceSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/RebalanceSpec.scala
@@ -332,7 +332,8 @@ class RebalanceSpec extends SpecBase with TestcontainersKafkaLike with Inside {
             val messageRange = startMessageIdx to endMessageIdx
             messageRange.foreach(messageId => {
               val topicPartition = s"${topic1}-${partitionIdx}"
-              log.debug(s"produce messages for topicPartition=${topicPartition} messageId=${messageId}")
+              if (messageId % 1000 == 0)
+                log.debug(s"produce messages for topicPartition=${topicPartition} messageId=${messageId}")
               msgTpMap.put(messageId, topicPartition)
             })
             produce(topic1, messageRange, partitionIdx)

--- a/tests/src/test/scala/akka/kafka/scaladsl/RebalanceSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/RebalanceSpec.scala
@@ -19,7 +19,6 @@ import akka.stream.testkit.scaladsl.TestSink
 import akka.testkit.TestProbe
 import akka.{Done, NotUsed}
 import org.apache.kafka.clients.consumer.RoundRobinAssignor
-import org.apache.kafka.clients.producer.ProducerConfig
 
 //import org.apache.kafka.clients.consumer.RangeAssignor
 import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor
@@ -252,9 +251,6 @@ class RebalanceSpec extends SpecBase with TestcontainersKafkaLike with Inside {
       control1.isShutdown.futureValue shouldBe Done
       control2.isShutdown.futureValue shouldBe Done
     }
-
-    def producerDefaults: ProducerSettings[String, String] =
-      super.producerDefaults.withProperty(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true")
 
     "no message loss during partition revocation and re-subscription" in assertAllStagesStopped {
       // BEGIN: vals and defs


### PR DESCRIPTION
The tests for #1016 failed on Travis as the log grows too big. This contains a change to reduce logging.

The original author did not create a separate branch, to run the test on Travis I branched the PR into this.