### PR TITLE
Set stopTimeout to zero in BaseKafkaTest.consumeString.

### DIFF
--- a/testkit/src/main/java/akka/kafka/testkit/javadsl/BaseKafkaTest.java
+++ b/testkit/src/main/java/akka/kafka/testkit/javadsl/BaseKafkaTest.java
@@ -71,7 +71,8 @@ public abstract class BaseKafkaTest extends KafkaTestKitClass {
   protected Consumer.DrainingControl<List<ConsumerRecord<String, String>>> consumeString(
       String topic, long take) {
     return Consumer.plainSource(
-            consumerDefaults().withGroupId(createGroupId(1)), Subscriptions.topics(topic))
+            consumerDefaults().withGroupId(createGroupId(1)).withStopTimeout(Duration.ZERO),
+            Subscriptions.topics(topic))
         .take(take)
         .toMat(Sink.seq(), Keep.both())
         .mapMaterializedValue(Consumer::createDrainingControl)


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
Sets consumer stop timeout to `Duration.ZERO` in `BaseKafkaTest.consumeString` since it's using [consumer draining control](https://doc.akka.io/docs/alpakka-kafka/current/consumer.html#draining-control).

