### PR TITLE
Extend copyright headers to 2020

### DIFF
--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/AlpakkaCommittableProducer.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/AlpakkaCommittableProducer.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.kafka.benchmarks
 
 import akka.kafka.benchmarks.BenchmarksBase.{topic_100_100, topic_100_5000}

--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/BatchedConsumer.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/BatchedConsumer.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.kafka.benchmarks
 
 import akka.kafka.benchmarks.BenchmarksBase.{topic_1000_100, topic_1000_5000, topic_1000_5000_8}

--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/Benchmarks.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/Benchmarks.scala
@@ -1,7 +1,8 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
+
 package akka.kafka.benchmarks
 
 import akka.kafka.benchmarks.BenchmarksBase._

--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/NoCommitBackpressure.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/NoCommitBackpressure.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.kafka.benchmarks
 
 import akka.kafka.benchmarks.Timed.runPerfTest

--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/Producer.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/Producer.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.kafka.benchmarks
 
 import akka.kafka.benchmarks.BenchmarksBase.{topic_2000_100, topic_2000_500, topic_2000_5000, topic_2000_5000_8}

--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/SpecBase.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/SpecBase.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.kafka.benchmarks
 
 import akka.kafka.testkit.scaladsl.ScalatestKafkaSpec

--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/Transactions.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/Transactions.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.kafka.benchmarks
 
 import akka.kafka.benchmarks.BenchmarksBase.{topic_100_100, topic_100_5000}

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/AlpakkaCommittableSinkFixtures.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/AlpakkaCommittableSinkFixtures.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.benchmarks

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/FixtureGen.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/FixtureGen.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.benchmarks

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/InflightMetrics.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/InflightMetrics.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.benchmarks

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaConsumerBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaConsumerBenchmarks.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.benchmarks

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaConsumerFixtureGen.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaConsumerFixtureGen.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.benchmarks

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaProducerBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaProducerBenchmarks.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.benchmarks

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaProducerFixtureGen.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaProducerFixtureGen.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.benchmarks

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaTransactionBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaTransactionBenchmarks.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.benchmarks

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaTransactionFixtureGen.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaTransactionFixtureGen.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.benchmarks

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/PerfFixtureHelpers.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/PerfFixtureHelpers.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.benchmarks

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaConsumerBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaConsumerBenchmarks.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.benchmarks

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaConsumerFixtures.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaConsumerFixtures.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.benchmarks

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaProducerBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaProducerBenchmarks.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.benchmarks

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaProducerFixtures.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaProducerFixtures.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.benchmarks

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaTransactionBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaTransactionBenchmarks.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.benchmarks

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaTransactionFixtures.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaTransactionFixtures.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.benchmarks

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/Timed.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/Timed.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.benchmarks

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/app/RunTestCommand.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/app/RunTestCommand.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.benchmarks.app

--- a/build.sbt
+++ b/build.sbt
@@ -149,9 +149,9 @@ val commonSettings = Def.settings(
   scalafmtOnCompile := true,
   headerLicense := Some(
       HeaderLicense.Custom(
-        """|Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
-         |Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
-         |""".stripMargin
+        """|Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+           |Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
+           |""".stripMargin
       )
     ),
   bintrayOrganization := Some("akka"),
@@ -262,7 +262,7 @@ lazy val tests = project
   .configs(IntegrationTest.extend(Test))
   .settings(commonSettings)
   .settings(Defaults.itSettings)
-  .settings(automateHeaderSettings(IntegrationTest))
+  .settings(headerSettings(IntegrationTest))
   .settings(
     name := "akka-stream-kafka-tests",
     libraryDependencies ++= Seq(
@@ -383,7 +383,7 @@ lazy val benchmarks = project
   .configs(IntegrationTest)
   .settings(commonSettings)
   .settings(Defaults.itSettings)
-  .settings(automateHeaderSettings(IntegrationTest))
+  .settings(headerSettings(IntegrationTest))
   .settings(
     name := "akka-stream-kafka-benchmarks",
     publish / skip := true,

--- a/core/src/main/scala/akka/kafka/CommitTimeoutException.scala
+++ b/core/src/main/scala/akka/kafka/CommitTimeoutException.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka

--- a/core/src/main/scala/akka/kafka/CommitterSettings.scala
+++ b/core/src/main/scala/akka/kafka/CommitterSettings.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka

--- a/core/src/main/scala/akka/kafka/ConnectionCheckerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConnectionCheckerSettings.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka

--- a/core/src/main/scala/akka/kafka/ConsumerFailed.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerFailed.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka

--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka

--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka

--- a/core/src/main/scala/akka/kafka/KafkaConnectionFailed.scala
+++ b/core/src/main/scala/akka/kafka/KafkaConnectionFailed.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka

--- a/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/KafkaConsumerActor.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka

--- a/core/src/main/scala/akka/kafka/Metadata.scala
+++ b/core/src/main/scala/akka/kafka/Metadata.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka

--- a/core/src/main/scala/akka/kafka/ProducerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ProducerMessage.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka

--- a/core/src/main/scala/akka/kafka/ProducerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ProducerSettings.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka

--- a/core/src/main/scala/akka/kafka/RestrictedConsumer.scala
+++ b/core/src/main/scala/akka/kafka/RestrictedConsumer.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka

--- a/core/src/main/scala/akka/kafka/Subscriptions.scala
+++ b/core/src/main/scala/akka/kafka/Subscriptions.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka

--- a/core/src/main/scala/akka/kafka/internal/BaseSingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/BaseSingleSourceLogic.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/internal/CommittableSources.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommittableSources.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/internal/CommittingProducerSinkStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommittingProducerSinkStage.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/internal/ConfigSettings.scala
+++ b/core/src/main/scala/akka/kafka/internal/ConfigSettings.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/internal/ConnectionChecker.scala
+++ b/core/src/main/scala/akka/kafka/internal/ConnectionChecker.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/internal/ControlImplementations.scala
+++ b/core/src/main/scala/akka/kafka/internal/ControlImplementations.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/internal/DefaultProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/DefaultProducerStage.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/internal/DeferredProducer.scala
+++ b/core/src/main/scala/akka/kafka/internal/DeferredProducer.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/internal/ExternalSingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/ExternalSingleSourceLogic.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/internal/KafkaSourceStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaSourceStage.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/internal/LoggingWithId.scala
+++ b/core/src/main/scala/akka/kafka/internal/LoggingWithId.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
+++ b/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/internal/PartitionAssignmentHelpers.scala
+++ b/core/src/main/scala/akka/kafka/internal/PartitionAssignmentHelpers.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/internal/PlainSources.scala
+++ b/core/src/main/scala/akka/kafka/internal/PlainSources.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/internal/SourceLogicBuffer.scala
+++ b/core/src/main/scala/akka/kafka/internal/SourceLogicBuffer.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/internal/SourceLogicSubscription.scala
+++ b/core/src/main/scala/akka/kafka/internal/SourceLogicSubscription.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/internal/TransactionalSources.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalSources.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/core/src/main/scala/akka/kafka/javadsl/Committer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Committer.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.javadsl

--- a/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.javadsl

--- a/core/src/main/scala/akka/kafka/javadsl/DiscoverySupport.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/DiscoverySupport.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.javadsl

--- a/core/src/main/scala/akka/kafka/javadsl/MetadataClient.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/MetadataClient.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.javadsl

--- a/core/src/main/scala/akka/kafka/javadsl/PartitionAssignmentHandler.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/PartitionAssignmentHandler.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.javadsl

--- a/core/src/main/scala/akka/kafka/javadsl/Producer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Producer.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.javadsl

--- a/core/src/main/scala/akka/kafka/javadsl/Transactional.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Transactional.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.javadsl

--- a/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Committer.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/core/src/main/scala/akka/kafka/scaladsl/DiscoverySupport.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/DiscoverySupport.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/core/src/main/scala/akka/kafka/scaladsl/MetadataClient.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/MetadataClient.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/core/src/main/scala/akka/kafka/scaladsl/PartitionAssignmentHandler.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/PartitionAssignmentHandler.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Producer.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/core/src/main/scala/akka/kafka/scaladsl/Transactional.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Transactional.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/testkit/src/main/java/akka/kafka/testkit/internal/AlpakkaKafkaContainer.java
+++ b/testkit/src/main/java/akka/kafka/testkit/internal/AlpakkaKafkaContainer.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit.internal;

--- a/testkit/src/main/java/akka/kafka/testkit/internal/KafkaContainerCluster.java
+++ b/testkit/src/main/java/akka/kafka/testkit/internal/KafkaContainerCluster.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit.internal;

--- a/testkit/src/main/java/akka/kafka/testkit/javadsl/BaseKafkaTest.java
+++ b/testkit/src/main/java/akka/kafka/testkit/javadsl/BaseKafkaTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit.javadsl;

--- a/testkit/src/main/java/akka/kafka/testkit/javadsl/EmbeddedKafkaJunit4Test.java
+++ b/testkit/src/main/java/akka/kafka/testkit/javadsl/EmbeddedKafkaJunit4Test.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit.javadsl;

--- a/testkit/src/main/java/akka/kafka/testkit/javadsl/EmbeddedKafkaTest.java
+++ b/testkit/src/main/java/akka/kafka/testkit/javadsl/EmbeddedKafkaTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit.javadsl;

--- a/testkit/src/main/java/akka/kafka/testkit/javadsl/KafkaJunit4Test.java
+++ b/testkit/src/main/java/akka/kafka/testkit/javadsl/KafkaJunit4Test.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit.javadsl;

--- a/testkit/src/main/java/akka/kafka/testkit/javadsl/KafkaTest.java
+++ b/testkit/src/main/java/akka/kafka/testkit/javadsl/KafkaTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit.javadsl;

--- a/testkit/src/main/java/akka/kafka/testkit/javadsl/TestcontainersKafkaJunit4Test.java
+++ b/testkit/src/main/java/akka/kafka/testkit/javadsl/TestcontainersKafkaJunit4Test.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit.javadsl;

--- a/testkit/src/main/java/akka/kafka/testkit/javadsl/TestcontainersKafkaTest.java
+++ b/testkit/src/main/java/akka/kafka/testkit/javadsl/TestcontainersKafkaTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit.javadsl;

--- a/testkit/src/main/scala/akka/kafka/testkit/ConsumerResultFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/ConsumerResultFactory.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit

--- a/testkit/src/main/scala/akka/kafka/testkit/KafkaTestkitSettings.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/KafkaTestkitSettings.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit

--- a/testkit/src/main/scala/akka/kafka/testkit/KafkaTestkitTestcontainersSettings.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/KafkaTestkitTestcontainersSettings.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit

--- a/testkit/src/main/scala/akka/kafka/testkit/ProducerResultFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/ProducerResultFactory.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit.internal

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKitChecks.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKitChecks.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit.internal

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/TestFrameworkInterface.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/TestFrameworkInterface.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit.internal

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/TestcontainersKafka.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/TestcontainersKafka.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit.internal

--- a/testkit/src/main/scala/akka/kafka/testkit/javadsl/ConsumerControlFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/javadsl/ConsumerControlFactory.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit.javadsl

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/ConsumerControlFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/ConsumerControlFactory.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit.scaladsl

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/EmbeddedKafkaLike.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/EmbeddedKafkaLike.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit.scaladsl

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit.scaladsl

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/ScalatestKafkaSpec.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/ScalatestKafkaSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit.scaladsl

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/TestcontainersKafkaLike.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/TestcontainersKafkaLike.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit.scaladsl

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/TestcontainersKafkaPerClassLike.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/TestcontainersKafkaPerClassLike.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.testkit.scaladsl

--- a/tests/src/it/scala/akka/kafka/IntegrationTests.scala
+++ b/tests/src/it/scala/akka/kafka/IntegrationTests.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.kafka
 
 import akka.NotUsed

--- a/tests/src/it/scala/akka/kafka/PartitionedSourceFailoverSpec.scala
+++ b/tests/src/it/scala/akka/kafka/PartitionedSourceFailoverSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.kafka
 
 import akka.Done

--- a/tests/src/it/scala/akka/kafka/PlainSourceFailoverSpec.scala
+++ b/tests/src/it/scala/akka/kafka/PlainSourceFailoverSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.kafka
 
 import akka.kafka.scaladsl.{Consumer, Producer, SpecBase}

--- a/tests/src/it/scala/akka/kafka/TransactionsPartitionedSourceSpec.scala
+++ b/tests/src/it/scala/akka/kafka/TransactionsPartitionedSourceSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.kafka
 
 import java.util.concurrent.atomic.AtomicInteger

--- a/tests/src/it/scala/akka/kafka/TransactionsSourceSpec.scala
+++ b/tests/src/it/scala/akka/kafka/TransactionsSourceSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.kafka
 
 import java.util.concurrent.atomic.AtomicInteger

--- a/tests/src/main/scala/akka/kafka/KafkaPorts.scala
+++ b/tests/src/main/scala/akka/kafka/KafkaPorts.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka

--- a/tests/src/test/java/akka/kafka/javadsl/EmbeddedKafkaWithSchemaRegistryTest.java
+++ b/tests/src/test/java/akka/kafka/javadsl/EmbeddedKafkaWithSchemaRegistryTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.javadsl;

--- a/tests/src/test/java/docs/javadsl/AssignmentTest.java
+++ b/tests/src/test/java/docs/javadsl/AssignmentTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.javadsl;

--- a/tests/src/test/java/docs/javadsl/AssignmentWithTestcontainersTest.java
+++ b/tests/src/test/java/docs/javadsl/AssignmentWithTestcontainersTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.javadsl;

--- a/tests/src/test/java/docs/javadsl/AtLeastOnceTest.java
+++ b/tests/src/test/java/docs/javadsl/AtLeastOnceTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.javadsl;

--- a/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.javadsl;

--- a/tests/src/test/java/docs/javadsl/ConsumerSettingsTest.java
+++ b/tests/src/test/java/docs/javadsl/ConsumerSettingsTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.javadsl;

--- a/tests/src/test/java/docs/javadsl/FetchMetadataTest.java
+++ b/tests/src/test/java/docs/javadsl/FetchMetadataTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.javadsl;

--- a/tests/src/test/java/docs/javadsl/MetadataClientTest.java
+++ b/tests/src/test/java/docs/javadsl/MetadataClientTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.javadsl;

--- a/tests/src/test/java/docs/javadsl/ProducerExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/ProducerExampleTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.javadsl;

--- a/tests/src/test/java/docs/javadsl/ProducerSettingsTest.java
+++ b/tests/src/test/java/docs/javadsl/ProducerSettingsTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.javadsl;

--- a/tests/src/test/java/docs/javadsl/ProducerWithTestcontainersTest.java
+++ b/tests/src/test/java/docs/javadsl/ProducerWithTestcontainersTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.javadsl;

--- a/tests/src/test/java/docs/javadsl/SampleData.java
+++ b/tests/src/test/java/docs/javadsl/SampleData.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.javadsl;

--- a/tests/src/test/java/docs/javadsl/SerializationTest.java
+++ b/tests/src/test/java/docs/javadsl/SerializationTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.javadsl;

--- a/tests/src/test/java/docs/javadsl/TestkitSamplesTest.java
+++ b/tests/src/test/java/docs/javadsl/TestkitSamplesTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.javadsl;

--- a/tests/src/test/java/docs/javadsl/TestkitTestcontainersTest.java
+++ b/tests/src/test/java/docs/javadsl/TestkitTestcontainersTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.javadsl;

--- a/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.javadsl;

--- a/tests/src/test/scala/akka/kafka/ConfigSettingsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/ConfigSettingsSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka

--- a/tests/src/test/scala/akka/kafka/ConsumerSettingsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/ConsumerSettingsSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka

--- a/tests/src/test/scala/akka/kafka/ProducerSettingsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/ProducerSettingsSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka

--- a/tests/src/test/scala/akka/kafka/Repeated.scala
+++ b/tests/src/test/scala/akka/kafka/Repeated.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka

--- a/tests/src/test/scala/akka/kafka/TransactionsOps.scala
+++ b/tests/src/test/scala/akka/kafka/TransactionsOps.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka

--- a/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/tests/src/test/scala/akka/kafka/internal/CommittingWithMockSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingWithMockSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/tests/src/test/scala/akka/kafka/internal/ConnectionCheckerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConnectionCheckerSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/tests/src/test/scala/akka/kafka/internal/ConsumerDummy.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConsumerDummy.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/tests/src/test/scala/akka/kafka/internal/ConsumerMock.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConsumerMock.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/tests/src/test/scala/akka/kafka/internal/ConsumerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConsumerSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/tests/src/test/scala/akka/kafka/internal/EnhancedConfigSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/EnhancedConfigSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/tests/src/test/scala/akka/kafka/internal/OffsetAggregationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/OffsetAggregationSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/tests/src/test/scala/akka/kafka/internal/SubscriptionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/SubscriptionsSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.internal

--- a/tests/src/test/scala/akka/kafka/javadsl/ControlSpec.scala
+++ b/tests/src/test/scala/akka/kafka/javadsl/ControlSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.javadsl

--- a/tests/src/test/scala/akka/kafka/scaladsl/CommittableSinkSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/CommittableSinkSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/tests/src/test/scala/akka/kafka/scaladsl/ConnectionCheckerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/ConnectionCheckerSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/tests/src/test/scala/akka/kafka/scaladsl/ControlSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/ControlSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/tests/src/test/scala/akka/kafka/scaladsl/EmbeddedKafkaSampleSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/EmbeddedKafkaSampleSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/tests/src/test/scala/akka/kafka/scaladsl/MetadataClientSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/MetadataClientSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/tests/src/test/scala/akka/kafka/scaladsl/MisconfiguredConsumerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/MisconfiguredConsumerSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/tests/src/test/scala/akka/kafka/scaladsl/MisconfiguredProducerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/MisconfiguredProducerSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/tests/src/test/scala/akka/kafka/scaladsl/MultiConsumerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/MultiConsumerSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/tests/src/test/scala/akka/kafka/scaladsl/RebalanceSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/RebalanceSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/tests/src/test/scala/akka/kafka/scaladsl/ReconnectSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/ReconnectSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/tests/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/tests/src/test/scala/akka/kafka/scaladsl/TimestampSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TimestampSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.scaladsl

--- a/tests/src/test/scala/akka/kafka/tests/CapturingAppender.scala
+++ b/tests/src/test/scala/akka/kafka/tests/CapturingAppender.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.tests

--- a/tests/src/test/scala/akka/kafka/tests/LogbackUtil.scala
+++ b/tests/src/test/scala/akka/kafka/tests/LogbackUtil.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.tests

--- a/tests/src/test/scala/akka/kafka/tests/javadsl/LogCapturingExtension.scala
+++ b/tests/src/test/scala/akka/kafka/tests/javadsl/LogCapturingExtension.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.tests.javadsl

--- a/tests/src/test/scala/akka/kafka/tests/javadsl/LogCapturingJunit4.scala
+++ b/tests/src/test/scala/akka/kafka/tests/javadsl/LogCapturingJunit4.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.tests.javadsl

--- a/tests/src/test/scala/akka/kafka/tests/scaladsl/LogCapturing.scala
+++ b/tests/src/test/scala/akka/kafka/tests/scaladsl/LogCapturing.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.kafka.tests.scaladsl

--- a/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.scaladsl

--- a/tests/src/test/scala/docs/scaladsl/AtLeastOnce.scala
+++ b/tests/src/test/scala/docs/scaladsl/AtLeastOnce.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.scaladsl

--- a/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.scaladsl

--- a/tests/src/test/scala/docs/scaladsl/DocsSpecBase.scala
+++ b/tests/src/test/scala/docs/scaladsl/DocsSpecBase.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.scaladsl

--- a/tests/src/test/scala/docs/scaladsl/FetchMetadata.scala
+++ b/tests/src/test/scala/docs/scaladsl/FetchMetadata.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.scaladsl

--- a/tests/src/test/scala/docs/scaladsl/PartitionExamples.scala
+++ b/tests/src/test/scala/docs/scaladsl/PartitionExamples.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.scaladsl

--- a/tests/src/test/scala/docs/scaladsl/ProducerExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/ProducerExample.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.scaladsl

--- a/tests/src/test/scala/docs/scaladsl/SerializationSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/SerializationSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.scaladsl

--- a/tests/src/test/scala/docs/scaladsl/TestkitSamplesSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/TestkitSamplesSpec.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.scaladsl

--- a/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
@@ -1,6 +1,6 @@
 /*
- * Copyright (C) 2014 - 2016 Softwaremill <http://softwaremill.com>
- * Copyright (C) 2016 - 2019 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package docs.scaladsl


### PR DESCRIPTION
* Update header setting
* use `headerSettings(IntegrationTest)`
* apply to all (now including integration test sources) (second commit)