### PR TITLE
Java API createCommittableOffsetBatch accepts Committable

### DIFF
--- a/core/src/main/mima-filters/2.0.1.backwards.excludes/PR1033-widen-type-for-committablebatch-factory-method.excludes
+++ b/core/src/main/mima-filters/2.0.1.backwards.excludes/PR1033-widen-type-for-committablebatch-factory-method.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[IncompatibleSignatureProblem]("akka.kafka.ConsumerMessage.createCommittableOffsetBatch")

--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -181,7 +181,7 @@ object ConsumerMessage {
    * Java API:
    * Create an offset batch out of a list of offsets.
    */
-  def createCommittableOffsetBatch(offsets: java.util.List[CommittableOffset]): CommittableOffsetBatch = {
+  def createCommittableOffsetBatch[T <: Committable](offsets: java.util.List[T]): CommittableOffsetBatch = {
     import scala.jdk.CollectionConverters._
     CommittableOffsetBatch(offsets.asScala.toList)
   }


### PR DESCRIPTION
## Purpose

The Java API `createCommittableOffsetBatch` requires a list of `CommittableOffset` where it should allow `Committable` (as the Scala API does in apply).

## References

#1020 
