### PR TITLE
Producer: avoid race between failure and upstream finish

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/DefaultProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/DefaultProducerStage.scala
@@ -5,18 +5,16 @@
 
 package akka.kafka.internal
 
-import java.util.concurrent.atomic.AtomicInteger
-
 import akka.Done
 import akka.annotation.InternalApi
 import akka.kafka.ProducerMessage._
 import akka.kafka.ProducerSettings
-import akka.kafka.internal.ProducerStage.{MessageCallback, ProducerCompletionState}
+import akka.kafka.internal.ProducerStage.ProducerCompletionState
 import akka.stream.ActorAttributes.SupervisionStrategy
 import akka.stream.Supervision.Decider
 import akka.stream.stage._
 import akka.stream.{Attributes, FlowShape, Supervision}
-import org.apache.kafka.clients.producer.{Callback, RecordMetadata}
+import org.apache.kafka.clients.producer.{Callback, ProducerRecord, RecordMetadata}
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success, Try}
@@ -45,18 +43,18 @@ private class DefaultProducerStageLogic[K, V, P, IN <: Envelope[K, V, P], OUT <:
 ) extends TimerGraphStageLogic(stage.shape)
     with StageIdLogging
     with DeferredProducer[K, V]
-    with MessageCallback[K, V, P]
     with ProducerCompletionState {
 
   private lazy val decider: Decider =
     inheritedAttributes.get[SupervisionStrategy].map(_.decider).getOrElse(Supervision.stoppingDecider)
-  protected val awaitingConfirmation = new AtomicInteger(0)
-
+  private var awaitingConfirmation = 0
   private var completionState: Option[Try[Done]] = None
 
   override protected def logSource: Class[_] = classOf[DefaultProducerStage[_, _, _, _, _]]
 
   final override val producerSettings: ProducerSettings[K, V] = stage.settings
+
+  protected def awaitingConfirmationValue: Int = awaitingConfirmation
 
   protected class DefaultInHandler extends InHandler {
     override def onPush(): Unit = produce(grab(stage.in))
@@ -77,8 +75,8 @@ private class DefaultProducerStageLogic[K, V, P, IN <: Envelope[K, V, P], OUT <:
     resolveProducer(stage.settings)
   }
 
-  def checkForCompletion(): Unit =
-    if (isClosed(stage.in) && awaitingConfirmation.get == 0) {
+  private def checkForCompletion(): Unit =
+    if (isClosed(stage.in) && awaitingConfirmation == 0) {
       completionState match {
         case Some(Success(_)) => onCompletionSuccess()
         case Some(Failure(ex)) => onCompletionFailure(ex)
@@ -90,7 +88,8 @@ private class DefaultProducerStageLogic[K, V, P, IN <: Envelope[K, V, P], OUT <:
 
   override def onCompletionFailure(ex: Throwable): Unit = failStage(ex)
 
-  val checkForCompletionCB: AsyncCallback[Unit] = getAsyncCallback[Unit] { _ =>
+  private val confirmAndCheckForCompletionCB: AsyncCallback[Unit] = getAsyncCallback[Unit] { _ =>
+    awaitingConfirmation -= 1
     checkForCompletion()
   }
 
@@ -140,10 +139,8 @@ private class DefaultProducerStageLogic[K, V, P, IN <: Envelope[K, V, P], OUT <:
     in match {
       case msg: Message[K, V, P] =>
         val r = Promise[Result[K, V, P]]
-        awaitingConfirmation.incrementAndGet()
-        producer.send(msg.record, sendCallback(r, onSuccess = metadata => {
-          r.success(Result(metadata, msg))
-        }))
+        awaitingConfirmation += 1
+        producer.send(msg.record, new SendCallback(msg, r))
         postSend(msg)
         val future = r.future.asInstanceOf[Future[OUT]]
         push(stage.out, future)
@@ -153,8 +150,8 @@ private class DefaultProducerStageLogic[K, V, P, IN <: Envelope[K, V, P], OUT <:
           msg <- multiMsg.records
         } yield {
           val r = Promise[MultiResultPart[K, V]]
-          awaitingConfirmation.incrementAndGet()
-          producer.send(msg, sendCallback(r, onSuccess = metadata => r.success(MultiResultPart(metadata, msg))))
+          awaitingConfirmation += 1
+          producer.send(msg, new SendMultiCallback(msg, r))
           r.future
         }
         postSend(multiMsg)
@@ -172,25 +169,40 @@ private class DefaultProducerStageLogic[K, V, P, IN <: Envelope[K, V, P], OUT <:
 
     }
 
-  private def sendCallback(promise: Promise[_], onSuccess: RecordMetadata => Unit): Callback = new Callback {
-    override def onCompletion(metadata: RecordMetadata, exception: Exception): Unit = {
-      if (exception == null) {
-        onSuccess(metadata)
-        if (awaitingConfirmation.decrementAndGet() == 0)
-          checkForCompletionCB.invoke(())
-      } else
-        decider(exception) match {
-          case Supervision.Stop => closeAndFailStageCb.invoke(exception)
-          case _ =>
-            promise.failure(exception)
-            if (awaitingConfirmation.decrementAndGet() == 0)
-              checkForCompletionCB.invoke(())
-        }
+  private sealed abstract class CallbackBase extends Callback {
+    protected def onException(exception: Exception, promise: Promise[_]): Unit = {
+      decider(exception) match {
+        case Supervision.Stop => closeAndFailStageCb.invoke(exception)
+        case _ =>
+          promise.failure(exception)
+          confirmAndCheckForCompletionCB.invoke(())
+      }
     }
   }
 
+  /** send-callback for a single message. */
+  private final class SendCallback(msg: Message[K, V, P], promise: Promise[Result[K, V, P]]) extends CallbackBase {
+
+    override def onCompletion(metadata: RecordMetadata, exception: Exception): Unit =
+      if (exception == null) {
+        promise.success(Result(metadata, msg))
+        confirmAndCheckForCompletionCB.invoke(())
+      } else onException(exception, promise)
+  }
+
+  /** send-callback for a multi-message. */
+  private final class SendMultiCallback(msg: ProducerRecord[K, V], promise: Promise[MultiResultPart[K, V]])
+      extends CallbackBase {
+
+    override def onCompletion(metadata: RecordMetadata, exception: Exception): Unit =
+      if (exception == null) {
+        promise.success(MultiResultPart(metadata, msg))
+        confirmAndCheckForCompletionCB.invoke(())
+      } else onException(exception, promise)
+  }
+
   override def postStop(): Unit = {
-    log.debug("ProducerStage completed")
+    log.debug("ProducerStage postStop")
     closeProducer()
     super.postStop()
   }

--- a/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
@@ -38,8 +38,4 @@ private[internal] object ProducerStage {
     def onCompletionSuccess(): Unit
     def onCompletionFailure(ex: Throwable): Unit
   }
-
-  trait MessageCallback[K, V, P] {
-    protected def awaitingConfirmation: AtomicInteger
-  }
 }

--- a/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
@@ -10,7 +10,7 @@ import akka.annotation.InternalApi
 import akka.kafka.ConsumerMessage.{GroupTopicPartition, PartitionOffsetCommittedMarker}
 import akka.kafka.ProducerMessage.{Envelope, Results}
 import akka.kafka.internal.DeferredProducer._
-import akka.kafka.internal.ProducerStage.{MessageCallback, ProducerCompletionState}
+import akka.kafka.internal.ProducerStage.ProducerCompletionState
 import akka.kafka.{ConsumerMessage, ProducerSettings}
 import akka.stream.stage._
 import akka.stream.{Attributes, FlowShape}
@@ -21,7 +21,6 @@ import org.apache.kafka.common.TopicPartition
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
-import scala.util.{Failure, Success}
 
 /**
  * INTERNAL API
@@ -104,7 +103,6 @@ private final class TransactionalProducerStageLogic[K, V, P](
     inheritedAttributes: Attributes
 ) extends DefaultProducerStageLogic[K, V, P, Envelope[K, V, P], Results[K, V, P]](stage, inheritedAttributes)
     with StageIdLogging
-    with MessageCallback[K, V, P]
     with ProducerCompletionState {
 
   import TransactionalProducerStage._
@@ -162,7 +160,7 @@ private final class TransactionalProducerStageLogic[K, V, P](
 
   private def maybeCommitTransaction(beginNewTransaction: Boolean = true,
                                      abortEmptyTransactionOnComplete: Boolean = false): Unit = {
-    val awaitingConf = awaitingConfirmation.get
+    val awaitingConf = awaitingConfirmationValue
     batchOffsets match {
       case batch: NonemptyTransactionBatch if awaitingConf == 0 =>
         commitTransaction(batch, beginNewTransaction)

--- a/tests/src/test/scala/docs/scaladsl/ProducerExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/ProducerExample.scala
@@ -206,6 +206,7 @@ class ProducerExample extends DocsSpecBase with TestcontainersKafkaLike {
     result.futureValue should have size (100)
   }
 
+  // This showed a race fixed in https://github.com/akka/alpakka-kafka/pull/1025
   it should "fail stream with error from producing" in assertAllStagesStopped {
     val streamCompletion =
       Source
@@ -213,7 +214,7 @@ class ProducerExample extends DocsSpecBase with TestcontainersKafkaLike {
         .via(Producer.flexiFlow(producerDefaults))
         .runWith(Sink.head)
 
-    streamCompletion.failed.futureValue shouldBe a[org.apache.kafka.common.errors.InvalidTopicException]
+    streamCompletion.failed.futureValue shouldBe an[org.apache.kafka.common.errors.InvalidTopicException]
   }
 
 }

--- a/tests/src/test/scala/docs/scaladsl/ProducerExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/ProducerExample.scala
@@ -13,7 +13,6 @@ import akka.kafka.{ProducerMessage, ProducerSettings, Subscriptions}
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import org.apache.kafka.clients.producer.ProducerRecord
-import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.serialization.StringSerializer
 
 import scala.concurrent.Future


### PR DESCRIPTION
Decrementing `awaitingConfirmation` before the `closeAndFailStageCb` gets handled may lead to successful stage completion if upstream completes.

The new test cases fails without this fix.