### PR TITLE
Docs: swap Java API in SerializationSpec for Scala API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ tmp
 .history
 dist
 /.idea
+.metals
+.bloop
 /*.iml
 /out
 /.idea_modules

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,6 @@ tmp
 .history
 dist
 /.idea
-.metals
-.bloop
 /*.iml
 /out
 /.idea_modules

--- a/tests/src/test/scala/docs/scaladsl/SerializationSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/SerializationSpec.scala
@@ -110,13 +110,9 @@ class SerializationSpec
 
     // #spray-deser
 
-    val resumeOnParsingException = ActorAttributes.withSupervisionStrategy {
-      new akka.japi.function.Function[Throwable, Supervision.Directive] {
-        override def apply(t: Throwable): Supervision.Directive = t match {
-          case _: spray.json.JsonParser.ParsingException => Supervision.Resume
-          case _ => Supervision.stop
-        }
-      }
+    val resumeOnParsingException = ActorAttributes.supervisionStrategy {
+      case _: spray.json.JsonParser.ParsingException => Supervision.Resume
+      case _ => Supervision.stop
     }
 
     val consumer = Consumer


### PR DESCRIPTION
this is a minor improvement in the test.
Scala code should use the Scala API instead of the Java API. 
This change leads to better documentation in `serialization.md`