### PR TITLE
Increase test timefactor on Travis

### DIFF
--- a/.jvmopts-travis
+++ b/.jvmopts-travis
@@ -1,7 +1,6 @@
 # This is used to configure the sbt instance that Travis launches
 
 -Dfile.encoding=UTF8
--Dakka.test.timefactor=6.0
 -Dsbt.color=always
 -Xms1G
 -Xmx1G

--- a/.jvmopts-travis
+++ b/.jvmopts-travis
@@ -1,6 +1,7 @@
 # This is used to configure the sbt instance that Travis launches
 
 -Dfile.encoding=UTF8
+-Dakka.test.timefactor=6.0
 -Dsbt.color=always
 -Xms1G
 -Xmx1G

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,3 +118,5 @@ env:
     - secure: "NLb9af0D3zS8UIHYqK86sLapFIN/iBpgXwjhc3t8e7bbVRVS1VKMNoqpzn75sd7rgYsComWboFUAo1oDMnGuOTf2onVOLDPWmp4QK568DVQTlEJ9rSI02RijjoPx4ViksI7wbh7Lz9VtupQVnBYU34Ozn7tuK12NGEHxQd9fCNE="
     # encrypt with: travis encrypt BINTRAY_PASS=...
     - secure: "DAhVvZ5hBy1MAznBCrQu6Rw6Pa7pCmqkpsYQFxG+y8Hsvi37WNMfyCOYcR6VnunMYWHDaFJ8LaqgWx8O4Usrl6JxZYt2J/jT7axKLqpsZg7xWaB2++tFWI2lZJewvb6EnPIZuEdr5oVKnazD5f55mxSqprOAHebim5IOXVaRGS0="
+    # override default akka.test.timefactor
+    - AKKA_TEST_TIMEFACTOR=10.0

--- a/tests/src/test/resources/application.conf
+++ b/tests/src/test/resources/application.conf
@@ -11,6 +11,7 @@ akka {
   test {
     # https://github.com/akka/alpakka-kafka/pull/994
     timefactor = 3.0
+    timefactor = ${?AKKA_TEST_TIMEFACTOR}
     single-expect-default = 10s
   }
 

--- a/tests/src/test/scala/docs/scaladsl/SerializationSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/SerializationSpec.scala
@@ -35,7 +35,6 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization._
 // #imports
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{FlatSpecLike, Matchers}
 import org.slf4j.bridge.SLF4JBridgeHandler
 


### PR DESCRIPTION
Increase the `akka.test.timefactor` for Travis tests. This should help mitigate timeouts in certain tests, like those with frequently stream restarts in `TransactionsSpec` (specifically #826).  A project default was defined in #994, but when I repeated the test locally I observed some runs still taking longer than the max allowed time (3x10sec=30sec). This new timefactor should allow for test runs of up to 60 seconds.

Instead of increasing the project default we can instead override the configuration on Travis builds only.

EDIT: Passing a system property (or any JVM flag) to the underlying ScalaTest suite and through SBT was more difficult than I thought.  I opted to use a global environment variable with an optional override in the test `application.conf` instead.

https://stackoverflow.com/questions/29857985/how-to-set-system-property-for-a-scalatest-from-sbt-command-line

EDIT 2: Also removes the unused imports failing some of the build.