### PR TITLE
testkit: Admin instead of AdminClient

### DIFF
--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/PerfFixtureHelpers.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/PerfFixtureHelpers.scala
@@ -8,10 +8,10 @@ package akka.kafka.benchmarks
 import java.time.Duration
 import java.util
 import java.util.concurrent.TimeUnit
-import java.util.{Arrays, Properties, UUID}
+import java.util.{Arrays, UUID}
 
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.kafka.clients.admin.{AdminClient, NewTopic}
+import org.apache.kafka.clients.admin.{Admin, NewTopic}
 import org.apache.kafka.clients.producer._
 import org.apache.kafka.common.serialization.{ByteArraySerializer, StringSerializer}
 
@@ -49,19 +49,19 @@ private[benchmarks] trait PerfFixtureHelpers extends LazyLogging {
     initTopicAndProducer(ft, kafkaHost)
 
   def createTopic(ft: FilledTopic, kafkaHost: String): KafkaProducer[Array[Byte], String] = {
-    val props = new Properties
+    val props = new java.util.HashMap[String, AnyRef]()
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaHost)
-    val admin = AdminClient.create(props)
+    val admin = Admin.create(props)
     val producer = createTopicAndFill(ft, props, admin)
     admin.close(adminClientCloseTimeout)
     producer
   }
 
   private def initTopicAndProducer(ft: FilledTopic, kafkaHost: String): Unit = {
-    val props = new Properties
+    val props = new java.util.HashMap[String, AnyRef]()
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaHost)
     //
-    val admin = AdminClient.create(props)
+    val admin = Admin.create(props)
     val existing = admin.listTopics().names().get(10, TimeUnit.SECONDS)
     if (existing.contains(ft.topic)) {
       logger.info(s"Reusing existing topic $ft")
@@ -72,7 +72,7 @@ private[benchmarks] trait PerfFixtureHelpers extends LazyLogging {
     admin.close(adminClientCloseTimeout)
   }
 
-  private def createTopicAndFill(ft: FilledTopic, props: Properties, admin: AdminClient) = {
+  private def createTopicAndFill(ft: FilledTopic, props: java.util.Map[String, AnyRef], admin: Admin) = {
     val result = admin.createTopics(
       Arrays.asList(
         new NewTopic(ft.topic, ft.numberOfPartitions, ft.replicationFactor.toShort)

--- a/build.sbt
+++ b/build.sbt
@@ -105,8 +105,7 @@ val commonSettings = Def.settings(
       "-unchecked",
       "-Xlint",
       "-Ywarn-dead-code",
-      "-Ywarn-numeric-widen",
-      "-target:jvm-1.8"
+      "-Ywarn-numeric-widen"
     ) ++ {
       if (scalaBinaryVersion.value == "2.13") Seq.empty
       else Seq("-Yno-adapted-args", "-Xfuture")

--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,8 @@ val commonSettings = Def.settings(
       "-unchecked",
       "-Xlint",
       "-Ywarn-dead-code",
-      "-Ywarn-numeric-widen"
+      "-Ywarn-numeric-widen",
+      "-target:jvm-1.8"
     ) ++ {
       if (scalaBinaryVersion.value == "2.13") Seq.empty
       else Seq("-Yno-adapted-args", "-Xfuture")

--- a/testkit/src/main/mima-filters/2.0.x.backwards.excludes
+++ b/testkit/src/main/mima-filters/2.0.x.backwards.excludes
@@ -6,3 +6,6 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.testkit.scaladsl.
 
 # Changed signature, but EmbeddedKafka will be removed with #1229
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.testkit.javadsl.EmbeddedKafkaJunit4Test.this")
+
+# Changed to return the Admin interface instead of the AdminClient class #1183
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.kafka.testkit.scaladsl.KafkaSpec.adminClient")

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
@@ -8,12 +8,12 @@ package akka.kafka.testkit.internal
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
-import java.util.{Arrays, Properties}
+import java.util.Arrays
 
 import akka.actor.ActorSystem
 import akka.kafka.testkit.KafkaTestkitSettings
 import akka.kafka.{CommitterSettings, ConsumerSettings, ProducerSettings}
-import org.apache.kafka.clients.admin.{AdminClient, AdminClientConfig, NewTopic}
+import org.apache.kafka.clients.admin.{Admin, AdminClientConfig, NewTopic}
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.{Deserializer, Serializer, StringDeserializer, StringSerializer}
 import org.slf4j.Logger
@@ -84,18 +84,18 @@ trait KafkaTestKit {
 
   val settings = KafkaTestkitSettings(system)
 
-  private lazy val adminDefaults = {
-    val config = new Properties()
+  private lazy val adminDefaults: java.util.Map[String, AnyRef] = {
+    val config = new java.util.HashMap[String, AnyRef]()
     config.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers)
     config
   }
 
-  private var adminClientVar: AdminClient = _
+  private var adminClientVar: Admin = _
 
   /**
-   * Access to the Kafka AdminClient which life
+   * Access to the Kafka Admin client
    */
-  def adminClient: AdminClient = {
+  def adminClient: Admin = {
     assert(
       adminClientVar != null,
       "admin client not created, be sure to call setupAdminClient() and cleanupAdminClient()"
@@ -110,7 +110,7 @@ trait KafkaTestKit {
    */
   def setUpAdminClient(): Unit =
     if (adminClientVar == null) {
-      adminClientVar = AdminClient.create(adminDefaults)
+      adminClientVar = Admin.create(adminDefaults)
     }
 
   /**

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKitChecks.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKitChecks.scala
@@ -9,7 +9,7 @@ import java.util.Collections
 import java.util.concurrent.TimeUnit
 
 import org.apache.kafka.clients.admin.{
-  AdminClient,
+  Admin,
   ConsumerGroupDescription,
   DescribeClusterResult,
   DescribeConsumerGroupsOptions
@@ -23,7 +23,7 @@ import scala.util.{Failure, Success, Try}
 object KafkaTestKitChecks {
   def waitUntilCluster(timeout: FiniteDuration,
                        sleepInBetween: FiniteDuration,
-                       adminClient: AdminClient,
+                       adminClient: Admin,
                        predicate: DescribeClusterResult => Boolean,
                        log: Logger): Unit =
     periodicalCheck("cluster state", timeout, sleepInBetween)(() => adminClient.describeCluster())(predicate)(log)
@@ -31,7 +31,7 @@ object KafkaTestKitChecks {
   def waitUntilConsumerGroup(groupId: String,
                              timeout: FiniteDuration,
                              sleepInBetween: FiniteDuration,
-                             adminClient: AdminClient,
+                             adminClient: Admin,
                              predicate: ConsumerGroupDescription => Boolean,
                              log: Logger): Unit =
     periodicalCheck("consumer group state", timeout, sleepInBetween)(


### PR DESCRIPTION
Prepartion for Alpakka Kafka 2.1
Clients should use the newer `Admin` interface (even though `AdminClient` is not deprecated in Kafka 2.6.0).