### PR TITLE
KafkaConsumerActor: don't use deprecated KafkaConsumer#committed method

### DIFF
--- a/core/src/main/scala/akka/kafka/Metadata.scala
+++ b/core/src/main/scala/akka/kafka/Metadata.scala
@@ -188,7 +188,7 @@ object Metadata {
    * Java API:
    * [[org.apache.kafka.clients.consumer.KafkaConsumer#committed()]]
    */
-  @deprecated("use `getCommittedOffsets`", "2.0.3")
+  @deprecated("use `createGetCommittedOffsets`", "2.0.3")
   def createGetCommittedOffset(partition: TopicPartition): GetCommittedOffset = GetCommittedOffset(partition)
 
   /**

--- a/core/src/main/scala/akka/kafka/Metadata.scala
+++ b/core/src/main/scala/akka/kafka/Metadata.scala
@@ -170,6 +170,31 @@ object Metadata {
   /**
    * [[org.apache.kafka.clients.consumer.KafkaConsumer#committed()]]
    */
+  @deprecated("use `GetCommittedOffsets`", "2.0.3")
+  final case class GetCommittedOffset(partition: TopicPartition) extends Request with NoSerializationVerificationNeeded
+
+  @deprecated("use `CommittedOffsets`", "2.0.3")
+  final case class CommittedOffset(response: Try[OffsetAndMetadata])
+      extends Response
+      with NoSerializationVerificationNeeded {
+
+    /**
+     * Java API
+     */
+    def getResponse: Optional[OffsetAndMetadata] = Optional.ofNullable(response.toOption.orNull)
+  }
+
+  /**
+   * Java API:
+   * [[org.apache.kafka.clients.consumer.KafkaConsumer#committed()]]
+   */
+  @deprecated("use `getCommittedOffsets`", "2.0.3")
+  def createGetCommittedOffset(partition: TopicPartition): GetCommittedOffset =
+    GetCommittedOffset(partition)
+
+  /**
+   * [[org.apache.kafka.clients.consumer.KafkaConsumer#committed()]]
+   */
   final case class GetCommittedOffsets(partitions: Set[TopicPartition])
       extends Request
       with NoSerializationVerificationNeeded

--- a/core/src/main/scala/akka/kafka/Metadata.scala
+++ b/core/src/main/scala/akka/kafka/Metadata.scala
@@ -170,20 +170,28 @@ object Metadata {
   /**
    * [[org.apache.kafka.clients.consumer.KafkaConsumer#committed()]]
    */
-  final case class GetCommittedOffset(partition: TopicPartition) extends Request with NoSerializationVerificationNeeded
-  final case class CommittedOffset(response: Try[OffsetAndMetadata], requestedPartition: TopicPartition)
+  final case class GetCommittedOffsets(partitions: Set[TopicPartition])
+      extends Request
+      with NoSerializationVerificationNeeded
+  final case class CommittedOffsets(response: Try[Map[TopicPartition, OffsetAndMetadata]])
       extends Response
       with NoSerializationVerificationNeeded {
 
     /**
      * Java API
      */
-    def getResponse: Optional[OffsetAndMetadata] = Optional.ofNullable(response.toOption.orNull)
+    def getResponse: Optional[java.util.Map[TopicPartition, OffsetAndMetadata]] =
+      response
+        .map { m =>
+          Optional.of(m.asJava)
+        }
+        .getOrElse(Optional.empty())
   }
 
   /**
    * Java API:
    * [[org.apache.kafka.clients.consumer.KafkaConsumer#committed()]]
    */
-  def createGetCommittedOffset(partition: TopicPartition): GetCommittedOffset = GetCommittedOffset(partition)
+  def createGetCommittedOffsets(partitions: java.util.Set[TopicPartition]): GetCommittedOffsets =
+    GetCommittedOffsets(partitions.asScala.toSet)
 }

--- a/core/src/main/scala/akka/kafka/Metadata.scala
+++ b/core/src/main/scala/akka/kafka/Metadata.scala
@@ -174,7 +174,7 @@ object Metadata {
   final case class GetCommittedOffset(partition: TopicPartition) extends Request with NoSerializationVerificationNeeded
 
   @deprecated("use `CommittedOffsets`", "2.0.3")
-  final case class CommittedOffset(response: Try[OffsetAndMetadata])
+  final case class CommittedOffset(response: Try[OffsetAndMetadata], requestedPartition: TopicPartition)
       extends Response
       with NoSerializationVerificationNeeded {
 
@@ -189,8 +189,7 @@ object Metadata {
    * [[org.apache.kafka.clients.consumer.KafkaConsumer#committed()]]
    */
   @deprecated("use `getCommittedOffsets`", "2.0.3")
-  def createGetCommittedOffset(partition: TopicPartition): GetCommittedOffset =
-    GetCommittedOffset(partition)
+  def createGetCommittedOffset(partition: TopicPartition): GetCommittedOffset = GetCommittedOffset(partition)
 
   /**
    * [[org.apache.kafka.clients.consumer.KafkaConsumer#committed()]]

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -690,7 +690,8 @@ import scala.util.control.NonFatal
 
     case Metadata.GetCommittedOffset(partition) =>
       Metadata.CommittedOffset(
-        Try { consumer.committed(Collections.singleton(partition), settings.getMetadataRequestTimeout).get(partition) }
+        Try { consumer.committed(partition, settings.getMetadataRequestTimeout) },
+        partition
       )
 
   }

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -5,6 +5,7 @@
 
 package akka.kafka.internal
 
+import java.util.Collections
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.LockSupport
 import java.util.regex.Pattern
@@ -686,6 +687,12 @@ import scala.util.control.NonFatal
             .toMap
         }
       )
+
+    case Metadata.GetCommittedOffset(partition) =>
+      Metadata.CommittedOffset(
+        Try { consumer.committed(Collections.singleton(partition), settings.getMetadataRequestTimeout).get(partition) }
+      )
+
   }
 
   private def stopFromMessage(msg: StopLike) = msg match {

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -676,10 +676,15 @@ import scala.util.control.NonFatal
         consumer.offsetsForTimes(search, settings.getMetadataRequestTimeout).asScala.toMap
       })
 
-    case Metadata.GetCommittedOffset(partition) =>
-      Metadata.CommittedOffset(
-        Try { consumer.committed(partition, settings.getMetadataRequestTimeout) },
-        partition
+    case Metadata.GetCommittedOffsets(partitions) =>
+      Metadata.CommittedOffsets(
+        Try {
+          consumer
+            .committed(partitions.asJava, settings.getMetadataRequestTimeout)
+            .asScala
+            .filterNot(_._2 == null)
+            .toMap
+        }
       )
   }
 

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -5,7 +5,6 @@
 
 package akka.kafka.internal
 
-import java.util.Collections
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.locks.LockSupport
 import java.util.regex.Pattern
@@ -693,7 +692,6 @@ import scala.util.control.NonFatal
         Try { consumer.committed(partition, settings.getMetadataRequestTimeout) },
         partition
       )
-
   }
 
   private def stopFromMessage(msg: StopLike) = msg match {

--- a/core/src/main/scala/akka/kafka/javadsl/MetadataClient.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/MetadataClient.scala
@@ -69,6 +69,10 @@ class MetadataClient private (metadataClient: akka.kafka.scaladsl.MetadataClient
       }(ExecutionContexts.sameThreadExecutionContext)
       .toJava
 
+  @deprecated("use getCommittedOffsets")
+  def getCommittedOffset(partition: TopicPartition): CompletionStage[OffsetAndMetadata] =
+    metadataClient.getCommittedOffset(partition).toJava
+
   def getCommittedOffsets(
       partitions: java.util.Set[TopicPartition]
   ): CompletionStage[java.util.Map[TopicPartition, OffsetAndMetadata]] =

--- a/core/src/main/scala/akka/kafka/javadsl/MetadataClient.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/MetadataClient.scala
@@ -69,9 +69,14 @@ class MetadataClient private (metadataClient: akka.kafka.scaladsl.MetadataClient
       }(ExecutionContexts.sameThreadExecutionContext)
       .toJava
 
-  def getCommittedOffset(partition: TopicPartition): CompletionStage[OffsetAndMetadata] =
+  def getCommittedOffsets(
+      partitions: java.util.Set[TopicPartition]
+  ): CompletionStage[java.util.Map[TopicPartition, OffsetAndMetadata]] =
     metadataClient
-      .getCommittedOffset(partition)
+      .getCommittedOffsets(partitions.asScala.toSet)
+      .map { committedOffsets =>
+        committedOffsets.asJava
+      }(ExecutionContexts.sameThreadExecutionContext)
       .toJava
 
   def close(): Unit =

--- a/core/src/main/scala/akka/kafka/javadsl/MetadataClient.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/MetadataClient.scala
@@ -69,9 +69,11 @@ class MetadataClient private (metadataClient: akka.kafka.scaladsl.MetadataClient
       }(ExecutionContexts.sameThreadExecutionContext)
       .toJava
 
-  @deprecated("use getCommittedOffsets")
+  @deprecated("use `getCommittedOffsets`", "2.0.3")
   def getCommittedOffset(partition: TopicPartition): CompletionStage[OffsetAndMetadata] =
-    metadataClient.getCommittedOffset(partition).toJava
+    metadataClient
+      .getCommittedOffset(partition)
+      .toJava
 
   def getCommittedOffsets(
       partitions: java.util.Set[TopicPartition]

--- a/core/src/main/scala/akka/kafka/scaladsl/MetadataClient.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/MetadataClient.scala
@@ -9,10 +9,10 @@ import akka.actor.{ActorRef, ActorSystem}
 import akka.dispatch.ExecutionContexts
 import akka.kafka.Metadata.{
   BeginningOffsets,
-  CommittedOffset,
+  CommittedOffsets,
   EndOffsets,
   GetBeginningOffsets,
-  GetCommittedOffset,
+  GetCommittedOffsets,
   GetEndOffsets,
   GetPartitionsFor,
   ListTopics,
@@ -76,9 +76,9 @@ class MetadataClient private (consumerActor: ActorRef, timeout: Timeout, managed
         case Failure(e) => Future.failed(e)
       }(ExecutionContexts.sameThreadExecutionContext)
 
-  def getCommittedOffset(partition: TopicPartition): Future[OffsetAndMetadata] =
-    (consumerActor ? GetCommittedOffset(partition))(timeout)
-      .mapTo[CommittedOffset]
+  def getCommittedOffsets(partitions: Set[TopicPartition]): Future[Map[TopicPartition, OffsetAndMetadata]] =
+    (consumerActor ? GetCommittedOffsets(partitions))(timeout)
+      .mapTo[CommittedOffsets]
       .map(_.response)
       .flatMap {
         case Success(res) => Future.successful(res)

--- a/core/src/main/scala/akka/kafka/scaladsl/MetadataClient.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/MetadataClient.scala
@@ -5,6 +5,8 @@
 
 package akka.kafka.scaladsl
 
+import java.util.Collections
+
 import akka.actor.{ActorRef, ActorSystem}
 import akka.dispatch.ExecutionContexts
 import akka.kafka.Metadata.{
@@ -75,6 +77,10 @@ class MetadataClient private (consumerActor: ActorRef, timeout: Timeout, managed
         case Success(res) => Future.successful(res)
         case Failure(e) => Future.failed(e)
       }(ExecutionContexts.sameThreadExecutionContext)
+
+  @deprecated("use `getCommittedOffsets`", "2.0.3")
+  def getCommittedOffset(partition: TopicPartition): Future[OffsetAndMetadata] =
+    getCommittedOffsets(Set(partition)).map(map => map.getOrElse(partition, null))
 
   def getCommittedOffsets(partitions: Set[TopicPartition]): Future[Map[TopicPartition, OffsetAndMetadata]] =
     (consumerActor ? GetCommittedOffsets(partitions))(timeout)

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -310,7 +310,7 @@ class IntegrationSpec extends SpecBase with TestcontainersKafkaLike with Inside 
 
         // GetCommittedOffset
         inside(Await.result(consumer ? GetCommittedOffset(partition0), 10.seconds)) {
-          case CommittedOffset(Success(offsetMeta)) =>
+          case CommittedOffset(Success(offsetMeta), _) =>
             assert(offsetMeta == null, "Wrong offsets in GetCommittedOffset")
         }
 

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -309,9 +309,9 @@ class IntegrationSpec extends SpecBase with TestcontainersKafkaLike with Inside 
         }
 
         // GetCommittedOffset
-        inside(Await.result(consumer ? GetCommittedOffset(partition0), 10.seconds)) {
-          case CommittedOffset(Success(offsetMeta), _) =>
-            assert(offsetMeta == null, "Wrong offset in GetCommittedOffset")
+        inside(Await.result(consumer ? GetCommittedOffsets(Set(partition0)), 10.seconds)) {
+          case CommittedOffsets(Success(offsetMeta)) =>
+            assert(offsetMeta.isEmpty, "Wrong offsets in GetCommittedOffset")
         }
 
         // verify that consumption still works

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -311,13 +311,13 @@ class IntegrationSpec extends SpecBase with TestcontainersKafkaLike with Inside 
         // GetCommittedOffset
         inside(Await.result(consumer ? GetCommittedOffset(partition0), 10.seconds)) {
           case CommittedOffset(Success(offsetMeta), _) =>
-            assert(offsetMeta == null, "Wrong offsets in GetCommittedOffset")
+            assert(offsetMeta == null, "Wrong offset in GetCommittedOffset")
         }
 
         // GetCommittedOffsets
         inside(Await.result(consumer ? GetCommittedOffsets(Set(partition0)), 10.seconds)) {
           case CommittedOffsets(Success(offsetMeta)) =>
-            assert(offsetMeta.isEmpty, "Wrong offsets in GetCommittedOffset")
+            assert(offsetMeta.isEmpty, "Wrong offsets in GetCommittedOffsets")
         }
 
         // verify that consumption still works

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -308,12 +308,6 @@ class IntegrationSpec extends SpecBase with TestcontainersKafkaLike with Inside 
             assert(offsetAndTs.offset() == 0, "Wrong offset in OffsetsForTimes (beginning)")
         }
 
-        // GetCommittedOffset
-        inside(Await.result(consumer ? GetCommittedOffset(partition0), 10.seconds)) {
-          case CommittedOffset(Success(offsetMeta), _) =>
-            assert(offsetMeta == null, "Wrong offset in GetCommittedOffset")
-        }
-
         // GetCommittedOffsets
         inside(Await.result(consumer ? GetCommittedOffsets(Set(partition0)), 10.seconds)) {
           case CommittedOffsets(Success(offsetMeta)) =>

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -309,6 +309,12 @@ class IntegrationSpec extends SpecBase with TestcontainersKafkaLike with Inside 
         }
 
         // GetCommittedOffset
+        inside(Await.result(consumer ? GetCommittedOffset(partition0), 10.seconds)) {
+          case CommittedOffset(Success(offsetMeta)) =>
+            assert(offsetMeta == null, "Wrong offsets in GetCommittedOffset")
+        }
+
+        // GetCommittedOffsets
         inside(Await.result(consumer ? GetCommittedOffsets(Set(partition0)), 10.seconds)) {
           case CommittedOffsets(Success(offsetMeta)) =>
             assert(offsetMeta.isEmpty, "Wrong offsets in GetCommittedOffset")


### PR DESCRIPTION
Stop using deprecated [KafkaConsumer#committed](https://kafka.apache.org/24/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#committed-org.apache.kafka.common.TopicPartition-java.time.Duration-) method, and start using its [replacement](https://kafka.apache.org/24/javadoc/org/apache/kafka/clients/consumer/KafkaConsumer.html#committed-java.util.Set-). This allows to use a set of partitions in a single call, which has better performance than iterating on the old deprecated method.
