### PR TITLE
CommittingProducerSink: outstanding commits on multi-msg

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/CommittingProducerSinkStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommittingProducerSinkStage.scala
@@ -100,7 +100,7 @@ private final class CommittingProducerSinkStageLogic[K, V, IN <: Envelope[K, V, 
       case multiMsg: MultiMessage[K, V, Committable] =>
         val size = multiMsg.records.size
         awaitingProduceResult += size
-        awaitingCommitResult += size
+        awaitingCommitResult += 1
         val cb = new SendMultiCallback(size, multiMsg.passThrough)
         for {
           record <- multiMsg.records

--- a/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
@@ -214,6 +214,49 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
     control.drainAndShutdown().futureValue shouldBe Done
   }
 
+  it should "produce, and commit when batch size is reached with multi-messages" in assertAllStagesStopped {
+    val consumer = FakeConsumer(groupId, topic, startOffset = 1616L)
+
+    val elements = immutable.Seq(
+      consumer.message(partition, "value 1"),
+      consumer.message(partition, "value 2")
+    )
+
+    val producerRecordsPerInput = 2
+    val totalProducerRecords = elements.size * producerRecordsPerInput
+
+    val producer = new MockProducer[String, String](true, new StringSerializer, new StringSerializer)
+    val producerSettings = ProducerSettings(system, new StringSerializer, new StringSerializer)
+      .withProducer(producer)
+    val committerSettings = CommitterSettings(system).withMaxBatch(elements.size.longValue())
+
+    val control = Source(elements)
+      .concat(Source.maybe)
+      .viaMat(ConsumerControlFactory.controlFlow())(Keep.right)
+      .map { msg =>
+        ProducerMessage.multi(
+          (1 to producerRecordsPerInput)
+            .map(n => new ProducerRecord("targetTopic", msg.record.key, msg.record.value)),
+          msg.committableOffset
+        )
+      }
+      .toMat(
+        Producer.committableSink(producerSettings, committerSettings)
+      )(Keep.both)
+      .mapMaterializedValue(DrainingControl.apply)
+      .run()
+
+    val commitMsg = consumer.actor.expectMsgClass(classOf[Internal.Commit])
+    commitMsg.tp shouldBe new TopicPartition(topic, partition)
+    commitMsg.offsetAndMetadata.offset() shouldBe (consumer.startOffset + elements.size)
+    consumer.actor.reply(Done)
+
+    eventually {
+      producer.history.asScala should have size (totalProducerRecords.longValue())
+    }
+    control.drainAndShutdown().futureValue shouldBe Done
+  }
+
   it should "produce, and commit on completion" in assertAllStagesStopped {
     val consumer = FakeConsumer(groupId, topic, startOffset = 1616L)
 


### PR DESCRIPTION
Fixes the internal bookkeeping on the number of outstanding
commits in CommittingProducerSinkStageLogic when multi-messages
are passed in.

References #1040 
