### PR TITLE
Tests: Consistent ScalaTest PatienceConfig

### DIFF
--- a/tests/src/it/scala/akka/kafka/PartitionedSourceFailoverSpec.scala
+++ b/tests/src/it/scala/akka/kafka/PartitionedSourceFailoverSpec.scala
@@ -16,7 +16,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class PartitionedSourceFailoverSpec extends SpecBase with TestcontainersKafkaPerClassLike with WordSpecLike with ScalaFutures with Matchers {
-  implicit val pc = PatienceConfig(45.seconds, 1.second)
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(45.seconds, 1.second)
 
   override val testcontainersSettings = KafkaTestkitTestcontainersSettings(system)
     .withNumBrokers(3)

--- a/tests/src/it/scala/akka/kafka/PlainSourceFailoverSpec.scala
+++ b/tests/src/it/scala/akka/kafka/PlainSourceFailoverSpec.scala
@@ -15,7 +15,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 class PlainSourceFailoverSpec extends SpecBase with TestcontainersKafkaPerClassLike with WordSpecLike with ScalaFutures with Matchers {
-  implicit val pc = PatienceConfig(45.seconds, 100.millis)
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(45.seconds, 1.second)
 
   override val testcontainersSettings = KafkaTestkitTestcontainersSettings(system)
     .withNumBrokers(3)

--- a/tests/src/it/scala/akka/kafka/TransactionsPartitionedSourceSpec.scala
+++ b/tests/src/it/scala/akka/kafka/TransactionsPartitionedSourceSpec.scala
@@ -29,7 +29,7 @@ class TransactionsPartitionedSourceSpec extends SpecBase
 
   val replicationFactor = 2
 
-  implicit val pc = PatienceConfig(45.seconds, 1.second)
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(45.seconds, 1.second)
 
   override val testcontainersSettings = KafkaTestkitTestcontainersSettings(system)
     .withNumBrokers(3)

--- a/tests/src/it/scala/akka/kafka/TransactionsSourceSpec.scala
+++ b/tests/src/it/scala/akka/kafka/TransactionsSourceSpec.scala
@@ -28,7 +28,7 @@ class TransactionsSourceSpec extends SpecBase
   with TransactionsOps
   with Repeated {
 
-  implicit val pc = PatienceConfig(45.seconds, 1.second)
+  override implicit val patienceConfig: PatienceConfig = PatienceConfig(45.seconds, 1.second)
 
   override val testcontainersSettings = KafkaTestkitTestcontainersSettings(system)
     .withNumBrokers(3)

--- a/tests/src/test/scala/akka/kafka/ConsumerSettingsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/ConsumerSettingsSpec.scala
@@ -11,14 +11,17 @@ import akka.testkit.TestKit
 import com.typesafe.config.ConfigFactory
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, StringDeserializer}
 import org.scalatest._
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 
 import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
 
-class ConsumerSettingsSpec extends WordSpecLike with Matchers with OptionValues with ScalaFutures with LogCapturing {
-
-  implicit val patience = PatienceConfig(5.seconds, 10.millis)
+class ConsumerSettingsSpec
+    extends WordSpecLike
+    with Matchers
+    with OptionValues
+    with ScalaFutures
+    with IntegrationPatience
+    with LogCapturing {
 
   "ConsumerSettings" must {
 

--- a/tests/src/test/scala/akka/kafka/internal/CommittingWithMockSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingWithMockSpec.scala
@@ -20,12 +20,11 @@ import akka.testkit.TestKit
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization.StringDeserializer
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 
 import scala.jdk.CollectionConverters._
 import scala.collection.immutable.Seq
-import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
 object CommittingWithMockSpec {
@@ -53,11 +52,10 @@ class CommittingWithMockSpec(_system: ActorSystem)
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures
+    with IntegrationPatience
     with LogCapturing {
 
   import CommittingWithMockSpec._
-
-  implicit val patience: PatienceConfig = PatienceConfig(15.seconds, 1.second)
 
   def this() = this(ActorSystem())
 

--- a/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
@@ -23,7 +23,7 @@ import akka.testkit.TestKit
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization.StringDeserializer
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers, OptionValues}
 import org.slf4j.{Logger, LoggerFactory}
 
@@ -39,9 +39,8 @@ class PartitionedSourceSpec(_system: ActorSystem)
     with OptionValues
     with ScalaFutures
     with Eventually
+    with IntegrationPatience
     with LogCapturing {
-
-  implicit val patience = PatienceConfig(4.seconds, 50.millis)
 
   import PartitionedSourceSpec._
 

--- a/tests/src/test/scala/akka/kafka/scaladsl/CommittableSinkSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/CommittableSinkSpec.scala
@@ -12,7 +12,6 @@ import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import org.apache.kafka.clients.producer.ProducerRecord
-import org.scalatest.concurrent.IntegrationPatience
 
 import scala.collection.immutable
 import scala.concurrent.Future

--- a/tests/src/test/scala/akka/kafka/scaladsl/CommittableSinkSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/CommittableSinkSpec.scala
@@ -18,7 +18,7 @@ import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
 
-class CommittableSinkSpec extends SpecBase with TestcontainersKafkaLike with IntegrationPatience {
+class CommittableSinkSpec extends SpecBase with TestcontainersKafkaLike {
 
   final val Numbers = (1 to 200).map(_.toString)
   final val partition1 = 1

--- a/tests/src/test/scala/akka/kafka/scaladsl/MisconfiguredConsumerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/MisconfiguredConsumerSpec.scala
@@ -14,10 +14,8 @@ import akka.stream.{ActorMaterializer, Materializer}
 import akka.testkit.TestKit
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization.StringDeserializer
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.{Matchers, WordSpecLike}
-
-import scala.concurrent.duration._
 
 class MisconfiguredConsumerSpec
     extends TestKit(ActorSystem())
@@ -25,10 +23,10 @@ class MisconfiguredConsumerSpec
     with Matchers
     with ScalaFutures
     with Eventually
+    with IntegrationPatience
     with LogCapturing {
 
   implicit val materializer: Materializer = ActorMaterializer()
-  implicit val patience = PatienceConfig(2.seconds, 20.millis)
 
   def bootstrapServers = "nowhere:6666"
 

--- a/tests/src/test/scala/akka/kafka/scaladsl/MisconfiguredProducerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/MisconfiguredProducerSpec.scala
@@ -14,10 +14,8 @@ import akka.stream.{ActorMaterializer, Materializer}
 import akka.testkit.TestKit
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.StringSerializer
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.{Matchers, WordSpecLike}
-
-import scala.concurrent.duration._
 
 class MisconfiguredProducerSpec
     extends TestKit(ActorSystem())
@@ -25,10 +23,10 @@ class MisconfiguredProducerSpec
     with Matchers
     with ScalaFutures
     with Eventually
+    with IntegrationPatience
     with LogCapturing {
 
   implicit val materializer: Materializer = ActorMaterializer()
-  implicit val patience = PatienceConfig(2.seconds, 20.millis)
 
   "Failing producer construction" must {
     "fail stream appropriately" in assertAllStagesStopped {

--- a/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
@@ -29,7 +29,6 @@ import scala.util.{Failure, Success}
 
 class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with Inside with OptionValues {
 
-  implicit val patience = PatienceConfig(15.seconds, 500.millis)
   override def sleepAfterProduce: FiniteDuration = 500.millis
 
   "Partitioned source" must {

--- a/tests/src/test/scala/akka/kafka/scaladsl/RebalanceSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/RebalanceSpec.scala
@@ -28,7 +28,7 @@ import scala.util.Random
 
 class RebalanceSpec extends SpecBase with TestcontainersKafkaLike with Inside {
 
-  implicit val patience: PatienceConfig = PatienceConfig(30.seconds, 500.millis)
+  implicit override val patienceConfig: PatienceConfig = PatienceConfig(30.seconds, 500.millis)
 
   final val Numbers = (1 to 5000).map(_.toString)
   final val partition1 = 1

--- a/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
@@ -9,7 +9,7 @@ package akka.kafka.scaladsl
 import akka.kafka.Repeated
 import akka.kafka.testkit.scaladsl.ScalatestKafkaSpec
 import akka.kafka.tests.scaladsl.LogCapturing
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
+import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.{Matchers, WordSpecLike}
 
 abstract class SpecBase(kafkaPort: Int)
@@ -19,6 +19,9 @@ abstract class SpecBase(kafkaPort: Int)
     with ScalaFutures
     with Eventually
     with LogCapturing
+    // #testkit
+    with IntegrationPatience
+    // #testkit
     with Repeated {
 
   protected def this() = this(kafkaPort = -1)

--- a/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
@@ -25,8 +25,6 @@ import scala.concurrent.{Await, Future}
 
 class TransactionsSpec extends SpecBase with TestcontainersKafkaLike with TransactionsOps {
 
-  implicit val patience = PatienceConfig(5.seconds, 15.millis)
-
   "A consume-transform-produce cycle" must {
 
     "complete in happy-path scenario" in {

--- a/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala
@@ -16,11 +16,8 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 
 import scala.collection.immutable
-import scala.concurrent.duration._
 
 class AssignmentSpec extends SpecBase with TestcontainersKafkaLike {
-
-  implicit val patience = PatienceConfig(15.seconds, 1.second)
 
   "subscription with partition assignment" must {
 

--- a/tests/src/test/scala/docs/scaladsl/DocsSpecBase.scala
+++ b/tests/src/test/scala/docs/scaladsl/DocsSpecBase.scala
@@ -10,8 +10,7 @@ import akka.kafka.testkit.scaladsl.KafkaSpec
 import akka.kafka.testkit.internal.TestFrameworkInterface
 import akka.stream.scaladsl.Flow
 import org.scalatest.{FlatSpecLike, Matchers, Suite}
-import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 
 abstract class DocsSpecBase(kafkaPort: Int)
     extends KafkaSpec(kafkaPort)
@@ -19,14 +18,12 @@ abstract class DocsSpecBase(kafkaPort: Int)
     with TestFrameworkInterface.Scalatest
     with Matchers
     with ScalaFutures
+    with IntegrationPatience
     with Eventually {
 
   this: Suite =>
 
   protected def this() = this(kafkaPort = -1)
-
-  override implicit def patienceConfig: PatienceConfig =
-    PatienceConfig(timeout = scaled(Span(5, Seconds)), interval = scaled(Span(15, Millis)))
 
   def businessFlow[T]: Flow[T, T, NotUsed] = Flow[T]
 

--- a/tests/src/test/scala/docs/scaladsl/FetchMetadata.scala
+++ b/tests/src/test/scala/docs/scaladsl/FetchMetadata.scala
@@ -26,7 +26,7 @@ import scala.concurrent.duration._
 
 class FetchMetadata extends DocsSpecBase with TestcontainersKafkaLike with TryValues {
 
-  override implicit def patienceConfig: PatienceConfig =
+  override implicit val patienceConfig: PatienceConfig =
     PatienceConfig(timeout = scaled(Span(20, Seconds)), interval = scaled(Span(1, Seconds)))
 
   "Consumer metadata" should "be available" in {

--- a/tests/src/test/scala/docs/scaladsl/SerializationSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/SerializationSpec.scala
@@ -20,6 +20,7 @@ import akka.stream.testkit.scaladsl.TestSink
 import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig
 import org.apache.avro.util.Utf8
 import org.apache.kafka.common.TopicPartition
+import org.scalatest.concurrent.IntegrationPatience
 // #imports
 import io.confluent.kafka.serializers.{AbstractKafkaAvroSerDeConfig, KafkaAvroDeserializer, KafkaAvroSerializer}
 import org.apache.avro.specific.SpecificRecord
@@ -62,10 +63,8 @@ class SerializationSpec
     with TestFrameworkInterface.Scalatest
     with Matchers
     with ScalaFutures
+    with IntegrationPatience
     with Eventually {
-
-  override implicit def patienceConfig: PatienceConfig =
-    PatienceConfig(timeout = scaled(Span(5, Seconds)), interval = scaled(Span(15, Millis)))
 
   val schemaRegistryPort = KafkaPorts.ScalaAvroSerialization + 2
 

--- a/tests/src/test/scala/docs/scaladsl/TestkitSamplesSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/TestkitSamplesSpec.scala
@@ -6,7 +6,7 @@
 package docs.scaladsl
 
 import akka.actor.ActorSystem
-import akka.kafka.ConsumerMessage.{CommittableOffset}
+import akka.kafka.ConsumerMessage.CommittableOffset
 import akka.kafka.scaladsl.{Committer, Consumer}
 import akka.kafka.{CommitterSettings, ConsumerMessage, ProducerMessage}
 import akka.stream.scaladsl.{Flow, Keep, Source}
@@ -16,21 +16,19 @@ import akka.testkit.TestKit
 import akka.{Done, NotUsed}
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.producer.ProducerRecord
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 
 import scala.collection.immutable
-import scala.concurrent.duration._
 
 class TestkitSamplesSpec
     extends TestKit(ActorSystem("example"))
     with FlatSpecLike
     with Matchers
     with BeforeAndAfterAll
-    with ScalaFutures {
+    with ScalaFutures
+    with IntegrationPatience {
   implicit val mat: Materializer = ActorMaterializer()
-
-  implicit val patience = PatienceConfig(3.seconds, 100.millis)
 
   override protected def afterAll(): Unit = TestKit.shutdownActorSystem(system)
 


### PR DESCRIPTION
Use and apply ScalaTest `PatienceConfig` (to resolve `Futures`) in a more consistent manner.  Hopefully this will lead to less timeout configs in tests that don't have their own `PatienceConfig`.

Changes

* Add `IntegrationPatience` trait to `SpecBase`. This provides a more generous configuration for the rest of our integration tests. The default config is:
```
    PatienceConfig(
      timeout = scaled(Span(15, Seconds)),
      interval = scaled(Span(150, Millis))
    )
```
* Use `IntegrationPatience` in any test that overrides the default with config that is shorter than what is defined in `IntegrationPatience`.
* Use and override `IntegrationPatience` in any test that overrides the default with config that is longer than what is defined in `IntegrationPatience`.