### PR TITLE
docs: update Akka version

### DIFF
--- a/docs/src/main/paradox/home.md
+++ b/docs/src/main/paradox/home.md
@@ -12,6 +12,7 @@ This **Alpakka Kafka connector** lets you connect [Apache Kafka](https://kafka.a
 
 |Kafka client | Scala Versions | Akka version | Alpakka Kafka Connector
 |-------------|----------------|--------------|-------------------------
+|[2.4.1](https://dist.apache.org/repos/dist/release/kafka/2.4.1/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.31+, 2.6.6+ | @ref:[release 2.0.5](release-notes/2.0.x.md)
 |[2.4.1](https://dist.apache.org/repos/dist/release/kafka/2.4.1/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.30+, 2.6.6+ | @ref:[release 2.0.4](release-notes/2.0.x.md)
 |[2.4.1](https://dist.apache.org/repos/dist/release/kafka/2.4.1/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.30+, 2.6.3+ | @ref:[release 2.0.3](release-notes/2.0.x.md)
 |[2.4.0](https://dist.apache.org/repos/dist/release/kafka/2.4.0/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.23+, 2.6.x | @ref:[release 2.0.0](release-notes/2.0.x.md)


### PR DESCRIPTION
This release ups the required Akka 2.5 version.

References #1191