### PR TITLE
[WIP] Non-streaming consumer helpers

### DIFF
--- a/core/src/main/scala/akka/kafka/scaladsl/Processor.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Processor.scala
@@ -1,9 +1,13 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package akka.kafka.scaladsl
 
+import akka.dispatch.ExecutionContexts
 import akka.kafka.ProducerMessage.Envelope
-import akka.kafka.scaladsl.Consumer.DrainingControl
-import akka.kafka.{CommitterSettings, ConsumerMessage, ConsumerSettings, ProducerSettings, Subscription}
-import akka.stream.Materializer
+import akka.kafka._
 import akka.stream.scaladsl.{Keep, Source}
 import akka.{Done, NotUsed}
 import org.apache.kafka.clients.consumer.ConsumerRecord
@@ -12,65 +16,73 @@ import scala.concurrent.Future
 
 object Processor {
 
+  /**
+   * Convenience for "at-least-once processing" of a function.
+   * Committing is managed by the usual [[Committer]] and the source emits information about batches of committed messages.
+   *
+   * All records from the given subscription will be processed sequentially.
+   */
   def atLeastOnceSource[K, V](
       consumerSettings: ConsumerSettings[K, V],
       subscription: Subscription,
       committerSettings: CommitterSettings
   )(
-      process: ConsumerRecord[K, V] => Future[Done]
-  )(implicit materializer: Materializer): Source[ConsumerMessage.CommittableOffsetBatch, Consumer.Control] = {
+      process: ConsumerRecord[K, V] => Future[_]
+  ): Source[ConsumerMessage.CommittableOffsetBatch, Consumer.Control] = {
     Consumer
-      .sourceWithOffsetContext(consumerSettings, subscription)
-      .mapAsync(1)(process)
-      .viaMat(Committer.flowWithOffsetContext(committerSettings))(Keep.left)
-      .asSource
-      .map(_._2)
+      .committableSource(consumerSettings, subscription)
+      .mapAsync(1) { message =>
+        process(message.record).map(_ => message.committableOffset)(ExecutionContexts.sameThreadExecutionContext)
+      }
+      .viaMat(Committer.batchFlow(committerSettings))(Keep.left)
   }
 
-  def atLeastOnceRunner[K, V](
+  /**
+   * Convenience for "at-least-once processing" of a function.
+   * Committing is managed by the usual [[Committer]] and the source emits information about batches of committed messages.
+   *
+   * The `process` function will be called in parallel across Kafka partitions, two records for the same partition will
+   * not be processed in parallel.
+   */
+  def atLeastOncePerPartitionSource[K, V](
       consumerSettings: ConsumerSettings[K, V],
       subscription: Subscription,
+      maxPartitions: Int,
       committerSettings: CommitterSettings
-  )(process: ConsumerRecord[K, V] => Future[Done])(implicit materializer: Materializer): DrainingControl[Done] = {
+  )(
+      process: ConsumerRecord[K, V] => Future[_]
+  ): Source[ConsumerMessage.CommittableOffsetBatch, Consumer.Control] = {
     Consumer
-      .sourceWithOffsetContext(consumerSettings, subscription)
-      .mapAsync(1)(process)
-      .toMat(Committer.sinkWithOffsetContext(committerSettings))(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
-      .run()
+      .committableSource(consumerSettings, subscription)
+      .groupBy(maxPartitions, _.record.partition() % maxPartitions)
+      .mapAsync(1) { message =>
+        process(message.record).map(_ => message.committableOffset)(ExecutionContexts.sameThreadExecutionContext)
+      }
+      .mergeSubstreamsWithParallelism(maxPartitions)
+      .viaMat(Committer.batchFlow(committerSettings))(Keep.left)
   }
 
-  def consumeAndProduceSource[CK, CV, PK, PV](
+  /**
+   * Convenience for "at-least-once processing" of Kafka records that may or may not result in new records
+   * being produced to Kafka.
+   * Committing is managed by the usual [[Committer]] and the source emits information about batches of committed messages.
+   */
+  def atLeastOnceConsumeAndProduceSource[CK, CV, PK, PV](
       consumerSettings: ConsumerSettings[CK, CV],
       subscription: Subscription,
       producerSettings: ProducerSettings[PK, PV],
       committerSettings: CommitterSettings
   )(
       process: ConsumerRecord[CK, CV] => Future[Envelope[PK, PV, NotUsed]]
-  )(implicit materializer: Materializer): Source[ConsumerMessage.CommittableOffsetBatch, Consumer.Control] = {
+  ): Source[ConsumerMessage.CommittableOffsetBatch, Consumer.Control] =
     Consumer
-      .sourceWithOffsetContext(consumerSettings, subscription)
-      .mapAsync(1)(process)
-      .viaMat(Producer.flowWithContext(producerSettings))(Keep.left)
-      .viaMat(Committer.flowWithOffsetContext(committerSettings))(Keep.left)
-      .asSource
-      .map(_._2)
-  }
-
-  def consumeAndProduceRunner[CK, CV, PK, PV](
-      consumerSettings: ConsumerSettings[CK, CV],
-      subscription: Subscription,
-      producerSettings: ProducerSettings[PK, PV],
-      committerSettings: CommitterSettings
-  )(
-      process: ConsumerRecord[CK, CV] => Future[Envelope[PK, PV, NotUsed]]
-  )(implicit materializer: Materializer): DrainingControl[Done] = {
-    Consumer
-      .sourceWithOffsetContext(consumerSettings, subscription)
-      .mapAsync(1)(process)
-      .toMat(Producer.committableSinkWithOffsetContext(producerSettings, committerSettings))(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
-      .run()
-  }
-
+      .committableSource(consumerSettings, subscription)
+      .mapAsync(1) { message =>
+        process(message.record).map { envelope =>
+          envelope.withPassThrough(message.committableOffset)
+        }(ExecutionContexts.sameThreadExecutionContext)
+      }
+      .viaMat(Producer.flexiFlow(producerSettings))(Keep.left)
+      .map(_.passThrough)
+      .viaMat(Committer.batchFlow(committerSettings))(Keep.left)
 }

--- a/core/src/main/scala/akka/kafka/scaladsl/Processor.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Processor.scala
@@ -1,0 +1,44 @@
+package akka.kafka.scaladsl
+
+import akka.kafka.ProducerMessage.Envelope
+import akka.kafka.scaladsl.Consumer.DrainingControl
+import akka.kafka.{CommitterSettings, ConsumerSettings, ProducerSettings, Subscription}
+import akka.stream.Materializer
+import akka.stream.scaladsl.Keep
+import akka.{Done, NotUsed}
+import org.apache.kafka.clients.consumer.ConsumerRecord
+
+import scala.concurrent.Future
+
+object Processor {
+
+  def atLeastOnce[K, V](
+      consumerSettings: ConsumerSettings[K, V],
+      subscription: Subscription,
+      committerSettings: CommitterSettings
+  )(process: ConsumerRecord[K, V] => Future[Done])(implicit materializer: Materializer): DrainingControl[Done] = {
+    Consumer
+      .sourceWithOffsetContext(consumerSettings, subscription)
+      .mapAsync(1)(process)
+      .toMat(Committer.sinkWithOffsetContext(committerSettings))(Keep.both)
+      .mapMaterializedValue(DrainingControl.apply)
+      .run()
+  }
+
+  def consumeAndProduce[CK, CV, PK, PV](
+      consumerSettings: ConsumerSettings[CK, CV],
+      subscription: Subscription,
+      producerSettings: ProducerSettings[PK, PV],
+      committerSettings: CommitterSettings
+  )(
+      process: ConsumerRecord[CK, CV] => Future[Envelope[PK, PV, NotUsed]]
+  )(implicit materializer: Materializer): DrainingControl[Done] = {
+    Consumer
+      .sourceWithOffsetContext(consumerSettings, subscription)
+      .mapAsync(1)(process)
+      .toMat(Producer.committableSinkWithOffsetContext(producerSettings, committerSettings))(Keep.both)
+      .mapMaterializedValue(DrainingControl.apply)
+      .run()
+  }
+
+}


### PR DESCRIPTION
Helpers for the simple cases that users can 
* consume elements with a `Future`
* convert incoming elements for producing in a `Future`