### PR TITLE
Security: mask passwords in settings' toString

### DIFF
--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -623,9 +623,17 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
   def createKafkaConsumerCompletionStage(executor: Executor): CompletionStage[Consumer[K, V]] =
     enriched.map(consumerFactory)(ExecutionContext.fromExecutor(executor)).toJava
 
-  override def toString: String =
-    s"akka.kafka.ConsumerSettings(" +
-    s"properties=${properties.mkString(",")}," +
+  override def toString: String = {
+    val kafkaClients = properties.toSeq
+      .map {
+        case (key, _) if key.endsWith(".password") =>
+          key -> "[is set]"
+        case t => t
+      }
+      .sortBy(_._1)
+      .mkString(",")
+    "akka.kafka.ConsumerSettings(" +
+    s"properties=$kafkaClients," +
     s"keyDeserializer=$keyDeserializerOpt," +
     s"valueDeserializer=$valueDeserializerOpt," +
     s"pollInterval=${pollInterval.toCoarsest}," +
@@ -643,4 +651,5 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
     s"partitionHandlerWarning=${partitionHandlerWarning.toCoarsest}" +
     s"enrichAsync=${enrichAsync.map(_ => "needs to be applied")}" +
     ")"
+  }
 }

--- a/core/src/main/scala/akka/kafka/ProducerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ProducerSettings.scala
@@ -388,9 +388,17 @@ class ProducerSettings[K, V] @InternalApi private[kafka] (
                                enrichAsync,
                                producerFactorySync)
 
-  override def toString: String =
+  override def toString: String = {
+    val kafkaClients = properties.toSeq
+      .map {
+        case (key, _) if key.endsWith(".password") =>
+          key -> "[is set]"
+        case t => t
+      }
+      .sortBy(_._1)
+      .mkString(",")
     "akka.kafka.ProducerSettings(" +
-    s"properties=${properties.mkString(",")}," +
+    s"properties=$kafkaClients," +
     s"keySerializer=$keySerializerOpt," +
     s"valueSerializer=$valueSerializerOpt," +
     s"closeTimeout=${closeTimeout.toCoarsest}," +
@@ -400,6 +408,7 @@ class ProducerSettings[K, V] @InternalApi private[kafka] (
     s"eosCommitInterval=${eosCommitInterval.toCoarsest}," +
     s"enrichAsync=${enrichAsync.map(_ => "needs to be applied")}," +
     s"producerFactorySync=${producerFactorySync.map(_ => "is defined").getOrElse("is undefined")})"
+  }
 
   /**
    * Applies `enrichAsync` to complement these settings from asynchronous sources.

--- a/docs/src/main/paradox/production.md
+++ b/docs/src/main/paradox/production.md
@@ -18,7 +18,7 @@ This is just a start, please add your experiences to this list by [opening a Pul
 
 ## Monitoring
 
-For performance monitoring consider [Lightbend Telemetry](https://developer.lightbend.com/docs/telemetry/current/) which gives insights into Akka and Akka Streams.
+For performance monitoring consider [Lightbend Telemetry](https://developer.lightbend.com/docs/telemetry/current/home.html) which gives insights into Akka and Akka Streams.
 
 
 ## Security setup
@@ -30,7 +30,7 @@ The different security setups offered by Kafka brokers are described in the @ext
 
 The properties described in Kafka's @extref[Configuring Kafka Clients for SSL](kafka:/documentation.html#security_configclients) go in the
 `akka.kafka.consumer.kafka-clients` and `akka.kafka.producer.kafka-clients` sections of the configuration, or can be added programmatically via
-`ProducerSettings.withProperties` and `ConsumerSettings.withProperties`.
+`ProducerSettings.withProperties` and `ConsumerSettings.withProperties`. The necessary property name constants are available in @javadoc[SslConfigs](org.apache.kafka.common.config.SslConfigs).
 
 ```hocon
 akka.kafka.producer { # and akka.kafka.consumer respectively

--- a/tests/src/test/scala/akka/kafka/ConsumerSettingsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/ConsumerSettingsSpec.scala
@@ -9,6 +9,7 @@ import akka.actor.ActorSystem
 import akka.kafka.tests.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import com.typesafe.config.ConfigFactory
+import org.apache.kafka.common.config.SslConfigs
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, StringDeserializer}
 import org.scalatest._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
@@ -92,6 +93,18 @@ class ConsumerSettingsSpec
         .getConfig("akka.kafka.consumer")
       val settings = ConsumerSettings(conf, None, Some(new ByteArrayDeserializer))
       settings.getProperty("bootstrap.servers") should ===("localhost:9092")
+    }
+
+    "filter passwords from kafka-clients properties" in {
+      val conf = ConfigFactory.load().getConfig("akka.kafka.consumer")
+      val settings = ConsumerSettings(conf, new ByteArrayDeserializer, new StringDeserializer)
+        .withProperty(SslConfigs.SSL_KEY_PASSWORD_CONFIG, "hemligt")
+        .withProperty("ssl.truststore.password", "geheim")
+      val s = settings.toString
+      s should include(SslConfigs.SSL_KEY_PASSWORD_CONFIG)
+      s should not include ("hemligt")
+      s should include("ssl.truststore.password")
+      s should not include ("geheim")
     }
 
     "throw IllegalArgumentException if no value deserializer defined" in {


### PR DESCRIPTION
Alpakka Kafka logs the settings on producer and consumer startup.
This filters out passwords from the `toString` methods.