### PR TITLE
Order logging params for RetriableException consumer failures

### DIFF
--- a/core/src/main/scala/akka/kafka/CommitTimeoutException.scala
+++ b/core/src/main/scala/akka/kafka/CommitTimeoutException.scala
@@ -8,7 +8,6 @@ package akka.kafka
 import java.util.concurrent.TimeoutException
 
 /**
- * Calls to `commitJavadsl` and `commitScaladsl` will be failed with this exception if
- * Kafka doesn't respond within `commit-timeout`
+ * Commits will be failed with this exception if Kafka doesn't respond within `commit-timeout`
  */
 class CommitTimeoutException(msg: String) extends TimeoutException(msg) {}

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -609,9 +609,9 @@ import scala.util.control.NonFatal
 
             case e: RetriableCommitFailedException =>
               log.warning("Kafka commit is to be retried, after={} ms, commitsInProgress={}, cause={}",
-                          e.getCause,
                           duration / 1000000L,
-                          commitsInProgress)
+                          commitsInProgress,
+                          e.getCause)
               commitMaps = commitMap.toList ++ commitMaps
               commitSenders = commitSenders ++ replyTo
               requestDelayedPoll()


### PR DESCRIPTION
Discovered from user logging provided in #1166