### PR TITLE
Commit when next offset is observed

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -166,6 +166,8 @@ akka.kafka.committer {
   # WaitForAck: Expect replies for commits, and backpressure the stream if replies do not arrive.
   # SendAndForget: Send off commits to the internal actor without expecting replies (experimental feature since 1.1)
   delivery = WaitForAck
+
+  trigger = FirstObserved
 }
 # // #committer-settings
 

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -167,7 +167,11 @@ akka.kafka.committer {
   # SendAndForget: Send off commits to the internal actor without expecting replies (experimental feature since 1.1)
   delivery = WaitForAck
 
-  when = FirstObserved
+  # API may change.
+  # Controls when a `Committable` message is enlisted in a batch or committed.
+  # OffsetFirstObserved: When the message the offset is associated with is processed then enlist or commit commit
+  # NextOffsetObserved: Once the next offset is observed commit the previous offset.
+  when = OffsetFirstObserved
 }
 # // #committer-settings
 

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -168,9 +168,9 @@ akka.kafka.committer {
   delivery = WaitForAck
 
   # API may change.
-  # Controls when a `Committable` message is enlisted in a batch or committed.
-  # OffsetFirstObserved: When the message the offset is associated with is processed then enlist or commit commit
-  # NextOffsetObserved: Once the next offset is observed commit the previous offset.
+  # Controls when a `Committable` message is queued to be committed.
+  # OffsetFirstObserved: When the offset of a message has been successfully produced.
+  # NextOffsetObserved: When the next offset is observed.
   when = OffsetFirstObserved
 }
 # // #committer-settings

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -167,7 +167,7 @@ akka.kafka.committer {
   # SendAndForget: Send off commits to the internal actor without expecting replies (experimental feature since 1.1)
   delivery = WaitForAck
 
-  trigger = FirstObserved
+  when = FirstObserved
 }
 # // #committer-settings
 

--- a/core/src/main/scala/akka/kafka/CommitterSettings.scala
+++ b/core/src/main/scala/akka/kafka/CommitterSettings.scala
@@ -55,43 +55,43 @@ object CommitDelivery {
 }
 
 @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/1092")
-sealed trait CommitTrigger
+sealed trait CommitWhen
 
 /**
  * Selects when the stream will commit an offset.
  */
 @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/1092")
-object CommitTrigger {
+object CommitWhen {
 
   /**
    * Commit as soon as a [[Committable]] is observed.
    */
   @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/1092")
-  case object FirstObserved extends CommitTrigger
+  case object FirstObserved extends CommitWhen
 
   /**
    * Commit once a new [[Committable]] is observed
    */
   @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/1092")
-  case object DeferToNextCommit extends CommitTrigger
+  case object DeferToNextOffset extends CommitWhen
 
   /**
    * Java API.
    */
   @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/1092")
-  val firstObserved: CommitTrigger = FirstObserved
+  val firstObserved: CommitWhen = FirstObserved
 
   /**
    * Java API.
    */
   @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/1092")
-  val deferToNextCommit: CommitTrigger = DeferToNextCommit
+  val deferToNextOffset: CommitWhen = DeferToNextOffset
 
-  def valueOf(s: String): CommitTrigger = s match {
+  def valueOf(s: String): CommitWhen = s match {
     case "FirstObserved" => FirstObserved
-    case "DeferToNextCommit" => DeferToNextCommit
+    case "DeferToNextOffset" => DeferToNextOffset
     case other =>
-      throw new IllegalArgumentException(s"allowed values are: FirstObserved, DeferToNextCommit. Received: $other")
+      throw new IllegalArgumentException(s"allowed values are: FirstObserved, DeferToNextOffset. Received: $other")
   }
 }
 
@@ -124,8 +124,8 @@ object CommitterSettings {
     val maxInterval = config.getDuration("max-interval", TimeUnit.MILLISECONDS).millis
     val parallelism = config.getInt("parallelism")
     val delivery = CommitDelivery.valueOf(config.getString("delivery"))
-    val trigger = CommitTrigger.valueOf(config.getString("trigger"))
-    new CommitterSettings(maxBatch, maxInterval, parallelism, delivery, trigger)
+    val when = CommitWhen.valueOf(config.getString("when"))
+    new CommitterSettings(maxBatch, maxInterval, parallelism, delivery, when)
   }
 
   /**
@@ -164,7 +164,7 @@ class CommitterSettings private (
     val maxInterval: FiniteDuration,
     val parallelism: Int,
     val delivery: CommitDelivery,
-    val trigger: CommitTrigger
+    val when: CommitWhen
 ) {
 
   def withMaxBatch(maxBatch: Long): CommitterSettings =
@@ -184,15 +184,15 @@ class CommitterSettings private (
     copy(delivery = value)
 
   @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/1092")
-  def withTrigger(value: CommitTrigger): CommitterSettings =
-    copy(trigger = value)
+  def withCommitWhen(value: CommitWhen): CommitterSettings =
+    copy(when = value)
 
   private def copy(maxBatch: Long = maxBatch,
                    maxInterval: FiniteDuration = maxInterval,
                    parallelism: Int = parallelism,
                    delivery: CommitDelivery = delivery,
-                   trigger: CommitTrigger = trigger): CommitterSettings =
-    new CommitterSettings(maxBatch, maxInterval, parallelism, delivery, trigger)
+                   when: CommitWhen = when): CommitterSettings =
+    new CommitterSettings(maxBatch, maxInterval, parallelism, delivery, when)
 
   override def toString: String =
     "akka.kafka.CommitterSettings(" +
@@ -200,5 +200,5 @@ class CommitterSettings private (
     s"maxInterval=${maxInterval.toCoarsest}," +
     s"parallelism=$parallelism," +
     s"delivery=$delivery," +
-    s"trigger=$trigger)"
+    s"when=$when)"
 }

--- a/core/src/main/scala/akka/kafka/CommitterSettings.scala
+++ b/core/src/main/scala/akka/kafka/CommitterSettings.scala
@@ -64,34 +64,36 @@ sealed trait CommitWhen
 object CommitWhen {
 
   /**
-   * Commit as soon as a [[Committable]] is observed.
+   * Commit as soon as a [[Committable]] offset is observed.
    */
   @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/1092")
-  case object FirstObserved extends CommitWhen
+  case object OffsetFirstObserved extends CommitWhen
 
   /**
-   * Commit once a new [[Committable]] is observed
+   * Commit once the next [[Committable]] offset is observed
    */
   @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/1092")
-  case object DeferToNextOffset extends CommitWhen
-
-  /**
-   * Java API.
-   */
-  @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/1092")
-  val firstObserved: CommitWhen = FirstObserved
+  case object NextOffsetObserved extends CommitWhen
 
   /**
    * Java API.
    */
   @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/1092")
-  val deferToNextOffset: CommitWhen = DeferToNextOffset
+  val offsetFirstObserved: CommitWhen = OffsetFirstObserved
+
+  /**
+   * Java API.
+   */
+  @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/1092")
+  val nextOffsetObserved: CommitWhen = NextOffsetObserved
 
   def valueOf(s: String): CommitWhen = s match {
-    case "FirstObserved" => FirstObserved
-    case "DeferToNextOffset" => DeferToNextOffset
+    case "OffsetFirstObserved" => OffsetFirstObserved
+    case "NextOffsetObserved" => NextOffsetObserved
     case other =>
-      throw new IllegalArgumentException(s"allowed values are: FirstObserved, DeferToNextOffset. Received: $other")
+      throw new IllegalArgumentException(
+        s"allowed values are: OffsetFirstObserved, NextOffsetObserved. Received: $other"
+      )
   }
 }
 

--- a/core/src/main/scala/akka/kafka/CommitterSettings.scala
+++ b/core/src/main/scala/akka/kafka/CommitterSettings.scala
@@ -54,37 +54,37 @@ object CommitDelivery {
   }
 }
 
-@ApiMayChange(issue = "")
+@ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/1092")
 sealed trait CommitTrigger
 
 /**
  * Selects when the stream will commit an offset.
  */
-@ApiMayChange(issue = "")
+@ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/1092")
 object CommitTrigger {
 
   /**
    * Commit as soon as a [[Committable]] is observed.
    */
-  @ApiMayChange(issue = "")
+  @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/1092")
   case object FirstObserved extends CommitTrigger
 
   /**
    * Commit once a new [[Committable]] is observed
    */
-  @ApiMayChange(issue = "")
+  @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/1092")
   case object DeferToNextCommit extends CommitTrigger
 
   /**
    * Java API.
    */
-  @ApiMayChange(issue = "")
+  @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/1092")
   val firstObserved: CommitTrigger = FirstObserved
 
   /**
    * Java API.
    */
-  @ApiMayChange(issue = "")
+  @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/1092")
   val deferToNextCommit: CommitTrigger = DeferToNextCommit
 
   def valueOf(s: String): CommitTrigger = s match {
@@ -183,7 +183,7 @@ class CommitterSettings private (
   def withDelivery(value: CommitDelivery): CommitterSettings =
     copy(delivery = value)
 
-  @ApiMayChange(issue = "")
+  @ApiMayChange(issue = "https://github.com/akka/alpakka-kafka/issues/1092")
   def withTrigger(value: CommitTrigger): CommitterSettings =
     copy(trigger = value)
 

--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -10,7 +10,9 @@ import java.util.concurrent.CompletionStage
 
 import akka.Done
 import akka.annotation.{DoNotInherit, InternalApi}
+import akka.kafka.CommitWhen.{NextOffsetObserved, OffsetFirstObserved}
 import akka.kafka.internal.{CommittableOffsetBatchImpl, CommittedMarker}
+import akka.stream.stage.GraphStageLogic
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.TopicPartition
 
@@ -224,5 +226,4 @@ object ConsumerMessage {
      */
     def isEmpty: Boolean
   }
-
 }

--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -10,9 +10,7 @@ import java.util.concurrent.CompletionStage
 
 import akka.Done
 import akka.annotation.{DoNotInherit, InternalApi}
-import akka.kafka.CommitWhen.{NextOffsetObserved, OffsetFirstObserved}
 import akka.kafka.internal.{CommittableOffsetBatchImpl, CommittedMarker}
-import akka.stream.stage.GraphStageLogic
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.TopicPartition
 
@@ -226,4 +224,5 @@ object ConsumerMessage {
      */
     def isEmpty: Boolean
   }
+
 }

--- a/core/src/main/scala/akka/kafka/internal/CommitCollectorStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommitCollectorStage.scala
@@ -56,7 +56,6 @@ private final class CommitCollectorStageLogic(
   // ---- Consuming
   private def consume(offset: Committable): Unit = {
     log.debug("Consuming offset {}", offset)
-
     if (updateBatch(offset))
       pushDownStream(BatchSize)(push)
     else tryPull(stage.in) // accumulating the batch

--- a/core/src/main/scala/akka/kafka/internal/CommitObservationLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommitObservationLogic.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.kafka.internal
+
+import akka.kafka.CommitWhen.{NextOffsetObserved, OffsetFirstObserved}
+import akka.kafka.CommitterSettings
+import akka.kafka.ConsumerMessage.{Committable, CommittableOffsetBatch}
+import akka.stream.stage.GraphStageLogic
+
+/**
+ * Shared commit observation logic between [[GraphStageLogic]] that facilitate offset commits,
+ * such as [[CommitCollectorStage]] and [[CommittingProducerSinkStage]].  It's possible more
+ * logic could be shared between these implementations.
+ */
+private[internal] trait CommitObservationLogic { self: GraphStageLogic =>
+  def settings: CommitterSettings
+
+  /** Batches offsets until a commit is triggered. */
+  protected var offsetBatch: CommittableOffsetBatch = CommittableOffsetBatch.empty
+
+  /** Deferred offset when `CommitterSetting.when == CommitWhen.NextOffsetObserved` **/
+  protected var deferredOffset: Option[Committable] = None
+
+  /**
+   * Update the offset batch when applicable given `CommitWhen` settings.
+   *
+   * Returns true if the batch is ready to be committed.
+   */
+  def updateBatch(offset: Committable): Boolean = {
+    val updateOffsetBatch = (settings.when, deferredOffset) match {
+      case (OffsetFirstObserved, _) =>
+        Some(offset)
+      case (NextOffsetObserved, None) =>
+        deferredOffset = Some(offset)
+        None
+      case (NextOffsetObserved, deferred @ Some(dOffset)) if dOffset != offset =>
+        deferredOffset = Some(offset)
+        deferred
+    }
+
+    for (offset <- updateOffsetBatch) offsetBatch = offsetBatch.updated(offset)
+
+    offsetBatch.batchSize >= settings.maxBatch && updateOffsetBatch.isDefined
+  }
+}

--- a/core/src/main/scala/akka/kafka/internal/CommittingProducerSinkStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommittingProducerSinkStage.scala
@@ -9,7 +9,7 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import akka.Done
 import akka.annotation.InternalApi
-import akka.kafka.CommitWhen.{DeferToNextOffset, FirstObserved}
+import akka.kafka.CommitWhen.{NextOffsetObserved, OffsetFirstObserved}
 import akka.kafka.ConsumerMessage.{Committable, CommittableOffsetBatch}
 import akka.kafka.ProducerMessage._
 import akka.kafka.{CommitDelivery, CommitterSettings, ProducerSettings}
@@ -171,11 +171,11 @@ private final class CommittingProducerSinkStageLogic[K, V, IN <: Envelope[K, V, 
 
   private def collectOffset(offset: Committable): Unit = {
     (stage.committerSettings.when, deferredOffset) match {
-      case (FirstObserved, _) =>
+      case (OffsetFirstObserved, _) =>
         offsetBatch = offsetBatch.updated(offset)
-      case (DeferToNextOffset, None) =>
+      case (NextOffsetObserved, None) =>
         deferredOffset = Some(offset)
-      case (DeferToNextOffset, Some(dOffset)) if dOffset != offset =>
+      case (NextOffsetObserved, Some(dOffset)) if dOffset != offset =>
         deferredOffset = Some(offset)
         offsetBatch = offsetBatch.updated(dOffset)
     }

--- a/tests/src/test/scala/akka/kafka/internal/CommitCollectorStageSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommitCollectorStageSpec.scala
@@ -197,7 +197,7 @@ class CommitCollectorStageSpec(_system: ActorSystem)
         val batches = sinkProbe.expectNextN(2)
         sinkProbe.expectNoMessage(10.millis)
 
-        // batches are committed within a mapAsyncUnordered, so it's possible to receive batch acknowledgements
+        // batches are committed using mapAsyncUnordered, so it's possible to receive batch acknowledgements
         // downstream out of order
         val lastBatch = batches.maxBy(_.offsets.values.last)
 

--- a/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
@@ -653,7 +653,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
       )(DrainingControl.apply)
       .run()
 
-    consumer.actor.expectNoMessage(50.millis)
+    consumer.actor.expectNoMessage(10.millis)
 
     eventually {
       producer.history.asScala should have size (1)

--- a/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
@@ -277,8 +277,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
           msg.committableOffset
         )
       }
-      .toMat(Producer.committableSink(producerSettings, committerSettings))(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.apply)
       .run()
 
     val commitMsg = consumer.actor.expectMsgClass(500.millis, classOf[Internal.Commit])
@@ -651,8 +650,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
         Producer
           .committableSink(producerSettings, committerSettings)
           .withAttributes(ActorAttributes.supervisionStrategy(Supervision.resumingDecider))
-      )(Keep.both)
-      .mapMaterializedValue(DrainingControl.apply)
+      )(DrainingControl.apply)
       .run()
 
     consumer.actor.expectNoMessage(50.millis)

--- a/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
@@ -61,6 +61,7 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
   val groupId = "group1"
   val topic = "topic1"
   val partition = 1
+  val partition2 = 2
 
   "committable producer sink" should "produce, and commit after interval" in assertAllStagesStopped {
     val consumer = FakeConsumer(groupId, topic, startOffset = 1616L)
@@ -259,6 +260,45 @@ class CommittingProducerSinkSpec(_system: ActorSystem)
     val elements = immutable.Seq(
       consumer.message(partition, "value 1"),
       consumer.message(partition, "value 2")
+    )
+
+    val producer = new MockProducer[String, String](true, new StringSerializer, new StringSerializer)
+    val producerSettings = ProducerSettings(system, new StringSerializer, new StringSerializer)
+      .withProducer(producer)
+    val committerSettings = CommitterSettings(system)
+      .withMaxBatch(1L)
+      .withCommitWhen(CommitWhen.NextOffsetObserved)
+
+    val control = Source(elements)
+      .concat(Source.maybe) // keep the source alive
+      .viaMat(ConsumerControlFactory.controlFlow())(Keep.right)
+      .map { msg =>
+        ProducerMessage.single(
+          new ProducerRecord("targetTopic", msg.record.key, msg.record.value),
+          msg.committableOffset
+        )
+      }
+      .toMat(Producer.committableSink(producerSettings, committerSettings))(DrainingControl.apply)
+      .run()
+
+    val commitMsg = consumer.actor.expectMsgClass(500.millis, classOf[Internal.Commit])
+    commitMsg.tp shouldBe new TopicPartition(topic, partition)
+    commitMsg.offsetAndMetadata.offset() shouldBe (consumer.startOffset + 1)
+    consumer.actor.reply(Done)
+
+    eventually {
+      producer.history.asScala should have size (2)
+    }
+    control.drainAndShutdown().futureValue shouldBe Done
+  }
+
+  it should "produce, and commit when the next offset is observed for the same partition" in assertAllStagesStopped {
+    val consumer = FakeConsumer(groupId, topic, startOffset = 1616L)
+
+    val elements = immutable.Seq(
+      consumer.message(partition, "value 1"),
+      consumer.message(partition2, "value 2"),
+      consumer.message(partition, "value 3")
     )
 
     val producer = new MockProducer[String, String](true, new StringSerializer, new StringSerializer)


### PR DESCRIPTION
A new `CommitterSetting` that allows users to defer commits until the next is observed.

References #1092
