### PR TITLE
Update settings for Transactions docs Examples

### DIFF
--- a/tests/src/it/resources/reference.conf
+++ b/tests/src/it/resources/reference.conf
@@ -14,6 +14,7 @@ akka {
   test {
     # https://github.com/akka/alpakka-kafka/pull/994
     timefactor = 3.0
+    timefactor = ${?AKKA_TEST_TIMEFACTOR}
     single-expect-default = 10s
   }
 

--- a/tests/src/test/scala/akka/kafka/TransactionsOps.scala
+++ b/tests/src/test/scala/akka/kafka/TransactionsOps.scala
@@ -196,6 +196,18 @@ trait TransactionsOps extends TestSuite with Matchers {
 
   def withProbeConsumerSettings(settings: ConsumerSettings[String, String],
                                 groupId: String): ConsumerSettings[String, String] =
+    TransactionsOps.withProbeConsumerSettings(settings, groupId)
+
+  def withTestProducerSettings(settings: ProducerSettings[String, String]): ProducerSettings[String, String] =
+    TransactionsOps.withTestProducerSettings(settings)
+
+  def withTransactionalProducerSettings(settings: ProducerSettings[String, String]): ProducerSettings[String, String] =
+    TransactionsOps.withTransactionalProducerSettings(settings)
+}
+
+object TransactionsOps {
+  def withProbeConsumerSettings(settings: ConsumerSettings[String, String],
+                                groupId: String): ConsumerSettings[String, String] =
     settings
       .withGroupId(groupId)
       .withProperties(ConsumerConfig.ISOLATION_LEVEL_CONFIG -> "read_committed")


### PR DESCRIPTION
I noticed that the Transactions docs examples don't use the same settings as the rest of the transactional tests do.  There are a few possible causes of #1051, but I think the most likely case is the reuse of consumer settings in the transactions workflow, with the consumer workflow used to assert messages ended up in the sink topic.

Bonus: I also updated the integration tests to make use of the `akka.test.timefactor` override when present in the Travis build introduced with #1048.

Fixes #1051 (hopefully!)
