### PR TITLE
Committing: retry commits marked as retriable

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/CommittingProducerSinkStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommittingProducerSinkStage.scala
@@ -9,7 +9,6 @@ import java.util.concurrent.atomic.AtomicInteger
 
 import akka.Done
 import akka.annotation.InternalApi
-import akka.kafka.CommitWhen.{NextOffsetObserved, OffsetFirstObserved}
 import akka.kafka.ConsumerMessage.{Committable, CommittableOffsetBatch}
 import akka.kafka.ProducerMessage._
 import akka.kafka.{CommitDelivery, CommitterSettings, ProducerSettings}
@@ -52,7 +51,6 @@ private final class CommittingProducerSinkStageLogic[K, V, IN <: Envelope[K, V, 
     with StageIdLogging
     with DeferredProducer[K, V] {
 
-  import CommittingProducerSinkStage._
   import CommitTrigger._
 
   /** The promise behind the materialized future. */

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -605,10 +605,10 @@ import scala.util.control.NonFatal
               requestDelayedPoll()
 
             case commitException =>
-              log.warning("Kafka commit failed after={} ms, commitsInProgress={}, exception={}",
-                          duration / 1000000L,
-                          commitsInProgress,
-                          commitException)
+              log.error("Kafka commit failed after={} ms, commitsInProgress={}, exception={}",
+                        duration / 1000000L,
+                        commitsInProgress,
+                        commitException)
               val failure = Status.Failure(commitException)
               replyTo.foreach(_ ! failure)
           }

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -596,7 +596,7 @@ import scala.util.control.NonFatal
               replyTo.foreach(_ ! Done)
 
             case e: RetriableCommitFailedException =>
-              log.warning("Kafka commit is to be retried, cause={}, after={} ms, commitsInProgress={}",
+              log.warning("Kafka commit is to be retried, after={} ms, commitsInProgress={}, cause={}",
                           e.getCause,
                           duration / 1000000L,
                           commitsInProgress)
@@ -604,8 +604,12 @@ import scala.util.control.NonFatal
               commitSenders = commitSenders ++ replyTo
               requestDelayedPoll()
 
-            case e =>
-              val failure = Status.Failure(exception)
+            case commitException =>
+              log.warning("Kafka commit failed after={} ms, commitsInProgress={}, exception={}",
+                          duration / 1000000L,
+                          commitsInProgress,
+                          commitException)
+              val failure = Status.Failure(commitException)
               replyTo.foreach(_ ! failure)
           }
         }

--- a/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/ProducerStage.scala
@@ -5,8 +5,6 @@
 
 package akka.kafka.internal
 
-import java.util.concurrent.atomic.AtomicInteger
-
 import akka.annotation.InternalApi
 import akka.kafka.ProducerMessage._
 import akka.kafka.ProducerSettings


### PR DESCRIPTION
## Changes

* Test the commit callback exception for `RetriableCommitFailedException`
	* Re-add the commits and reply addresses to for aggregation with the next commit
	* Request an immediate poll
* Log other commit failures in the `KafkaConsumerActor` (as suggested in #955)
* Log "Kafka commit took longer than..." for successful commits only

## Background context

The Kafka client may report an exception to the commit async callback which marks the commit as not executed, but worth to be retried.
Before this change Alpakka Kafka would fail the stream for any kind of exception reported to the commit callback.

The "Kafka commit took longer than..." logging showed even for failed commit requests which gave the impression commits became slower and finally failed.