### PR TITLE
Cluster-sharding: single listener per entity type key + Java DSL

### DIFF
--- a/cluster-sharding/src/main/scala/akka/kafka/cluster/sharding/KafkaClusterSharding.scala
+++ b/cluster-sharding/src/main/scala/akka/kafka/cluster/sharding/KafkaClusterSharding.scala
@@ -221,6 +221,7 @@ final class KafkaClusterSharding(system: ExtendedActorSystem) extends Extension 
    * val listenerClassicActorRef: akka.actor.ActorRef = listenerTypedActorRef.toClassic
    * }}}
    */
+  @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/1074")
   def rebalanceListener(typeKey: EntityTypeKey[_]): akka.actor.typed.ActorRef[ConsumerRebalanceEvent] = {
     rebalanceListeners.computeIfAbsent(typeKey, _ => {
       system.toTyped
@@ -246,6 +247,7 @@ final class KafkaClusterSharding(system: ExtendedActorSystem) extends Extension 
    * val listenerClassicActorRef: akka.actor.ActorRef = listenerTypedActorRef.toClassic
    * }}}
    */
+  @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/1074")
   def rebalanceListener(
       typeKey: akka.cluster.sharding.typed.javadsl.EntityTypeKey[_]
   ): akka.actor.typed.ActorRef[ConsumerRebalanceEvent] = {

--- a/cluster-sharding/src/test/java/docs/javadsl/ClusterShardingExample.java
+++ b/cluster-sharding/src/test/java/docs/javadsl/ClusterShardingExample.java
@@ -1,0 +1,85 @@
+package docs.javadsl;
+
+import akka.actor.typed.ActorSystem;
+import akka.actor.typed.Behavior;
+import akka.actor.typed.javadsl.Adapter;
+import akka.actor.typed.javadsl.Behaviors;
+import akka.cluster.sharding.external.ExternalShardAllocationStrategy;
+import akka.cluster.sharding.typed.javadsl.ClusterSharding;
+import akka.cluster.sharding.typed.javadsl.Entity;
+import akka.cluster.sharding.typed.javadsl.EntityTypeKey;
+import akka.kafka.AutoSubscription;
+import akka.kafka.ConsumerRebalanceEvent;
+import akka.kafka.ConsumerSettings;
+import akka.kafka.Subscriptions;
+import akka.kafka.cluster.sharding.KafkaClusterSharding;
+import akka.kafka.javadsl.Consumer;
+import akka.util.Timeout;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+
+import java.time.Duration;
+import java.util.concurrent.CompletionStage;
+
+public class ClusterShardingExample {
+
+    // #user-entity
+    final static class User {
+        public final String id;
+        public final String mame;
+
+        User(String id, String mame) {
+            this.id = id;
+            this.mame = mame;
+        }
+    }
+    // #user-entity
+
+    public static Behavior<User> userBehaviour() {
+        return Behaviors.empty();
+    }
+
+    public static void example() {
+        ActorSystem<Void> typedSystem = ActorSystem.create(Behaviors.empty(), "ClusterShardingExample");
+        String kafkaBootstrapServers = "localhost:9092";
+
+
+        // #message-extractor
+        // automatically retrieving the number of partitions requires a round trip to a Kafka broker
+        CompletionStage<KafkaClusterSharding.KafkaShardingNoEnvelopeExtractor<User>> messageExtractor = KafkaClusterSharding.get(typedSystem).messageExtractorNoEnvelope(
+                "user-topic",
+                Duration.ofSeconds(10),
+                (User msg) -> msg.id,
+                ConsumerSettings.create(Adapter.toClassic(typedSystem), new StringDeserializer(), new StringDeserializer())
+        );
+        // #message-extractor
+
+        // #setup-cluster-sharding
+
+        String groupId = "user-topic-group-id";
+        EntityTypeKey<User> typeKey = EntityTypeKey.create(User.class, groupId);
+
+        messageExtractor.thenAccept(extractor -> ClusterSharding.get(typedSystem).init(
+                    Entity.of(typeKey, ctx -> userBehaviour())
+                    .withAllocationStrategy(new ExternalShardAllocationStrategy(typedSystem, typeKey.name(), Timeout.create(Duration.ofSeconds(5))))
+                    .withMessageExtractor(extractor)));
+        // #setup-cluster-sharding
+
+        // #rebalance-listener
+        akka.actor.typed.ActorRef<ConsumerRebalanceEvent> rebalanceListener = KafkaClusterSharding.get(typedSystem).rebalanceListener(typeKey);
+
+        ConsumerSettings<String, byte[]> consumerSettings = ConsumerSettings.create(Adapter.toClassic(typedSystem), new StringDeserializer(), new ByteArrayDeserializer())
+                .withBootstrapServers(kafkaBootstrapServers)
+                .withGroupId(typeKey.name());// use the same group id as we used in the `EntityTypeKey` for `User`
+
+        // pass the rebalance listener to the topic subscription
+        AutoSubscription subscription = Subscriptions
+                .topics("user-topic")
+                .withRebalanceListener(Adapter.toClassic(rebalanceListener));
+
+        Consumer.plainSource(consumerSettings, subscription);
+        // #rebalance-listener
+
+
+    }
+}

--- a/core/src/main/scala/akka/kafka/Subscriptions.scala
+++ b/core/src/main/scala/akka/kafka/Subscriptions.scala
@@ -68,9 +68,12 @@ sealed trait AutoSubscription extends Subscription {
     }
 }
 
+@ApiMayChange
 sealed trait ConsumerRebalanceEvent
+@ApiMayChange
 final case class TopicPartitionsAssigned(sub: Subscription, topicPartitions: Set[TopicPartition])
     extends ConsumerRebalanceEvent
+@ApiMayChange
 final case class TopicPartitionsRevoked(sub: Subscription, topicPartitions: Set[TopicPartition])
     extends ConsumerRebalanceEvent
 

--- a/docs/src/main/paradox/cluster-sharding.md
+++ b/docs/src/main/paradox/cluster-sharding.md
@@ -50,15 +50,24 @@ Given a user entity.
 Scala
 : @@snip [snip](/cluster-sharding/src/test/scala/docs/scaladsl/ClusterShardingExample.scala) { #user-entity }
 
+Java
+: @@snip [snip](/cluster-sharding/src/test/java/docs/javadsl/ClusterShardingExample.java) { #user-entity }
+
 Create a `MessageExtractor`.
 
 Scala
 : @@snip [snip](/cluster-sharding/src/test/scala/docs/scaladsl/ClusterShardingExample.scala) { #message-extractor }
 
+Java
+: @@snip [snip](/cluster-sharding/src/test/java/docs/javadsl/ClusterShardingExample.java) { #message-extractor }
+
 Setup Akka Typed Cluster Sharding.
 
 Scala
 : @@snip [snip](/cluster-sharding/src/test/scala/docs/scaladsl/ClusterShardingExample.scala) { #setup-cluster-sharding }
+
+Java
+: @@snip [snip](/cluster-sharding/src/test/java/docs/javadsl/ClusterShardingExample.java) { #setup-cluster-sharding }
 
 ## Rebalance Listener
 
@@ -81,3 +90,6 @@ Create the rebalance listener using the extension and pass it into an Alpakka Ka
 
 Scala
 : @@snip [snip](/cluster-sharding/src/test/scala/docs/scaladsl/ClusterShardingExample.scala) { #rebalance-listener }
+
+Java
+: @@snip [snip](/cluster-sharding/src/test/java/docs/javadsl/ClusterShardingExample.java) { #rebalance-listener }


### PR DESCRIPTION
That way if it is loaded multiple times only one actor is created.

Also remove the method that takes in an actor system. We shouldn't allow
an extension from one system to use another system

Adds a Java API + docs
