### PR TITLE
Deprecate RestrictedConsumer.committed(TopicPartition)

### DIFF
--- a/core/src/main/scala/akka/kafka/RestrictedConsumer.scala
+++ b/core/src/main/scala/akka/kafka/RestrictedConsumer.scala
@@ -5,8 +5,6 @@
 
 package akka.kafka
 
-import java.util
-
 import akka.annotation.ApiMayChange
 import com.github.ghik.silencer.silent
 import org.apache.kafka.clients.consumer.{Consumer, OffsetAndMetadata, OffsetAndTimestamp}
@@ -46,7 +44,7 @@ final class RestrictedConsumer(consumer: Consumer[_, _], duration: java.time.Dur
   /**
    * See [[org.apache.kafka.clients.consumer.KafkaConsumer#committed(java.util.Set[TopicPartition],java.time.Duration)]]
    */
-  def committed(partitions: util.Set[TopicPartition]): util.Map[TopicPartition, OffsetAndMetadata] =
+  def committed(partitions: java.util.Set[TopicPartition]): java.util.Map[TopicPartition, OffsetAndMetadata] =
     consumer.committed(partitions, duration)
 
   /**

--- a/core/src/main/scala/akka/kafka/RestrictedConsumer.scala
+++ b/core/src/main/scala/akka/kafka/RestrictedConsumer.scala
@@ -5,6 +5,8 @@
 
 package akka.kafka
 
+import java.util
+
 import akka.annotation.ApiMayChange
 import com.github.ghik.silencer.silent
 import org.apache.kafka.clients.consumer.{Consumer, OffsetAndMetadata, OffsetAndTimestamp}
@@ -38,7 +40,14 @@ final class RestrictedConsumer(consumer: Consumer[_, _], duration: java.time.Dur
    * See [[org.apache.kafka.clients.consumer.KafkaConsumer#committed(TopicPartition,java.time.Duration)]]
    */
   @silent
+  @deprecated("use `committed(java.util.Set[TopicPartition])`", "2.1.0")
   def committed(tp: TopicPartition): OffsetAndMetadata = consumer.committed(tp, duration)
+
+  /**
+   * See [[org.apache.kafka.clients.consumer.KafkaConsumer#committed(java.util.Set[TopicPartition],java.time.Duration)]]
+   */
+  def committed(partitions: util.Set[TopicPartition]): util.Map[TopicPartition, OffsetAndMetadata] =
+    consumer.committed(partitions, duration)
 
   /**
    * See [[org.apache.kafka.clients.consumer.KafkaConsumer#endOffsets(java.util.Collection[TopicPartition],java.time.Duration)]]


### PR DESCRIPTION
Due to upstream deprecation.  See https://github.com/akka/alpakka-kafka/pull/1177#discussion_r468131939