### PR TITLE
Eventually consumer should close

### DIFF
--- a/tests/src/test/scala/akka/kafka/internal/ConsumerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConsumerSpec.scala
@@ -11,7 +11,7 @@ import akka.kafka.ConsumerMessage._
 import akka.kafka.scaladsl.Consumer
 import akka.kafka.scaladsl.Consumer.Control
 import akka.kafka.tests.scaladsl.LogCapturing
-import akka.kafka.{CommitTimeoutException, ConsumerSettings, Subscriptions}
+import akka.kafka.{CommitTimeoutException, ConsumerSettings, Repeated, Subscriptions}
 import akka.stream._
 import akka.stream.scaladsl._
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
@@ -20,6 +20,7 @@ import akka.testkit.TestKit
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.mockito.Mockito._
+import org.scalatest.concurrent.Eventually
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 
 import scala.jdk.CollectionConverters._
@@ -51,7 +52,9 @@ class ConsumerSpec(_system: ActorSystem)
     with FlatSpecLike
     with Matchers
     with BeforeAndAfterAll
-    with LogCapturing {
+    with LogCapturing
+    with Eventually
+    with Repeated {
 
   import ConsumerSpec._
 
@@ -260,7 +263,9 @@ class ConsumerSpec(_system: ActorSystem)
 
     Await.result(done, remainingOrDefault)
     Await.result(stopped, remainingOrDefault)
-    mock.verifyClosed()
+    eventually {
+      mock.verifyClosed()
+    }
   }
 
   it should "complete futures with failure when commit after stop" in assertAllStagesStopped {


### PR DESCRIPTION
The `ConsumerSpec` test `"keep stage running until all futures completed"` will sometimes fail if the `KafkaConsumer` mock's `close` method is not called in time for the mock verification to occur (#1049).  I think this happens because there's no blocking between when the `Source` stage shuts down and when it _tells_ the `KafkaConsumerActor` to stop.

https://github.com/akka/alpakka-kafka/blob/master/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala#L67

Eventually the `KafkaConsumerActor` will close the `KafkaConsumer`, which may be enough to satisfy this test.