### PR TITLE
Don't use ctx.log in KafkaClusterSharding

### DIFF
--- a/cluster-sharding/src/test/java/docs/javadsl/ClusterShardingExample.java
+++ b/cluster-sharding/src/test/java/docs/javadsl/ClusterShardingExample.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (C) 2014 - 2016 Softwaremill <https://softwaremill.com>
+ * Copyright (C) 2016 - 2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
 package docs.javadsl;
 
 import akka.actor.typed.ActorSystem;


### PR DESCRIPTION
It is used from Future call backs. The protocol is separate so not easy
to add a wrapper for piping back to self. Seems the least worst option.