### PR TITLE
Fix logging an error with cause

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/LoggingWithId.scala
+++ b/core/src/main/scala/akka/kafka/internal/LoggingWithId.scala
@@ -49,7 +49,7 @@ private[internal] final class LoggingAdapterWithPrefix(logger: LoggingAdapter, p
   private def msgWithId(message: String): String = prefix + message
 
   override protected def notifyError(message: String): Unit = logger.error(msgWithId(message))
-  override protected def notifyError(cause: Throwable, message: String): Unit = logger.error(msgWithId(message), cause)
+  override protected def notifyError(cause: Throwable, message: String): Unit = logger.error(cause, msgWithId(message))
   override protected def notifyWarning(message: String): Unit = logger.warning(msgWithId(message))
   override protected def notifyInfo(message: String): Unit = logger.info(msgWithId(message))
   override protected def notifyDebug(message: String): Unit = logger.debug(msgWithId(message))


### PR DESCRIPTION
Swapping the message and cause in the logger made it using the [error method which takes a template](https://github.com/akka/akka/blob/master/akka-actor/src/main/scala/akka/event/Logging.scala#L1261) and therefore tries to parse the cause into the message.

This results in a confusing error message and a loss of information. For example the log in the [DeferredProducer](https://github.com/akka/alpakka-kafka/blob/master/core/src/main/scala/akka/kafka/internal/DeferredProducer.scala#L70) results in 

> producer creation failed WARNING arguments left: 1

By putting the arguments back into the initial order (first cause, then message) it will treat the cause properly as a Throwable again in this function https://github.com/akka/akka/blob/master/akka-actor/src/main/scala/akka/event/Logging.scala#L1211