### PR TITLE
Testkit: create ProducerMessage.PassThroughResult

### DIFF
--- a/testkit/src/main/scala/akka/kafka/testkit/ProducerResultFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/ProducerResultFactory.scala
@@ -54,7 +54,7 @@ object ProducerResultFactory {
       passThrough: PassThrough
   ): ProducerMessage.MultiResult[K, V, PassThrough] = ProducerMessage.MultiResult(parts.asScala.toList, passThrough)
 
-  def result[K, V, PassThrough](
+  def passThroughResult[K, V, PassThrough](
       passThrough: PassThrough
   ): ProducerMessage.PassThroughResult[K, V, PassThrough] = ProducerMessage.PassThroughResult(passThrough)
 }

--- a/testkit/src/main/scala/akka/kafka/testkit/ProducerResultFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/ProducerResultFactory.scala
@@ -53,4 +53,8 @@ object ProducerResultFactory {
       parts: java.util.Collection[ProducerMessage.MultiResultPart[K, V]],
       passThrough: PassThrough
   ): ProducerMessage.MultiResult[K, V, PassThrough] = ProducerMessage.MultiResult(parts.asScala.toList, passThrough)
+
+  def result[K, V, PassThrough](
+      passThrough: PassThrough
+  ): ProducerMessage.PassThroughResult[K, V, PassThrough] = ProducerMessage.PassThroughResult(passThrough)
 }


### PR DESCRIPTION
During writing test for solution described here https://discuss.lightbend.com/t/kafka-ability-to-react-on-message-publication-result/6208 I noticed that it is not possible in tests provide instance of ProducerMessage.PassThroughResult that is required to fully cover my implementation.

Thanks for reviewing this tiny PR and merging!

