### PR TITLE
DrainingControl: creation in toMat

### DIFF
--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/AlpakkaCommittableSinkFixtures.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/AlpakkaCommittableSinkFixtures.scala
@@ -131,7 +131,7 @@ object AlpakkaCommittableSinkBenchmarks extends LazyLogging {
           promise.complete(Success(()))
         msg
       }
-      .toMat(fixture.sink)(DrainingControl.form)
+      .toMat(fixture.sink)(DrainingControl.apply)
       .run()
 
     Await.result(promise.future, streamingTimeout)

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/AlpakkaCommittableSinkFixtures.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/AlpakkaCommittableSinkFixtures.scala
@@ -131,8 +131,7 @@ object AlpakkaCommittableSinkBenchmarks extends LazyLogging {
           promise.complete(Success(()))
         msg
       }
-      .toMat(fixture.sink)(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      .toMat(fixture.sink)(DrainingControl.form)
       .run()
 
     Await.result(promise.future, streamingTimeout)

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaConsumerBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaConsumerBenchmarks.scala
@@ -146,7 +146,7 @@ object ReactiveKafkaConsumerBenchmarks extends LazyLogging with InflightMetrics 
       .toMat(
         Committer
           .sink(committerDefaults.withDelivery(CommitDelivery.SendAndForget).withMaxBatch(commitBatchSize.toLong))
-      )(DrainingControl.form)
+      )(DrainingControl.apply)
       .run()
 
     Await.result(promise.future, streamingTimeout)

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaConsumerBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaConsumerBenchmarks.scala
@@ -146,10 +146,7 @@ object ReactiveKafkaConsumerBenchmarks extends LazyLogging with InflightMetrics 
       .toMat(
         Committer
           .sink(committerDefaults.withDelivery(CommitDelivery.SendAndForget).withMaxBatch(commitBatchSize.toLong))
-      )(
-        Keep.both
-      )
-      .mapMaterializedValue(DrainingControl.apply)
+      )(DrainingControl.form)
       .run()
 
     Await.result(promise.future, streamingTimeout)

--- a/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
@@ -114,7 +114,7 @@ object Consumer {
    *
    * For use in the `toMat` combination of materialized values.
    */
-  def formDrainingControl[T](c: Control, mat: CompletionStage[T]): DrainingControl[T] = new DrainingControl[T](c, mat)
+  def createDrainingControl[T](c: Control, mat: CompletionStage[T]): DrainingControl[T] = new DrainingControl[T](c, mat)
 
   /**
    * An implementation of Control to be used as an empty value, all methods return

--- a/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
@@ -98,12 +98,23 @@ object Consumer {
   }
 
   /**
-   * Combine control and a stream completion signal materialized values into
+   * Combine the consumer control and a stream completion signal materialized values into
    * one, so that the stream can be stopped in a controlled way without losing
    * commits.
+   *
+   * For use in `mapMaterializedValue`.
    */
   def createDrainingControl[T](pair: Pair[Control, CompletionStage[T]]) =
     new DrainingControl[T](pair.first, pair.second)
+
+  /**
+   * Combine the consumer control and a stream completion signal materialized values into
+   * one, so that the stream can be stopped in a controlled way without losing
+   * commits.
+   *
+   * For use in the `toMat` combination of materialized values.
+   */
+  def formDrainingControl[T](c: Control, mat: CompletionStage[T]): DrainingControl[T] = new DrainingControl[T](c, mat)
 
   /**
    * An implementation of Control to be used as an empty value, all methods return

--- a/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
@@ -143,7 +143,7 @@ object Consumer {
      *
      * For use in the `toMat` combination of materialized values.
      */
-    def form[T]: (Control, Future[T]) => DrainingControl[T] = new DrainingControl[T](_, _)
+    def apply[T]: (Control, Future[T]) => DrainingControl[T] = new DrainingControl[T](_, _)
   }
 
   /**

--- a/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
@@ -11,7 +11,7 @@ import akka.dispatch.ExecutionContexts
 import akka.kafka.ConsumerMessage.{CommittableMessage, CommittableOffset}
 import akka.kafka._
 import akka.kafka.internal._
-import akka.stream.scaladsl.{Source, SourceWithContext}
+import akka.stream.scaladsl.{Keep, Source, SourceWithContext}
 import akka.{Done, NotUsed}
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
@@ -128,11 +128,22 @@ object Consumer {
   object DrainingControl {
 
     /**
-     * Combine control and a stream completion signal materialized values into
+     * Combine the consumer control and a stream completion signal materialized values into
      * one, so that the stream can be stopped in a controlled way without losing
      * commits.
+     *
+     * For use in `mapMaterializedValue`.
      */
     def apply[T](tuple: (Control, Future[T])) = new DrainingControl[T](tuple._1, tuple._2)
+
+    /**
+     * Combine the consumer control and a stream completion signal materialized values into
+     * one, so that the stream can be stopped in a controlled way without losing
+     * commits.
+     *
+     * For use in the `toMat` combination of materialized values.
+     */
+    def form[T]: (Control, Future[T]) => DrainingControl[T] = new DrainingControl[T](_, _)
   }
 
   /**

--- a/docs/src/main/paradox/consumer.md
+++ b/docs/src/main/paradox/consumer.md
@@ -313,7 +313,7 @@ When you are using offset storage in Kafka, the shutdown process involves severa
 ### Draining control
 
 To manage this shutdown process, use the @apidoc[Consumer.DrainingControl]
-by combining the `Consumer.Control` with the sink's materialized completion future in `mapMaterializedValue`. That control offers the method `drainAndShutdown` which implements the process descibed above.
+by combining the @apidoc[Consumer.Control] with the sink's materialized completion future in `toMat` with @scala[`DrainingControl.form`]@java[`Consumer::formDrainingControl`], or from a tuple in `mapMaterializedValue` with @scala[`DrainingControl.apply`]@java[`Consumer::createDrainingControl`]. That control offers the method `drainAndShutdown` which implements the process described above.
 
 Note: The @apidoc[ConsumerSettings] `stop-timeout` delays stopping the Kafka Consumer and the stream, but when using `drainAndShutdown` that delay is not required and can be set to zero (as below).
 

--- a/docs/src/main/paradox/consumer.md
+++ b/docs/src/main/paradox/consumer.md
@@ -313,7 +313,7 @@ When you are using offset storage in Kafka, the shutdown process involves severa
 ### Draining control
 
 To manage this shutdown process, use the @apidoc[Consumer.DrainingControl]
-by combining the @apidoc[Consumer.Control] with the sink's materialized completion future in `toMat` with @scala[`DrainingControl.form`]@java[`Consumer::formDrainingControl`], or from a tuple in `mapMaterializedValue` with @scala[`DrainingControl.apply`]@java[`Consumer::createDrainingControl`]. That control offers the method `drainAndShutdown` which implements the process described above.
+by combining the @apidoc[Consumer.Control] with the sink's materialized completion future in `toMat` or in `mapMaterializedValue` with @scala[`DrainingControl.apply`]@java[`Consumer::createDrainingControl`]. That control offers the method `drainAndShutdown` which implements the process described above. The wrapped stream completion signal is available through the @scala[`streamCompletion`]@java[`streamCompletion()`] accessor.
 
 Note: The @apidoc[ConsumerSettings] `stop-timeout` delays stopping the Kafka Consumer and the stream, but when using `drainAndShutdown` that delay is not required and can be set to zero (as below).
 

--- a/testkit/src/main/java/akka/kafka/testkit/javadsl/BaseKafkaTest.java
+++ b/testkit/src/main/java/akka/kafka/testkit/javadsl/BaseKafkaTest.java
@@ -12,9 +12,7 @@ import akka.kafka.javadsl.Consumer;
 import akka.kafka.javadsl.Producer;
 import akka.kafka.testkit.internal.KafkaTestKitChecks;
 import akka.kafka.testkit.internal.KafkaTestKitClass;
-import akka.kafka.testkit.internal.KafkaTestKit;
 import akka.stream.Materializer;
-import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import org.apache.kafka.clients.admin.ConsumerGroupDescription;
@@ -73,7 +71,7 @@ public abstract class BaseKafkaTest extends KafkaTestKitClass {
     return Consumer.plainSource(
             consumerDefaults().withGroupId(createGroupId(1)), Subscriptions.topics(topic))
         .take(take)
-        .toMat(Sink.seq(), Consumer::formDrainingControl)
+        .toMat(Sink.seq(), Consumer::createDrainingControl)
         .run(materializer);
   }
 

--- a/testkit/src/main/java/akka/kafka/testkit/javadsl/BaseKafkaTest.java
+++ b/testkit/src/main/java/akka/kafka/testkit/javadsl/BaseKafkaTest.java
@@ -73,8 +73,7 @@ public abstract class BaseKafkaTest extends KafkaTestKitClass {
     return Consumer.plainSource(
             consumerDefaults().withGroupId(createGroupId(1)), Subscriptions.topics(topic))
         .take(take)
-        .toMat(Sink.seq(), Keep.both())
-        .mapMaterializedValue(Consumer::createDrainingControl)
+        .toMat(Sink.seq(), Consumer::formDrainingControl)
         .run(materializer);
   }
 

--- a/tests/src/test/java/docs/javadsl/AtLeastOnceTest.java
+++ b/tests/src/test/java/docs/javadsl/AtLeastOnceTest.java
@@ -82,7 +82,7 @@ public class AtLeastOnceTest extends TestcontainersKafkaJunit4Test {
                 })
             .via(Producer.flexiFlow(producerSettings))
             .map(m -> m.passThrough())
-            .toMat(Committer.sink(committerSettings), Consumer::formDrainingControl)
+            .toMat(Committer.sink(committerSettings), Consumer::createDrainingControl)
             .run(materializer);
     // #oneToMany
     Pair<Consumer.Control, CompletionStage<List<ConsumerRecord<String, String>>>> tuple =
@@ -122,7 +122,7 @@ public class AtLeastOnceTest extends TestcontainersKafkaJunit4Test {
                 })
             .via(Producer.flowWithContext(producerSettings))
             .toMat(
-                Committer.sinkWithOffsetContext(committerSettings), Consumer::formDrainingControl)
+                Committer.sinkWithOffsetContext(committerSettings), Consumer::createDrainingControl)
             .run(materializer);
     Pair<Consumer.Control, CompletionStage<List<ConsumerRecord<String, String>>>> tuple =
         Consumer.plainSource(consumerSettings, Subscriptions.topics(topic2, topic3))
@@ -182,7 +182,7 @@ public class AtLeastOnceTest extends TestcontainersKafkaJunit4Test {
                 })
             .via(Producer.flexiFlow(producerSettings))
             .map(m -> m.passThrough())
-            .toMat(Committer.sink(committerSettings), Consumer::formDrainingControl)
+            .toMat(Committer.sink(committerSettings), Consumer::createDrainingControl)
             .run(materializer);
     // #oneToConditional
 
@@ -220,7 +220,8 @@ public class AtLeastOnceTest extends TestcontainersKafkaJunit4Test {
             .mapContext(ConsumerMessage::createCommittableOffsetBatch)
             .via(Producer.flowWithContext(producerDefaults()))
             .toMat(
-                Committer.sinkWithOffsetContext(committerDefaults()), Consumer::formDrainingControl)
+                Committer.sinkWithOffsetContext(committerDefaults()),
+                Consumer::createDrainingControl)
             .run(materializer);
 
     Pair<Consumer.Control, CompletionStage<List<ConsumerRecord<String, String>>>> pair =

--- a/tests/src/test/java/docs/javadsl/AtLeastOnceTest.java
+++ b/tests/src/test/java/docs/javadsl/AtLeastOnceTest.java
@@ -82,8 +82,7 @@ public class AtLeastOnceTest extends TestcontainersKafkaJunit4Test {
                 })
             .via(Producer.flexiFlow(producerSettings))
             .map(m -> m.passThrough())
-            .toMat(Committer.sink(committerSettings), Keep.both())
-            .mapMaterializedValue(Consumer::createDrainingControl)
+            .toMat(Committer.sink(committerSettings), Consumer::formDrainingControl)
             .run(materializer);
     // #oneToMany
     Pair<Consumer.Control, CompletionStage<List<ConsumerRecord<String, String>>>> tuple =
@@ -122,8 +121,8 @@ public class AtLeastOnceTest extends TestcontainersKafkaJunit4Test {
                   return multiMsg;
                 })
             .via(Producer.flowWithContext(producerSettings))
-            .toMat(Committer.sinkWithOffsetContext(committerSettings), Keep.both())
-            .mapMaterializedValue(Consumer::createDrainingControl)
+            .toMat(
+                Committer.sinkWithOffsetContext(committerSettings), Consumer::formDrainingControl)
             .run(materializer);
     Pair<Consumer.Control, CompletionStage<List<ConsumerRecord<String, String>>>> tuple =
         Consumer.plainSource(consumerSettings, Subscriptions.topics(topic2, topic3))
@@ -183,8 +182,7 @@ public class AtLeastOnceTest extends TestcontainersKafkaJunit4Test {
                 })
             .via(Producer.flexiFlow(producerSettings))
             .map(m -> m.passThrough())
-            .toMat(Committer.sink(committerSettings), Keep.both())
-            .mapMaterializedValue(Consumer::createDrainingControl)
+            .toMat(Committer.sink(committerSettings), Consumer::formDrainingControl)
             .run(materializer);
     // #oneToConditional
 
@@ -221,8 +219,8 @@ public class AtLeastOnceTest extends TestcontainersKafkaJunit4Test {
                 })
             .mapContext(ConsumerMessage::createCommittableOffsetBatch)
             .via(Producer.flowWithContext(producerDefaults()))
-            .toMat(Committer.sinkWithOffsetContext(committerDefaults()), Keep.both())
-            .mapMaterializedValue(Consumer::createDrainingControl)
+            .toMat(
+                Committer.sinkWithOffsetContext(committerDefaults()), Consumer::formDrainingControl)
             .run(materializer);
 
     Pair<Consumer.Control, CompletionStage<List<ConsumerRecord<String, String>>>> pair =

--- a/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/ConsumerExampleTest.java
@@ -197,8 +197,7 @@ class ConsumerExampleTest extends TestcontainersKafkaTest {
                 msg ->
                     business(msg.record().key(), msg.record().value())
                         .thenApply(done -> msg.committableOffset()))
-            .toMat(Committer.sink(committerSettings.withMaxBatch(1)), Keep.both())
-            .mapMaterializedValue(Consumer::createDrainingControl)
+            .toMat(Committer.sink(committerSettings.withMaxBatch(1)), Consumer::formDrainingControl)
             .run(materializer);
 
     // #atLeastOnce
@@ -222,8 +221,7 @@ class ConsumerExampleTest extends TestcontainersKafkaTest {
                 msg ->
                     business(msg.record().key(), msg.record().value())
                         .<ConsumerMessage.Committable>thenApply(done -> msg.committableOffset()))
-            .toMat(Committer.sink(committerSettings), Keep.both())
-            .mapMaterializedValue(Consumer::createDrainingControl)
+            .toMat(Committer.sink(committerSettings), Consumer::formDrainingControl)
             .run(materializer);
     // #committerSink
     assertDone(produceString(topic, 10, partition0));
@@ -247,8 +245,7 @@ class ConsumerExampleTest extends TestcontainersKafkaTest {
                 msg ->
                     business(msg.record().key(), msg.record().value())
                         .thenApply(done -> msg.committableOffset()))
-            .toMat(Committer.sink(committerSettings), Keep.both())
-            .mapMaterializedValue(Consumer::createDrainingControl)
+            .toMat(Committer.sink(committerSettings), Consumer::formDrainingControl)
             .run(materializer);
     // #commitWithMetadata
     assertDone(produceString(topic, 10, partition0));
@@ -272,8 +269,9 @@ class ConsumerExampleTest extends TestcontainersKafkaTest {
                     ProducerMessage.<String, String, ConsumerMessage.Committable>single(
                         new ProducerRecord<>(targetTopic, msg.record().key(), msg.record().value()),
                         msg.committableOffset()))
-            .toMat(Producer.committableSink(producerSettings, committerSettings), Keep.both())
-            .mapMaterializedValue(Consumer::createDrainingControl)
+            .toMat(
+                Producer.committableSink(producerSettings, committerSettings),
+                Consumer::formDrainingControl)
             .run(materializer);
     // #consumerToProducerSink
     assertDone(produceString(topic1, 10, partition0));
@@ -303,8 +301,7 @@ class ConsumerExampleTest extends TestcontainersKafkaTest {
                         new ProducerRecord<>(targetTopic, record.key(), record.value())))
             .toMat(
                 Producer.committableSinkWithOffsetContext(producerSettings, committerSettings),
-                Keep.both())
-            .mapMaterializedValue(Consumer::createDrainingControl)
+                Consumer::formDrainingControl)
             .run(materializer);
     // #consumerToProducerWithContext
     assertDone(produceString(topic1, 10, partition0));
@@ -329,8 +326,7 @@ class ConsumerExampleTest extends TestcontainersKafkaTest {
             .flatMapMerge(maxPartitions, Pair::second)
             .via(business())
             .map(msg -> msg.committableOffset())
-            .toMat(Committer.sink(committerSettings), Keep.both())
-            .mapMaterializedValue(Consumer::createDrainingControl)
+            .toMat(Committer.sink(committerSettings), Consumer::formDrainingControl)
             .run(materializer);
     // #committablePartitionedSource
     assertDone(produceString(topic, 10, partition0));
@@ -357,8 +353,7 @@ class ConsumerExampleTest extends TestcontainersKafkaTest {
                       .map(message -> message.committableOffset())
                       .runWith(Committer.sink(committerSettings), materializer);
                 })
-            .toMat(Sink.ignore(), Keep.both())
-            .mapMaterializedValue(Consumer::createDrainingControl)
+            .toMat(Sink.ignore(), Consumer::formDrainingControl)
             .run(materializer);
     // #committablePartitionedSource-stream-per-partition
     assertDone(produceString(topic, 10, partition0));
@@ -477,8 +472,7 @@ class ConsumerExampleTest extends TestcontainersKafkaTest {
             // #withRebalanceListenerActor
             .take(messageCount)
             // #withRebalanceListenerActor
-            .toMat(Sink.seq(), Keep.both())
-            .mapMaterializedValue(Consumer::createDrainingControl)
+            .toMat(Sink.seq(), Consumer::formDrainingControl)
             .run(materializer);
     // #withRebalanceListenerActor
     assertDone(produceString(topic, messageCount, partition0));
@@ -528,8 +522,7 @@ class ConsumerExampleTest extends TestcontainersKafkaTest {
     Consumer.DrainingControl<List<ConsumerRecord<String, String>>> control =
         Consumer.plainSource(consumerSettings, subscription)
             .take(messageCount)
-            .toMat(Sink.seq(), Keep.both())
-            .mapMaterializedValue(Consumer::createDrainingControl)
+            .toMat(Sink.seq(), Consumer::formDrainingControl)
             .run(materializer);
     assertDone(produceString(topic, messageCount, partition0));
     assertDone(control.isShutdown());
@@ -551,8 +544,7 @@ class ConsumerExampleTest extends TestcontainersKafkaTest {
         Consumer.plainSource(
                 consumerSettings, Subscriptions.assignment(new TopicPartition(topic, 0)))
             .via(business())
-            .toMat(Sink.ignore(), Keep.both())
-            .mapMaterializedValue(Consumer::createDrainingControl)
+            .toMat(Sink.ignore(), Consumer::formDrainingControl)
             .run(materializer);
 
     // #consumerMetrics
@@ -587,8 +579,7 @@ class ConsumerExampleTest extends TestcontainersKafkaTest {
                             record ->
                                 business(record.key(), record.value())
                                     .thenApply(res -> db.storeProcessedOffset(record.offset())))
-                        .toMat(Sink.ignore(), Keep.both())
-                        .mapMaterializedValue(Consumer::createDrainingControl)
+                        .toMat(Sink.ignore(), Consumer::formDrainingControl)
                         .run(materializer));
 
     // Shutdown the consumer when desired
@@ -618,8 +609,7 @@ class ConsumerExampleTest extends TestcontainersKafkaTest {
             // #shutdownCommittableSource
             .take(messageCount)
             // #shutdownCommittableSource
-            .toMat(Committer.sink(committerSettings.withMaxBatch(1)), Keep.both())
-            .mapMaterializedValue(Consumer::createDrainingControl)
+            .toMat(Committer.sink(committerSettings.withMaxBatch(1)), Consumer::formDrainingControl)
             .run(materializer);
 
     // #shutdownCommittableSource

--- a/tests/src/test/java/docs/javadsl/SerializationTest.java
+++ b/tests/src/test/java/docs/javadsl/SerializationTest.java
@@ -15,7 +15,6 @@ import akka.kafka.javadsl.Consumer;
 import akka.kafka.javadsl.EmbeddedKafkaWithSchemaRegistryTest;
 import akka.kafka.javadsl.Producer;
 import akka.stream.*;
-import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.testkit.javadsl.TestKit;
@@ -119,7 +118,7 @@ public class SerializationTest extends EmbeddedKafkaWithSchemaRegistryTest {
             // #jackson-deserializer
             .take(samples.size())
             // #jackson-deserializer
-            .toMat(Sink.seq(), Consumer::formDrainingControl)
+            .toMat(Sink.seq(), Consumer::createDrainingControl)
             .run(mat);
     // #jackson-deserializer
 
@@ -183,7 +182,7 @@ public class SerializationTest extends EmbeddedKafkaWithSchemaRegistryTest {
     Consumer.DrainingControl<List<ConsumerRecord<String, Object>>> controlCompletionStagePair =
         Consumer.plainSource(consumerSettings, Subscriptions.topics(topic))
             .take(samples.size())
-            .toMat(Sink.seq(), Consumer::formDrainingControl)
+            .toMat(Sink.seq(), Consumer::createDrainingControl)
             .run(mat);
     // #de-serializer
 

--- a/tests/src/test/java/docs/javadsl/SerializationTest.java
+++ b/tests/src/test/java/docs/javadsl/SerializationTest.java
@@ -119,8 +119,7 @@ public class SerializationTest extends EmbeddedKafkaWithSchemaRegistryTest {
             // #jackson-deserializer
             .take(samples.size())
             // #jackson-deserializer
-            .toMat(Sink.seq(), Keep.both())
-            .mapMaterializedValue(Consumer::createDrainingControl)
+            .toMat(Sink.seq(), Consumer::formDrainingControl)
             .run(mat);
     // #jackson-deserializer
 
@@ -184,8 +183,7 @@ public class SerializationTest extends EmbeddedKafkaWithSchemaRegistryTest {
     Consumer.DrainingControl<List<ConsumerRecord<String, Object>>> controlCompletionStagePair =
         Consumer.plainSource(consumerSettings, Subscriptions.topics(topic))
             .take(samples.size())
-            .toMat(Sink.seq(), Keep.both())
-            .mapMaterializedValue(Consumer::createDrainingControl)
+            .toMat(Sink.seq(), Consumer::formDrainingControl)
             .run(mat);
     // #de-serializer
 

--- a/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java
@@ -81,7 +81,7 @@ public class TransactionsExampleTest extends TestcontainersKafkaJunit4Test {
                         msg.partitionOffset()))
             .toMat(
                 Transactional.sink(producerSettings, transactionalId),
-                Consumer::formDrainingControl)
+                Consumer::createDrainingControl)
             .run(materializer);
 
     // ...
@@ -115,7 +115,7 @@ public class TransactionsExampleTest extends TestcontainersKafkaJunit4Test {
                         new ProducerRecord<>(targetTopic, record.key(), record.value())))
             .toMat(
                 Transactional.sinkWithOffsetContext(producerSettings, transactionalId),
-                Consumer::formDrainingControl)
+                Consumer::createDrainingControl)
             .run(materializer);
 
     String testConsumerGroup = createGroupId(2);
@@ -228,7 +228,7 @@ public class TransactionsExampleTest extends TestcontainersKafkaJunit4Test {
       ConsumerSettings<String, String> settings, String topic, long take) {
     return Consumer.plainSource(settings, Subscriptions.topics(topic))
         .take(take)
-        .toMat(Sink.seq(), Consumer::formDrainingControl)
+        .toMat(Sink.seq(), Consumer::createDrainingControl)
         .run(materializer);
   }
 

--- a/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java
@@ -79,8 +79,9 @@ public class TransactionsExampleTest extends TestcontainersKafkaJunit4Test {
                     ProducerMessage.single(
                         new ProducerRecord<>(targetTopic, msg.record().key(), msg.record().value()),
                         msg.partitionOffset()))
-            .toMat(Transactional.sink(producerSettings, transactionalId), Keep.both())
-            .mapMaterializedValue(Consumer::createDrainingControl)
+            .toMat(
+                Transactional.sink(producerSettings, transactionalId),
+                Consumer::formDrainingControl)
             .run(materializer);
 
     // ...
@@ -113,8 +114,8 @@ public class TransactionsExampleTest extends TestcontainersKafkaJunit4Test {
                     ProducerMessage.single(
                         new ProducerRecord<>(targetTopic, record.key(), record.value())))
             .toMat(
-                Transactional.sinkWithOffsetContext(producerSettings, transactionalId), Keep.both())
-            .mapMaterializedValue(Consumer::createDrainingControl)
+                Transactional.sinkWithOffsetContext(producerSettings, transactionalId),
+                Consumer::formDrainingControl)
             .run(materializer);
 
     String testConsumerGroup = createGroupId(2);
@@ -227,8 +228,7 @@ public class TransactionsExampleTest extends TestcontainersKafkaJunit4Test {
       ConsumerSettings<String, String> settings, String topic, long take) {
     return Consumer.plainSource(settings, Subscriptions.topics(topic))
         .take(take)
-        .toMat(Sink.seq(), Keep.both())
-        .mapMaterializedValue(Consumer::createDrainingControl)
+        .toMat(Sink.seq(), Consumer::formDrainingControl)
         .run(materializer);
   }
 

--- a/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
@@ -84,7 +84,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
           msg.committableOffset
         )
       }
-      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.apply)
       .run()
 
     consumer.actor.expectNoMessage(commitInterval)
@@ -126,7 +126,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
           )
         }
       }
-      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.apply)
       .run()
 
     consumer.actor.expectNoMessage(commitInterval)
@@ -163,7 +163,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
           msg.committableOffset
         )
       }
-      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.apply)
       .run()
 
     val commitMsg = consumer.actor.expectMsgClass(500.millis, classOf[Internal.Commit])
@@ -196,7 +196,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
       .map { msg =>
         ProducerMessage.passThrough[String, String, ConsumerMessage.CommittableOffset](msg.committableOffset)
       }
-      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.apply)
       .run()
 
     val commitMsg = consumer.actor.expectMsgClass(500.millis, classOf[Internal.Commit])
@@ -238,7 +238,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
       }
       .toMat(
         Producer.committableSink(producerSettings, committerSettings)
-      )(DrainingControl.form)
+      )(DrainingControl.apply)
       .run()
 
     val commitMsg = consumer.actor.expectMsgClass(classOf[Internal.Commit])
@@ -275,7 +275,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
           msg.committableOffset
         )
       }
-      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.apply)
       .run()
 
     // expect the commit to reach the actor within 1 second
@@ -317,7 +317,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
           msg.committableOffset
         )
       }
-      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.apply)
       .run()
 
     val commitMsg = consumer.actor.expectMsgClass(1.second, classOf[Internal.Commit])
@@ -355,7 +355,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
           msg.committableOffset
         )
       }
-      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.apply)
       .run()
 
     val commitMsg = consumer.actor.expectMsgClass(1.second, classOf[Internal.CommitWithoutReply])
@@ -392,7 +392,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
           msg.committableOffset
         )
       }
-      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.apply)
       .run()
 
     while (!producer.completeNext()) {}
@@ -437,7 +437,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
         Producer
           .committableSink(producerSettings, committerSettings)
           .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
-      )(DrainingControl.form)
+      )(DrainingControl.apply)
       .run()
 
     // fail the first message
@@ -484,7 +484,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
         Producer
           .committableSink(producerSettings, committerSettings)
           .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
-      )(DrainingControl.form)
+      )(DrainingControl.apply)
       .run()
 
     // fail the first message
@@ -528,7 +528,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
           msg.committableOffset
         )
       }
-      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.apply)
       .run()
 
     val commitMsg = consumer.actor.expectMsgClass(classOf[Internal.Commit])
@@ -567,7 +567,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
         Producer
           .committableSink(producerSettings, committerSettings)
           .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
-      )(DrainingControl.form)
+      )(DrainingControl.apply)
       .run()
 
     val commitMsg = consumer.actor.expectMsgClass(classOf[Internal.Commit])
@@ -597,7 +597,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
           msg.committableOffset
         )
       }
-      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.apply)
       .run()
 
     control.drainAndShutdown().futureValue shouldBe Done

--- a/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
@@ -84,8 +84,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
           msg.committableOffset
         )
       }
-      .toMat(Producer.committableSink(producerSettings, committerSettings))(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
       .run()
 
     consumer.actor.expectNoMessage(commitInterval)
@@ -127,8 +126,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
           )
         }
       }
-      .toMat(Producer.committableSink(producerSettings, committerSettings))(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
       .run()
 
     consumer.actor.expectNoMessage(commitInterval)
@@ -165,8 +163,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
           msg.committableOffset
         )
       }
-      .toMat(Producer.committableSink(producerSettings, committerSettings))(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
       .run()
 
     val commitMsg = consumer.actor.expectMsgClass(500.millis, classOf[Internal.Commit])
@@ -199,8 +196,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
       .map { msg =>
         ProducerMessage.passThrough[String, String, ConsumerMessage.CommittableOffset](msg.committableOffset)
       }
-      .toMat(Producer.committableSink(producerSettings, committerSettings))(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
       .run()
 
     val commitMsg = consumer.actor.expectMsgClass(500.millis, classOf[Internal.Commit])
@@ -242,8 +238,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
       }
       .toMat(
         Producer.committableSink(producerSettings, committerSettings)
-      )(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      )(DrainingControl.form)
       .run()
 
     val commitMsg = consumer.actor.expectMsgClass(classOf[Internal.Commit])
@@ -280,8 +275,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
           msg.committableOffset
         )
       }
-      .toMat(Producer.committableSink(producerSettings, committerSettings))(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
       .run()
 
     // expect the commit to reach the actor within 1 second
@@ -323,8 +317,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
           msg.committableOffset
         )
       }
-      .toMat(Producer.committableSink(producerSettings, committerSettings))(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
       .run()
 
     val commitMsg = consumer.actor.expectMsgClass(1.second, classOf[Internal.Commit])
@@ -362,8 +355,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
           msg.committableOffset
         )
       }
-      .toMat(Producer.committableSink(producerSettings, committerSettings))(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
       .run()
 
     val commitMsg = consumer.actor.expectMsgClass(1.second, classOf[Internal.CommitWithoutReply])
@@ -400,8 +392,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
           msg.committableOffset
         )
       }
-      .toMat(Producer.committableSink(producerSettings, committerSettings))(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
       .run()
 
     while (!producer.completeNext()) {}
@@ -446,8 +437,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
         Producer
           .committableSink(producerSettings, committerSettings)
           .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
-      )(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      )(DrainingControl.form)
       .run()
 
     // fail the first message
@@ -494,8 +484,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
         Producer
           .committableSink(producerSettings, committerSettings)
           .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
-      )(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      )(DrainingControl.form)
       .run()
 
     // fail the first message
@@ -539,8 +528,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
           msg.committableOffset
         )
       }
-      .toMat(Producer.committableSink(producerSettings, committerSettings))(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
       .run()
 
     val commitMsg = consumer.actor.expectMsgClass(classOf[Internal.Commit])
@@ -579,8 +567,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
         Producer
           .committableSink(producerSettings, committerSettings)
           .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
-      )(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      )(DrainingControl.form)
       .run()
 
     val commitMsg = consumer.actor.expectMsgClass(classOf[Internal.Commit])
@@ -610,8 +597,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
           msg.committableOffset
         )
       }
-      .toMat(Producer.committableSink(producerSettings, committerSettings))(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
       .run()
 
     control.drainAndShutdown().futureValue shouldBe Done

--- a/tests/src/test/scala/akka/kafka/javadsl/ControlSpec.scala
+++ b/tests/src/test/scala/akka/kafka/javadsl/ControlSpec.scala
@@ -46,7 +46,7 @@ class ControlSpec extends WordSpecLike with ScalaFutures with Matchers with LogC
     "drain to stream result" in {
       val control = createControl()
       val drainingControl =
-        Consumer.createDrainingControl(akka.japi.Pair(control, Future.successful("expected").toJava))
+        Consumer.formDrainingControl(control, Future.successful("expected").toJava)
       drainingControl.drainAndShutdown(ec).toScala.futureValue should be("expected")
       control.shutdownCalled.get() should be(true)
     }
@@ -54,8 +54,9 @@ class ControlSpec extends WordSpecLike with ScalaFutures with Matchers with LogC
     "drain to stream failure" in {
       val control = createControl()
 
-      val drainingControl = Consumer.createDrainingControl(
-        akka.japi.Pair(control, Future.failed[String](new RuntimeException("expected")).toJava)
+      val drainingControl = Consumer.formDrainingControl(
+        control,
+        Future.failed[String](new RuntimeException("expected")).toJava
       )
       val value = drainingControl.drainAndShutdown(ec).toScala.failed.futureValue
       value shouldBe a[RuntimeException]
@@ -67,8 +68,9 @@ class ControlSpec extends WordSpecLike with ScalaFutures with Matchers with LogC
     "drain to stream failure even if shutdown fails" in {
       val control = createControl(shutdownFuture = Future.failed(new RuntimeException("not this")))
 
-      val drainingControl = Consumer.createDrainingControl(
-        akka.japi.Pair(control, Future.failed[String](new RuntimeException("expected")).toJava)
+      val drainingControl = Consumer.formDrainingControl(
+        control,
+        Future.failed[String](new RuntimeException("expected")).toJava
       )
       val value = drainingControl.drainAndShutdown(ec).toScala.failed.futureValue
       value shouldBe a[RuntimeException]
@@ -80,7 +82,7 @@ class ControlSpec extends WordSpecLike with ScalaFutures with Matchers with LogC
     "drain to shutdown failure when stream succeeds" in {
       val control = createControl(shutdownFuture = Future.failed(new RuntimeException("expected")))
 
-      val drainingControl = Consumer.createDrainingControl(akka.japi.Pair(control, Future.successful(Done).toJava))
+      val drainingControl = Consumer.formDrainingControl(control, Future.successful(Done).toJava)
       val value = drainingControl.drainAndShutdown(ec).toScala.failed.futureValue
       value shouldBe a[RuntimeException]
       // endWith to accustom Scala 2.11 and 2.12

--- a/tests/src/test/scala/akka/kafka/javadsl/ControlSpec.scala
+++ b/tests/src/test/scala/akka/kafka/javadsl/ControlSpec.scala
@@ -46,7 +46,7 @@ class ControlSpec extends WordSpecLike with ScalaFutures with Matchers with LogC
     "drain to stream result" in {
       val control = createControl()
       val drainingControl =
-        Consumer.formDrainingControl(control, Future.successful("expected").toJava)
+        Consumer.createDrainingControl(control, Future.successful("expected").toJava)
       drainingControl.drainAndShutdown(ec).toScala.futureValue should be("expected")
       control.shutdownCalled.get() should be(true)
     }
@@ -54,7 +54,7 @@ class ControlSpec extends WordSpecLike with ScalaFutures with Matchers with LogC
     "drain to stream failure" in {
       val control = createControl()
 
-      val drainingControl = Consumer.formDrainingControl(
+      val drainingControl = Consumer.createDrainingControl(
         control,
         Future.failed[String](new RuntimeException("expected")).toJava
       )
@@ -68,7 +68,7 @@ class ControlSpec extends WordSpecLike with ScalaFutures with Matchers with LogC
     "drain to stream failure even if shutdown fails" in {
       val control = createControl(shutdownFuture = Future.failed(new RuntimeException("not this")))
 
-      val drainingControl = Consumer.formDrainingControl(
+      val drainingControl = Consumer.createDrainingControl(
         control,
         Future.failed[String](new RuntimeException("expected")).toJava
       )
@@ -82,7 +82,7 @@ class ControlSpec extends WordSpecLike with ScalaFutures with Matchers with LogC
     "drain to shutdown failure when stream succeeds" in {
       val control = createControl(shutdownFuture = Future.failed(new RuntimeException("expected")))
 
-      val drainingControl = Consumer.formDrainingControl(control, Future.successful(Done).toJava)
+      val drainingControl = Consumer.createDrainingControl(control, Future.successful(Done).toJava)
       val value = drainingControl.drainAndShutdown(ec).toScala.failed.futureValue
       value shouldBe a[RuntimeException]
       // endWith to accustom Scala 2.11 and 2.12

--- a/tests/src/test/scala/akka/kafka/scaladsl/CommittableSinkSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/CommittableSinkSpec.scala
@@ -39,8 +39,7 @@ class CommittableSinkSpec extends SpecBase with TestcontainersKafkaLike {
         .map { record =>
           ProducerMessage.single(new ProducerRecord(targetTopic, record.key(), record.value()))
         }
-        .toMat(Producer.committableSinkWithOffsetContext(producerDefaults, committerDefaults))(Keep.both)
-        .mapMaterializedValue(DrainingControl.apply)
+        .toMat(Producer.committableSinkWithOffsetContext(producerDefaults, committerDefaults))(DrainingControl.form)
         .run()
 
       // read copied messages

--- a/tests/src/test/scala/akka/kafka/scaladsl/CommittableSinkSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/CommittableSinkSpec.scala
@@ -39,7 +39,7 @@ class CommittableSinkSpec extends SpecBase with TestcontainersKafkaLike {
         .map { record =>
           ProducerMessage.single(new ProducerRecord(targetTopic, record.key(), record.value()))
         }
-        .toMat(Producer.committableSinkWithOffsetContext(producerDefaults, committerDefaults))(DrainingControl.form)
+        .toMat(Producer.committableSinkWithOffsetContext(producerDefaults, committerDefaults))(DrainingControl.apply)
         .run()
 
       // read copied messages

--- a/tests/src/test/scala/akka/kafka/scaladsl/ControlSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/ControlSpec.scala
@@ -39,7 +39,7 @@ class ControlSpec extends WordSpecLike with ScalaFutures with Matchers with LogC
   "Control" should {
     "drain to stream result" in {
       val control = new ControlImpl
-      val drainingControl = DrainingControl.form(control, Future.successful("expected"))
+      val drainingControl = DrainingControl.apply(control, Future.successful("expected"))
       drainingControl.drainAndShutdown().futureValue should be("expected")
       control.shutdownCalled.get() should be(true)
     }
@@ -47,7 +47,7 @@ class ControlSpec extends WordSpecLike with ScalaFutures with Matchers with LogC
     "drain to stream failure" in {
       val control = new ControlImpl
 
-      val drainingControl = DrainingControl.form(control, Future.failed(new RuntimeException("expected")))
+      val drainingControl = DrainingControl.apply(control, Future.failed(new RuntimeException("expected")))
       val value = drainingControl.drainAndShutdown().failed.futureValue
       value shouldBe a[RuntimeException]
       // endWith to accustom Scala 2.11 and 2.12
@@ -58,7 +58,7 @@ class ControlSpec extends WordSpecLike with ScalaFutures with Matchers with LogC
     "drain to stream failure even if shutdown fails" in {
       val control = new ControlImpl(shutdownFuture = Future.failed(new RuntimeException("not this")))
 
-      val drainingControl = DrainingControl.form(control, Future.failed(new RuntimeException("expected")))
+      val drainingControl = DrainingControl.apply(control, Future.failed(new RuntimeException("expected")))
       val value = drainingControl.drainAndShutdown().failed.futureValue
       value shouldBe a[RuntimeException]
       // endWith to accustom Scala 2.11 and 2.12
@@ -69,7 +69,7 @@ class ControlSpec extends WordSpecLike with ScalaFutures with Matchers with LogC
     "drain to shutdown failure when stream succeeds" in {
       val control = new ControlImpl(shutdownFuture = Future.failed(new RuntimeException("expected")))
 
-      val drainingControl = DrainingControl.form(control, Future.successful(Done))
+      val drainingControl = DrainingControl.apply(control, Future.successful(Done))
       val value = drainingControl.drainAndShutdown().failed.futureValue
       value shouldBe a[RuntimeException]
       // endWith to accustom Scala 2.11 and 2.12

--- a/tests/src/test/scala/akka/kafka/scaladsl/ControlSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/ControlSpec.scala
@@ -39,7 +39,7 @@ class ControlSpec extends WordSpecLike with ScalaFutures with Matchers with LogC
   "Control" should {
     "drain to stream result" in {
       val control = new ControlImpl
-      val drainingControl = DrainingControl.apply((control, Future.successful("expected")))
+      val drainingControl = DrainingControl.form(control, Future.successful("expected"))
       drainingControl.drainAndShutdown().futureValue should be("expected")
       control.shutdownCalled.get() should be(true)
     }
@@ -47,7 +47,7 @@ class ControlSpec extends WordSpecLike with ScalaFutures with Matchers with LogC
     "drain to stream failure" in {
       val control = new ControlImpl
 
-      val drainingControl = DrainingControl.apply((control, Future.failed(new RuntimeException("expected"))))
+      val drainingControl = DrainingControl.form(control, Future.failed(new RuntimeException("expected")))
       val value = drainingControl.drainAndShutdown().failed.futureValue
       value shouldBe a[RuntimeException]
       // endWith to accustom Scala 2.11 and 2.12
@@ -58,7 +58,7 @@ class ControlSpec extends WordSpecLike with ScalaFutures with Matchers with LogC
     "drain to stream failure even if shutdown fails" in {
       val control = new ControlImpl(shutdownFuture = Future.failed(new RuntimeException("not this")))
 
-      val drainingControl = DrainingControl.apply((control, Future.failed(new RuntimeException("expected"))))
+      val drainingControl = DrainingControl.form(control, Future.failed(new RuntimeException("expected")))
       val value = drainingControl.drainAndShutdown().failed.futureValue
       value shouldBe a[RuntimeException]
       // endWith to accustom Scala 2.11 and 2.12
@@ -69,7 +69,7 @@ class ControlSpec extends WordSpecLike with ScalaFutures with Matchers with LogC
     "drain to shutdown failure when stream succeeds" in {
       val control = new ControlImpl(shutdownFuture = Future.failed(new RuntimeException("expected")))
 
-      val drainingControl = DrainingControl.apply((control, Future.successful(Done)))
+      val drainingControl = DrainingControl.form(control, Future.successful(Done))
       val value = drainingControl.drainAndShutdown().failed.futureValue
       value shouldBe a[RuntimeException]
       // endWith to accustom Scala 2.11 and 2.12

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -78,7 +78,7 @@ class IntegrationSpec extends SpecBase with TestcontainersKafkaLike with Inside 
             Done
           }
           .scan(0L)((c, _) => c + 1)
-          .toMat(Sink.last)(DrainingControl.form)
+          .toMat(Sink.last)(DrainingControl.apply)
           .run()
 
       def createAndRunProducer(elements: immutable.Iterable[Long]) =
@@ -228,7 +228,7 @@ class IntegrationSpec extends SpecBase with TestcontainersKafkaLike with Inside 
       val control =
         Consumer
           .committableSource(consumerDefaults, Subscriptions.topics(topic1))
-          .toMat(Sink.seq)(DrainingControl.form)
+          .toMat(Sink.seq)(DrainingControl.apply)
           .run()
 
       control.isShutdown.failed.futureValue shouldBe a[org.apache.kafka.common.errors.InvalidGroupIdException]

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -78,8 +78,7 @@ class IntegrationSpec extends SpecBase with TestcontainersKafkaLike with Inside 
             Done
           }
           .scan(0L)((c, _) => c + 1)
-          .toMat(Sink.last)(Keep.both)
-          .mapMaterializedValue(DrainingControl.apply)
+          .toMat(Sink.last)(DrainingControl.form)
           .run()
 
       def createAndRunProducer(elements: immutable.Iterable[Long]) =
@@ -229,8 +228,7 @@ class IntegrationSpec extends SpecBase with TestcontainersKafkaLike with Inside 
       val control =
         Consumer
           .committableSource(consumerDefaults, Subscriptions.topics(topic1))
-          .toMat(Sink.seq)(Keep.both)
-          .mapMaterializedValue(DrainingControl.apply)
+          .toMat(Sink.seq)(DrainingControl.form)
           .run()
 
       control.isShutdown.failed.futureValue shouldBe a[org.apache.kafka.common.errors.InvalidGroupIdException]

--- a/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
@@ -105,8 +105,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
         }
         .mergeSubstreams
         .scan(0L)((c, subValue) => c + subValue)
-        .toMat(Sink.last)(Keep.both)
-        .mapMaterializedValue(DrainingControl.apply)
+        .toMat(Sink.last)(DrainingControl.form)
         .run()
 
       // waits until all partitions are assigned to the single consumer
@@ -166,8 +165,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
           }
           .mergeSubstreams
           .scan(0L)((c, subValue) => c + subValue)
-          .toMat(Sink.last)(Keep.both)
-          .mapMaterializedValue(DrainingControl.apply)
+          .toMat(Sink.last)(DrainingControl.form)
           .run()
 
       val control = createAndRunConsumer()
@@ -252,8 +250,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
             v
           }
           .scan(0L)((c, _) => c + 1)
-          .toMat(Sink.last)(Keep.both)
-          .mapMaterializedValue(DrainingControl.apply)
+          .toMat(Sink.last)(DrainingControl.form)
           .run()
 
       val control = createAndRunConsumer(subscription1)
@@ -468,8 +465,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
                 }
           }
           .mergeSubstreams
-          .toMat(Sink.ignore)(Keep.both)
-          .mapMaterializedValue(DrainingControl.apply)
+          .toMat(Sink.ignore)(DrainingControl.form)
           .run()
 
       val firstHalfLatch = new CountDownLatch(1)
@@ -577,8 +573,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
         }
         .mergeSubstreams
         .scan(0L)((c, n) => c + n)
-        .toMat(Sink.last)(Keep.both)
-        .mapMaterializedValue(DrainingControl.apply)
+        .toMat(Sink.last)(DrainingControl.form)
         .run()
 
       // waits until all partitions are assigned to the single consumer

--- a/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
@@ -105,7 +105,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
         }
         .mergeSubstreams
         .scan(0L)((c, subValue) => c + subValue)
-        .toMat(Sink.last)(DrainingControl.form)
+        .toMat(Sink.last)(DrainingControl.apply)
         .run()
 
       // waits until all partitions are assigned to the single consumer
@@ -165,7 +165,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
           }
           .mergeSubstreams
           .scan(0L)((c, subValue) => c + subValue)
-          .toMat(Sink.last)(DrainingControl.form)
+          .toMat(Sink.last)(DrainingControl.apply)
           .run()
 
       val control = createAndRunConsumer()
@@ -250,7 +250,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
             v
           }
           .scan(0L)((c, _) => c + 1)
-          .toMat(Sink.last)(DrainingControl.form)
+          .toMat(Sink.last)(DrainingControl.apply)
           .run()
 
       val control = createAndRunConsumer(subscription1)
@@ -465,7 +465,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
                 }
           }
           .mergeSubstreams
-          .toMat(Sink.ignore)(DrainingControl.form)
+          .toMat(Sink.ignore)(DrainingControl.apply)
           .run()
 
       val firstHalfLatch = new CountDownLatch(1)
@@ -573,7 +573,7 @@ class PartitionedSourcesSpec extends SpecBase with TestcontainersKafkaLike with 
         }
         .mergeSubstreams
         .scan(0L)((c, n) => c + n)
-        .toMat(Sink.last)(DrainingControl.form)
+        .toMat(Sink.last)(DrainingControl.apply)
         .run()
 
       // waits until all partitions are assigned to the single consumer

--- a/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
@@ -462,8 +462,7 @@ class TransactionsSpec extends SpecBase with TestcontainersKafkaLike with Transa
                 .to(Transactional.sink(producerDefaults, transactionalId))
                 .run()
           }
-          .toMat(Sink.ignore)(Keep.both)
-          .mapMaterializedValue(DrainingControl.apply)
+          .toMat(Sink.ignore)(DrainingControl.form)
           .run()
 
       def createAndRunProducer(elements: immutable.Iterable[Long]) =
@@ -508,8 +507,7 @@ class TransactionsSpec extends SpecBase with TestcontainersKafkaLike with Transa
                                      Subscriptions.topics(outTopic))
         .mapAsync(1)(el => counterQueue.offer(el.value()).map(_ => el))
         .scan(0L)((c, _) => c + 1)
-        .toMat(Sink.last)(Keep.both)
-        .mapMaterializedValue(DrainingControl.apply)
+        .toMat(Sink.last)(DrainingControl.form)
         .run()
 
       counterCompletion.futureValue shouldBe totalMessages

--- a/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
@@ -462,7 +462,7 @@ class TransactionsSpec extends SpecBase with TestcontainersKafkaLike with Transa
                 .to(Transactional.sink(producerDefaults, transactionalId))
                 .run()
           }
-          .toMat(Sink.ignore)(DrainingControl.form)
+          .toMat(Sink.ignore)(DrainingControl.apply)
           .run()
 
       def createAndRunProducer(elements: immutable.Iterable[Long]) =
@@ -507,7 +507,7 @@ class TransactionsSpec extends SpecBase with TestcontainersKafkaLike with Transa
                                      Subscriptions.topics(outTopic))
         .mapAsync(1)(el => counterQueue.offer(el.value()).map(_ => el))
         .scan(0L)((c, _) => c + 1)
-        .toMat(Sink.last)(DrainingControl.form)
+        .toMat(Sink.last)(DrainingControl.apply)
         .run()
 
       counterCompletion.futureValue shouldBe totalMessages

--- a/tests/src/test/scala/docs/scaladsl/AtLeastOnce.scala
+++ b/tests/src/test/scala/docs/scaladsl/AtLeastOnce.scala
@@ -50,8 +50,7 @@ class AtLeastOnce extends DocsSpecBase with TestcontainersKafkaLike {
         )
         .via(Producer.flexiFlow(producerSettings))
         .map(_.passThrough)
-        .toMat(Committer.sink(committerSettings))(Keep.both)
-        .mapMaterializedValue(DrainingControl.apply)
+        .toMat(Committer.sink(committerSettings))(DrainingControl.form)
         .run()
     // #oneToMany
     val (control2, result) = Consumer
@@ -102,8 +101,7 @@ class AtLeastOnce extends DocsSpecBase with TestcontainersKafkaLike {
         })
         .via(Producer.flexiFlow(producerSettings))
         .map(_.passThrough)
-        .toMat(Committer.sink(committerSettings))(Keep.both)
-        .mapMaterializedValue(DrainingControl.apply)
+        .toMat(Committer.sink(committerSettings))(DrainingControl.form)
         .run()
     // #oneToConditional
 
@@ -151,8 +149,7 @@ class AtLeastOnce extends DocsSpecBase with TestcontainersKafkaLike {
           out
         })
         .via(Producer.flowWithContext(producerSettings))
-        .toMat(Committer.sinkWithOffsetContext(committerSettings))(Keep.both)
-        .mapMaterializedValue(DrainingControl.apply)
+        .toMat(Committer.sinkWithOffsetContext(committerSettings))(DrainingControl.form)
         .run()
 
     val (control2, result) = Consumer
@@ -183,8 +180,7 @@ class AtLeastOnce extends DocsSpecBase with TestcontainersKafkaLike {
         }
         .mapContext(CommittableOffsetBatch(_))
         .via(Producer.flowWithContext(producerDefaults))
-        .toMat(Committer.sinkWithOffsetContext(committerDefaults))(Keep.both)
-        .mapMaterializedValue(DrainingControl.apply)
+        .toMat(Committer.sinkWithOffsetContext(committerDefaults))(DrainingControl.form)
         .run()
 
     val (control2, result) = Consumer

--- a/tests/src/test/scala/docs/scaladsl/AtLeastOnce.scala
+++ b/tests/src/test/scala/docs/scaladsl/AtLeastOnce.scala
@@ -50,7 +50,7 @@ class AtLeastOnce extends DocsSpecBase with TestcontainersKafkaLike {
         )
         .via(Producer.flexiFlow(producerSettings))
         .map(_.passThrough)
-        .toMat(Committer.sink(committerSettings))(DrainingControl.form)
+        .toMat(Committer.sink(committerSettings))(DrainingControl.apply)
         .run()
     // #oneToMany
     val (control2, result) = Consumer
@@ -101,7 +101,7 @@ class AtLeastOnce extends DocsSpecBase with TestcontainersKafkaLike {
         })
         .via(Producer.flexiFlow(producerSettings))
         .map(_.passThrough)
-        .toMat(Committer.sink(committerSettings))(DrainingControl.form)
+        .toMat(Committer.sink(committerSettings))(DrainingControl.apply)
         .run()
     // #oneToConditional
 
@@ -149,7 +149,7 @@ class AtLeastOnce extends DocsSpecBase with TestcontainersKafkaLike {
           out
         })
         .via(Producer.flowWithContext(producerSettings))
-        .toMat(Committer.sinkWithOffsetContext(committerSettings))(DrainingControl.form)
+        .toMat(Committer.sinkWithOffsetContext(committerSettings))(DrainingControl.apply)
         .run()
 
     val (control2, result) = Consumer
@@ -180,7 +180,7 @@ class AtLeastOnce extends DocsSpecBase with TestcontainersKafkaLike {
         }
         .mapContext(CommittableOffsetBatch(_))
         .via(Producer.flowWithContext(producerDefaults))
-        .toMat(Committer.sinkWithOffsetContext(committerDefaults))(DrainingControl.form)
+        .toMat(Committer.sinkWithOffsetContext(committerDefaults))(DrainingControl.apply)
         .run()
 
     val (control2, result) = Consumer

--- a/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
@@ -45,7 +45,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
           )
         )
         .mapAsync(1)(db.businessLogicAndStoreOffset)
-        .toMat(Sink.seq)(DrainingControl.form)
+        .toMat(Sink.seq)(DrainingControl.apply)
         .run()
     }
     // #plainSource
@@ -126,7 +126,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
       Consumer
         .atMostOnceSource(consumerSettings, Subscriptions.topics(topic))
         .mapAsync(1)(record => business(record.key, record.value()))
-        .toMat(Sink.seq)(DrainingControl.form)
+        .toMat(Sink.seq)(DrainingControl.apply)
         .run()
     // #atMostOnce
 
@@ -154,7 +154,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
           business(msg.record.key, msg.record.value).map(_ => msg.committableOffset)
         }
         .via(Committer.flow(committerDefaults.withMaxBatch(1)))
-        .toMat(Sink.seq)(DrainingControl.form)
+        .toMat(Sink.seq)(DrainingControl.apply)
         .run()
     // #atLeastOnce
     awaitProduce(produce(topic, 1 to 10))
@@ -179,7 +179,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
           business(record.key, record.value)
         }
         .via(Committer.flowWithOffsetContext(committerDefaults))
-        .toMat(Sink.seq)(DrainingControl.form)
+        .toMat(Sink.seq)(DrainingControl.apply)
         .run()
     awaitProduce(produce(topic, 1 to 10))
     control.drainAndShutdown().futureValue.map { case (_, b) => b.batchSize }.sum shouldBe 10
@@ -199,7 +199,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
           business(msg.record.key, msg.record.value)
             .map(_ => msg.committableOffset)
         }
-        .toMat(Committer.sink(committerDefaults))(DrainingControl.form)
+        .toMat(Committer.sink(committerDefaults))(DrainingControl.apply)
         .run()
     // #commitWithMetadata
     awaitProduce(produce(topic, 1 to 10))
@@ -219,7 +219,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
           business(msg.record.key, msg.record.value)
             .map(_ => msg.committableOffset)
         }
-        .toMat(Committer.sink(committerSettings))(DrainingControl.form)
+        .toMat(Committer.sink(committerSettings))(DrainingControl.apply)
         .run()
     // #committerSink
     awaitProduce(produce(topic, 1 to 10))
@@ -244,7 +244,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
             msg.committableOffset
           )
         }
-        .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
+        .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.apply)
         .run()
     // #consumerToProducerSink
     //format: on
@@ -253,7 +253,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
     val consumerSettings2 = consumerDefaults.withGroupId("consumer to producer validation")
     val receiveControl = Consumer
       .plainSource(consumerSettings2, Subscriptions.topics(targetTopic))
-      .toMat(Sink.seq)(DrainingControl.form)
+      .toMat(Sink.seq)(DrainingControl.apply)
       .run()
     waitBeforeValidation()
     Await.result(receiveControl.drainAndShutdown(), 5.seconds) should have size (20)
@@ -273,7 +273,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
         .map { record =>
           ProducerMessage.single(new ProducerRecord(targetTopic, record.key, record.value))
         }
-        .toMat(Producer.committableSinkWithOffsetContext(producerSettings, committerSettings))(DrainingControl.form)
+        .toMat(Producer.committableSinkWithOffsetContext(producerSettings, committerSettings))(DrainingControl.apply)
         .run()
     // #consumerToProducerWithContext
     awaitProduce(produce(topic1, 1 to 10), produce(topic2, 1 to 10))
@@ -281,7 +281,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
     val consumerSettings2 = consumerDefaults.withGroupId("consumer to producer validation")
     val receiveControl = Consumer
       .plainSource(consumerSettings2, Subscriptions.topics(targetTopic))
-      .toMat(Sink.seq)(DrainingControl.form)
+      .toMat(Sink.seq)(DrainingControl.apply)
       .run()
     waitBeforeValidation()
     Await.result(receiveControl.drainAndShutdown(), 5.seconds) should have size (20)
@@ -297,7 +297,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
       .flatMapMerge(maxPartitions, _._2)
       .via(businessFlow)
       .map(_.committableOffset)
-      .toMat(Committer.sink(committerDefaults))(DrainingControl.form)
+      .toMat(Committer.sink(committerDefaults))(DrainingControl.apply)
       .run()
     // #committablePartitionedSource
     awaitProduce(produce(topic, 1 to 10))
@@ -319,7 +319,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
             .map(_.committableOffset)
             .runWith(Committer.sink(committerSettings))
       }
-      .toMat(Sink.ignore)(DrainingControl.form)
+      .toMat(Sink.ignore)(DrainingControl.apply)
       .run()
     // #committablePartitionedSource-stream-per-partition
     awaitProduce(produce(topic, 1 to 10))
@@ -456,7 +456,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
         .mapAsync(1) { msg =>
           business(msg.record).map(_ => msg.committableOffset)
         }
-        .toMat(Committer.sink(committerSettings))(DrainingControl.form)
+        .toMat(Committer.sink(committerSettings))(DrainingControl.apply)
         .run()
 
     val streamComplete = drainingControl.drainAndShutdown()
@@ -517,7 +517,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
       .runWith(Sink.ignore)
     awaitProduce(produce(topic, 1 to 10))
     // when shut down is desired
-    val drainingControl = DrainingControl.form(control.get(), result)
+    val drainingControl = DrainingControl.apply(control.get(), result)
     drainingControl.drainAndShutdown().futureValue shouldBe Done
   }
 }

--- a/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/ConsumerExample.scala
@@ -45,8 +45,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
           )
         )
         .mapAsync(1)(db.businessLogicAndStoreOffset)
-        .toMat(Sink.seq)(Keep.both)
-        .mapMaterializedValue(DrainingControl.apply)
+        .toMat(Sink.seq)(DrainingControl.form)
         .run()
     }
     // #plainSource
@@ -127,8 +126,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
       Consumer
         .atMostOnceSource(consumerSettings, Subscriptions.topics(topic))
         .mapAsync(1)(record => business(record.key, record.value()))
-        .toMat(Sink.seq)(Keep.both)
-        .mapMaterializedValue(DrainingControl.apply)
+        .toMat(Sink.seq)(DrainingControl.form)
         .run()
     // #atMostOnce
 
@@ -156,8 +154,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
           business(msg.record.key, msg.record.value).map(_ => msg.committableOffset)
         }
         .via(Committer.flow(committerDefaults.withMaxBatch(1)))
-        .toMat(Sink.seq)(Keep.both)
-        .mapMaterializedValue(DrainingControl.apply)
+        .toMat(Sink.seq)(DrainingControl.form)
         .run()
     // #atLeastOnce
     awaitProduce(produce(topic, 1 to 10))
@@ -182,8 +179,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
           business(record.key, record.value)
         }
         .via(Committer.flowWithOffsetContext(committerDefaults))
-        .toMat(Sink.seq)(Keep.both)
-        .mapMaterializedValue(DrainingControl.apply)
+        .toMat(Sink.seq)(DrainingControl.form)
         .run()
     awaitProduce(produce(topic, 1 to 10))
     control.drainAndShutdown().futureValue.map { case (_, b) => b.batchSize }.sum shouldBe 10
@@ -203,8 +199,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
           business(msg.record.key, msg.record.value)
             .map(_ => msg.committableOffset)
         }
-        .toMat(Committer.sink(committerDefaults))(Keep.both)
-        .mapMaterializedValue(DrainingControl.apply)
+        .toMat(Committer.sink(committerDefaults))(DrainingControl.form)
         .run()
     // #commitWithMetadata
     awaitProduce(produce(topic, 1 to 10))
@@ -224,8 +219,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
           business(msg.record.key, msg.record.value)
             .map(_ => msg.committableOffset)
         }
-        .toMat(Committer.sink(committerSettings))(Keep.both)
-        .mapMaterializedValue(DrainingControl.apply)
+        .toMat(Committer.sink(committerSettings))(DrainingControl.form)
         .run()
     // #committerSink
     awaitProduce(produce(topic, 1 to 10))
@@ -250,8 +244,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
             msg.committableOffset
           )
         }
-        .toMat(Producer.committableSink(producerSettings, committerSettings))(Keep.both)
-        .mapMaterializedValue(DrainingControl.apply)
+        .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.form)
         .run()
     // #consumerToProducerSink
     //format: on
@@ -260,8 +253,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
     val consumerSettings2 = consumerDefaults.withGroupId("consumer to producer validation")
     val receiveControl = Consumer
       .plainSource(consumerSettings2, Subscriptions.topics(targetTopic))
-      .toMat(Sink.seq)(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      .toMat(Sink.seq)(DrainingControl.form)
       .run()
     waitBeforeValidation()
     Await.result(receiveControl.drainAndShutdown(), 5.seconds) should have size (20)
@@ -281,8 +273,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
         .map { record =>
           ProducerMessage.single(new ProducerRecord(targetTopic, record.key, record.value))
         }
-        .toMat(Producer.committableSinkWithOffsetContext(producerSettings, committerSettings))(Keep.both)
-        .mapMaterializedValue(DrainingControl.apply)
+        .toMat(Producer.committableSinkWithOffsetContext(producerSettings, committerSettings))(DrainingControl.form)
         .run()
     // #consumerToProducerWithContext
     awaitProduce(produce(topic1, 1 to 10), produce(topic2, 1 to 10))
@@ -290,8 +281,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
     val consumerSettings2 = consumerDefaults.withGroupId("consumer to producer validation")
     val receiveControl = Consumer
       .plainSource(consumerSettings2, Subscriptions.topics(targetTopic))
-      .toMat(Sink.seq)(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      .toMat(Sink.seq)(DrainingControl.form)
       .run()
     waitBeforeValidation()
     Await.result(receiveControl.drainAndShutdown(), 5.seconds) should have size (20)
@@ -307,8 +297,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
       .flatMapMerge(maxPartitions, _._2)
       .via(businessFlow)
       .map(_.committableOffset)
-      .toMat(Committer.sink(committerDefaults))(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      .toMat(Committer.sink(committerDefaults))(DrainingControl.form)
       .run()
     // #committablePartitionedSource
     awaitProduce(produce(topic, 1 to 10))
@@ -330,8 +319,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
             .map(_.committableOffset)
             .runWith(Committer.sink(committerSettings))
       }
-      .toMat(Sink.ignore)(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      .toMat(Sink.ignore)(DrainingControl.form)
       .run()
     // #committablePartitionedSource-stream-per-partition
     awaitProduce(produce(topic, 1 to 10))
@@ -468,8 +456,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
         .mapAsync(1) { msg =>
           business(msg.record).map(_ => msg.committableOffset)
         }
-        .toMat(Committer.sink(committerSettings))(Keep.both)
-        .mapMaterializedValue(DrainingControl.apply)
+        .toMat(Committer.sink(committerSettings))(DrainingControl.form)
         .run()
 
     val streamComplete = drainingControl.drainAndShutdown()
@@ -530,7 +517,7 @@ class ConsumerExample extends DocsSpecBase with TestcontainersKafkaLike {
       .runWith(Sink.ignore)
     awaitProduce(produce(topic, 1 to 10))
     // when shut down is desired
-    val drainingControl = DrainingControl(Tuple2(control.get(), result))
+    val drainingControl = DrainingControl.form(control.get(), result)
     drainingControl.drainAndShutdown().futureValue shouldBe Done
   }
 }

--- a/tests/src/test/scala/docs/scaladsl/SerializationSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/SerializationSpec.scala
@@ -130,8 +130,7 @@ class SerializationSpec
       // #spray-deser
       .take(samples.size.toLong)
       // #spray-deser
-      .toMat(Sink.seq)(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      .toMat(Sink.seq)(DrainingControl.form)
       .run()
     // #spray-deser
 

--- a/tests/src/test/scala/docs/scaladsl/SerializationSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/SerializationSpec.scala
@@ -130,7 +130,7 @@ class SerializationSpec
       // #spray-deser
       .take(samples.size.toLong)
       // #spray-deser
-      .toMat(Sink.seq)(DrainingControl.form)
+      .toMat(Sink.seq)(DrainingControl.apply)
       .run()
     // #spray-deser
 

--- a/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
@@ -37,8 +37,7 @@ class TransactionsExample extends DocsSpecBase with TestcontainersKafkaLike with
         .map { msg =>
           ProducerMessage.single(new ProducerRecord(sinkTopic, msg.record.key, msg.record.value), msg.partitionOffset)
         }
-        .toMat(Transactional.sink(producerSettings, transactionalId))(Keep.both)
-        .mapMaterializedValue(DrainingControl.apply)
+        .toMat(Transactional.sink(producerSettings, transactionalId))(DrainingControl.form)
         .run()
 
     // ...
@@ -71,8 +70,7 @@ class TransactionsExample extends DocsSpecBase with TestcontainersKafkaLike with
         .map { record =>
           ProducerMessage.single(new ProducerRecord(sinkTopic, record.key, record.value))
         }
-        .toMat(Transactional.sinkWithOffsetContext(producerSettings, createTransactionalId()))(Keep.both)
-        .mapMaterializedValue(DrainingControl.apply)
+        .toMat(Transactional.sinkWithOffsetContext(producerSettings, createTransactionalId()))(DrainingControl.form)
         .run()
 
     val testConsumerGroup = createGroupId(2)
@@ -152,8 +150,7 @@ class TransactionsExample extends DocsSpecBase with TestcontainersKafkaLike with
 //              }
 //              .runWith(Transactional.sink(producerSettings, transactionalId))
 //        }
-//        .toMat(Sink.ignore)(Keep.both)
-//        .mapMaterializedValue(DrainingControl.apply)
+//        .toMat(Sink.ignore)(DrainingControl.form)
 //        .run()
 //    // ...
 //

--- a/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
@@ -37,7 +37,7 @@ class TransactionsExample extends DocsSpecBase with TestcontainersKafkaLike with
         .map { msg =>
           ProducerMessage.single(new ProducerRecord(sinkTopic, msg.record.key, msg.record.value), msg.partitionOffset)
         }
-        .toMat(Transactional.sink(producerSettings, transactionalId))(DrainingControl.form)
+        .toMat(Transactional.sink(producerSettings, transactionalId))(DrainingControl.apply)
         .run()
 
     // ...
@@ -70,7 +70,7 @@ class TransactionsExample extends DocsSpecBase with TestcontainersKafkaLike with
         .map { record =>
           ProducerMessage.single(new ProducerRecord(sinkTopic, record.key, record.value))
         }
-        .toMat(Transactional.sinkWithOffsetContext(producerSettings, createTransactionalId()))(DrainingControl.form)
+        .toMat(Transactional.sinkWithOffsetContext(producerSettings, createTransactionalId()))(DrainingControl.apply)
         .run()
 
     val testConsumerGroup = createGroupId(2)


### PR DESCRIPTION
All examples create the `DrainingControl` from the tuple of `Control` and the stream completion, this introduces methods to create it immediately in `toMat` with a new combinator.
