### PR TITLE
CommittingProducerSink: Fix count on failure

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/CommittingProducerSinkStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommittingProducerSinkStage.scala
@@ -111,11 +111,12 @@ private final class CommittingProducerSinkStageLogic[K, V, IN <: Envelope[K, V, 
         collectOffset(0, msg.passThrough)
     }
 
-  private val sendFailureCb: AsyncCallback[Throwable] = getAsyncCallback[Throwable] { exception =>
-    decider(exception) match {
-      case Supervision.Stop => closeAndFailStage(exception)
-      case _ => collectOffsetIgnore(exception)
-    }
+  private val sendFailureCb: AsyncCallback[(Int, Throwable)] = getAsyncCallback[(Int, Throwable)] {
+    case (count, exception) =>
+      decider(exception) match {
+        case Supervision.Stop => closeAndFailStage(exception)
+        case _ => collectOffsetIgnore(count, exception)
+      }
   }
 
   /** send-callback for a single message. */
@@ -123,7 +124,7 @@ private final class CommittingProducerSinkStageLogic[K, V, IN <: Envelope[K, V, 
 
     override def onCompletion(metadata: RecordMetadata, exception: Exception): Unit =
       if (exception == null) collectOffsetCb.invoke(offset)
-      else sendFailureCb.invoke(exception)
+      else sendFailureCb.invoke(1 -> exception)
   }
 
   /** send-callback for a multi-message. */
@@ -133,7 +134,7 @@ private final class CommittingProducerSinkStageLogic[K, V, IN <: Envelope[K, V, 
     override def onCompletion(metadata: RecordMetadata, exception: Exception): Unit =
       if (exception == null) {
         if (counter.decrementAndGet() == 0) collectOffsetMultiCb.invoke(count -> offset)
-      } else sendFailureCb.invoke(exception)
+      } else sendFailureCb.invoke(count -> exception)
   }
 
   // ---- Committing
@@ -149,9 +150,10 @@ private final class CommittingProducerSinkStageLogic[K, V, IN <: Envelope[K, V, 
       collectOffset(count, offset)
   }
 
-  private def collectOffsetIgnore(exception: Throwable): Unit = {
+  private def collectOffsetIgnore(count: Int, exception: Throwable): Unit = {
     log.warning("ignoring send failure {}", exception)
     awaitingCommitResult -= 1
+    awaitingProduceResult -= count
   }
 
   private def scheduleCommit(): Unit =


### PR DESCRIPTION
Correct the updating of the count of outstanding produce requests
when a producer failure occurs in CommittingProducerSinkStage.

References #1042 
