### PR TITLE
Simplify consuming stream for AssignmentSpec "consume from the specified topic pattern" test

### DIFF
--- a/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/AssignmentSpec.scala
@@ -9,9 +9,8 @@ import akka.Done
 import akka.kafka.Subscriptions
 import akka.kafka.scaladsl.{Consumer, Producer, SpecBase}
 import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
-import akka.stream.scaladsl.{Flow, Sink, Source}
+import akka.stream.scaladsl.{Sink, Source}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
-import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
 
@@ -67,13 +66,7 @@ class AssignmentSpec extends SpecBase with TestcontainersKafkaLike {
 
       val messages =
         consumer
-          .alsoTo(
-            // cancel once we've seen the last message on all topics
-            Flow[ConsumerRecord[String, String]]
-              .filter(_.value.toInt == totalMessages)
-              .take(topics.length.toLong)
-              .to(Sink.ignore)
-          )
+          .take(totalMessages * topics.length.toLong)
           .runWith(Sink.seq)
       val received = messages.futureValue
       if (received.size != totalMessages * topics.size) {


### PR DESCRIPTION
Addresses #1128 

I couldn't reproduce the failure in #1128, but I thought the test was a little strange so I simplified it.  With the old approach I suppose it's possible an early cancellation signal could shutdown the stream before the primary branch returns all the elements.
