### PR TITLE
Generate version information when publishing artifacts

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -222,6 +222,7 @@ lazy val core = project
   .enablePlugins(AutomateHeaderPlugin)
   .disablePlugins(SitePlugin)
   .settings(commonSettings)
+  .settings(VersionGenerator.settings)
   .settings(
     name := "akka-stream-kafka",
     AutomaticModuleName.settings("akka.stream.alpakka.kafka"),

--- a/project/VersionGenerator.scala
+++ b/project/VersionGenerator.scala
@@ -1,0 +1,35 @@
+import sbt._
+import sbt.Keys._
+
+/**
+ * Generate version.conf and akka/kafka/Version.scala files based on the version setting.
+ *
+ * This was adapted from https://github.com/akka/akka/blob/v2.6.8/project/VersionGenerator.scala
+ */
+object VersionGenerator {
+
+  val settings: Seq[Setting[_]] = inConfig(Compile)(
+    Seq(
+      resourceGenerators += generateVersion(resourceManaged, _ / "version.conf", """|akka.kafka.version = "%s"
+         |"""),
+      sourceGenerators += generateVersion(
+          sourceManaged,
+          _ / "akka" / "kafka" / "Version.scala",
+          """|package akka.kafka
+         |
+         |object Version {
+         |  val current: String = "%s"
+         |}
+         |"""
+        )
+    )
+  )
+
+  def generateVersion(dir: SettingKey[File], locate: File => File, template: String) = Def.task[Seq[File]] {
+    val file = locate(dir.value)
+    val content = template.stripMargin.format(version.value)
+    if (!file.exists || IO.read(file) != content) IO.write(file, content)
+    Seq(file)
+  }
+
+}


### PR DESCRIPTION
Currently, the only way to get version information from alpakka-kafka artifacts is by reading its `MANIFEST.MF` file, which may be fragile when sbt-assembly or other fatjar packagers are used: the manifest can be lost, overridden by another one, or multiple artifacts may be using `Implementation-Version` key.

To overcome this problem, [Akka](https://github.com/akka/akka/blob/v2.6.8/project/VersionGenerator.scala), [Play](https://github.com/playframework/playframework/blob/2.8.2/project/Tasks.scala#L8-L37), and [Lagom](https://github.com/lagom/lagom/blob/1.6.3/project/Tasks.scala) all package a version class containing such information. Therefore, no matter if the application using them is building a fatjar or not, the version information is consistently accessible.

This pull request brings Akka solution and creates both `akka.kafka.Version` class as well as a `version.conf` with a key that is less prone to conflict with another artifact.
