### PR TITLE
Commit collector: avoid pushing twice

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/CommitCollectorStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommitCollectorStage.scala
@@ -46,7 +46,7 @@ private final class CommitCollectorStageLogic(
 
   override protected def logSource: Class[_] = classOf[CommitCollectorStageLogic]
 
-  private var emitOnPull = false
+  private var pushOnNextPull = false
 
   override def preStart(): Unit = {
     super.preStart()
@@ -64,7 +64,7 @@ private final class CommitCollectorStageLogic(
         // Otherwise instruct `onPull` to emit what is there when the next pull occurs.
         // This is very hard to get tested consistently, so it gets this big comment instead.
         if (isAvailable(stage.out)) pushDownStream(Interval)
-        else emitOnPull = true
+        else pushOnNextPull = true
       } else scheduleCommit()
   }
 
@@ -111,9 +111,9 @@ private final class CommitCollectorStageLogic(
     stage.out,
     new OutHandler {
       def onPull(): Unit =
-        if (emitOnPull) {
+        if (pushOnNextPull) {
           pushDownStream(Interval)
-          emitOnPull = false
+          pushOnNextPull = false
         } else if (!hasBeenPulled(stage.in)) {
           tryPull(stage.in)
         }


### PR DESCRIPTION
The first commit tackles #1186 by explicitly checking if out can be pushed. The new tests did not illustrate the possible unlucky timing which may lead to pushing it twice.

The other commits simplify things in independent steps.

References #1186
