### PR TITLE
CommittableProducer: Record outstanding commits on pass-through

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/CommittingProducerSinkStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommittingProducerSinkStage.scala
@@ -107,6 +107,7 @@ private final class CommittingProducerSinkStageLogic[K, V, IN <: Envelope[K, V, 
         } producer.send(record, cb)
 
       case msg: PassThroughMessage[K, V, Committable] =>
+        awaitingCommitResult += 1
         collectOffset(0, msg.passThrough)
     }
 


### PR DESCRIPTION
Fixes the internal bookkeeping on the number of outstanding
commits in CommittingProducerSinkStageLogic when pass-through
messages are passed in.

<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?
-->
## Purpose

Fixes the internal bookkeeping on the number of outstanding commits in CommittingProducerSinkStageLogic when pass-through messages are passed in.

## References

References #1021 

## Changes

Adds a couple of tests to demonstrate the issue, as well as (what appears to be) the trivial fix
