### PR TITLE
add api taking batch as input element for the flow

### DIFF
--- a/core/src/main/scala/akka/kafka/javadsl/Committer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Committer.scala
@@ -10,7 +10,7 @@ import akka.annotation.ApiMayChange
 import akka.japi.Pair
 import akka.{Done, NotUsed}
 import akka.kafka.ConsumerMessage.{Committable, CommittableOffsetBatch}
-import akka.kafka.{scaladsl, CommitterSettings}
+import akka.kafka.{scaladsl, CommitDelivery, CommitterSettings}
 import akka.stream.javadsl.{Flow, FlowWithContext, Sink}
 
 import scala.compat.java8.FutureConverters.FutureOps
@@ -28,6 +28,13 @@ object Committer {
    */
   def batchFlow[C <: Committable](settings: CommitterSettings): Flow[C, CommittableOffsetBatch, NotUsed] =
     scaladsl.Committer.batchFlow(settings).asJava
+
+  /**
+   * Commits batches to Kafka, emits `CommittableOffsetBatch` for every committed batch.
+   */
+  def batchFlow[C <: CommittableOffsetBatch](delivery: CommitDelivery,
+                                             parallelism: Int): Flow[C, CommittableOffsetBatch, NotUsed] =
+    scaladsl.Committer.batchFlow(delivery, parallelism).asJava
 
   /**
    * API MAY CHANGE

--- a/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
@@ -23,7 +23,7 @@ object Committer {
     batchFlow(settings).map(_ => Done)
 
   /**
-   * Commits batches to Kafka, emits `CommittableOffsetBatch` for every committed batch.
+   * Batches offsets and commits them to Kafka, emits `CommittableOffsetBatch` for every committed batch.
    */
   def batchFlow(settings: CommitterSettings): Flow[Committable, CommittableOffsetBatch, NotUsed] = {
     val offsetBatches = Flow[Committable]
@@ -34,7 +34,7 @@ object Committer {
   }
 
   /**
-   * Batches offsets and commits them to Kafka, emits `CommittableOffsetBatch` for every committed batch.
+   * Commits batches to Kafka, emits `CommittableOffsetBatch` for every committed batch.
    */
   def batchFlow(delivery: CommitDelivery,
                 parallelism: Int): Flow[CommittableOffsetBatch, CommittableOffsetBatch, NotUsed] = {


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
CLA signed

## Purpose

<!-- What does this PR do? -->
Enhances `Committer` API allowing committing batches of variable size.

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
Addresses issue #1032 

## Changes

<!-- Bullets for important changes in this PR -->
The changes are minimal and is basically split existing `flowBatch` in 2  pieces allowing greater flexibility when constructing the flow.

Test coverage is not reduced.

## Background Context

<!-- Why did you take this approach? -->
Prior to version 2.0.0 it was possible to create batches of custom size (because they had to be created 'manually'). The use case for that is to be able to commit 'successful part' of batch in case of stream error. This is to minimise duplicates when re-reading from last committed offset (gets us closer to exactly once strategy). 

With the release of version 2.0.0 batch creation is taken care of by `Committer` API and manual committing of batches is either deprecated or made package-private.

This PR addresses this problem.