### PR TITLE
ScalaTest 3.1 with rewrites

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -8,6 +8,7 @@ updates.pin = [
   { groupId = "io.github.embeddedkafka", version="2.4." }
   # To be updated in tandem with upstream Akka
   { groupId = "com.fasterxml.jackson.core", version="2.10." }
+  { groupId = "org.scalatest", artifactId = "scalatest", version = "3.1." }
 ]
 
 commits.message = "${artifactName} ${nextVersion} (was ${currentVersion})"

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ val embeddedKafka = "io.github.embeddedkafka" %% "embedded-kafka" % embeddedKafk
 // that depends on the same Kafka version, as is defined above
 val embeddedKafkaSchemaRegistryVersion = "5.4.1.2"
 val kafkaVersionForDocs = "24"
-val scalatestVersion = "3.0.8"
+val scalatestVersion = "3.1.4"
 val testcontainersVersion = "1.14.3"
 val slf4jVersion = "1.7.30"
 val confluentAvroSerializerVersion = "5.4.1"

--- a/tests/src/test/scala/akka/kafka/ConfigSettingsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/ConfigSettingsSpec.scala
@@ -8,9 +8,10 @@ package akka.kafka
 import akka.kafka.internal.ConfigSettings
 import akka.kafka.tests.scaladsl.LogCapturing
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class ConfigSettingsSpec extends WordSpecLike with Matchers with LogCapturing {
+class ConfigSettingsSpec extends AnyWordSpec with Matchers with LogCapturing {
 
   "ConfigSettings" must {
 

--- a/tests/src/test/scala/akka/kafka/ConsumerSettingsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/ConsumerSettingsSpec.scala
@@ -11,13 +11,15 @@ import akka.testkit.TestKit
 import com.typesafe.config.ConfigFactory
 import org.apache.kafka.common.config.SslConfigs
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, StringDeserializer}
-import org.scalatest._
+import org.scalatest.OptionValues
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 import scala.concurrent.ExecutionContext
 
 class ConsumerSettingsSpec
-    extends WordSpecLike
+    extends AnyWordSpec
     with Matchers
     with OptionValues
     with ScalaFutures

--- a/tests/src/test/scala/akka/kafka/ProducerSettingsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/ProducerSettingsSpec.scala
@@ -11,11 +11,13 @@ import akka.testkit.TestKit
 import com.typesafe.config.ConfigFactory
 import org.apache.kafka.common.config.SslConfigs
 import org.apache.kafka.common.serialization.{ByteArraySerializer, StringSerializer}
-import org.scalatest._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 
 class ProducerSettingsSpec
-    extends WordSpecLike
+    extends AnyWordSpec
     with Matchers
     with ScalaFutures
     with IntegrationPatience

--- a/tests/src/test/scala/akka/kafka/TransactionsOps.scala
+++ b/tests/src/test/scala/akka/kafka/TransactionsOps.scala
@@ -16,7 +16,8 @@ import akka.stream.testkit.TestSubscriber
 import akka.stream.testkit.scaladsl.TestSink
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
-import org.scalatest.{Matchers, TestSuite}
+import org.scalatest.TestSuite
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.immutable
 import scala.concurrent.Future

--- a/tests/src/test/scala/akka/kafka/internal/CommitCollectorStageSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommitCollectorStageSpec.scala
@@ -23,7 +23,9 @@ import akka.stream.testkit.scaladsl.{TestSink, TestSource}
 import akka.stream.testkit.{TestPublisher, TestSubscriber}
 import akka.testkit.TestKit
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
-import org.scalatest.{AppendedClues, BeforeAndAfterAll, Matchers, WordSpecLike}
+import org.scalatest.{AppendedClues, BeforeAndAfterAll}
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.should.Matchers
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.duration.{FiniteDuration, _}
@@ -31,7 +33,7 @@ import scala.concurrent.{ExecutionContext, Future, Promise}
 
 class CommitCollectorStageSpec(_system: ActorSystem)
     extends TestKit(_system)
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with BeforeAndAfterAll
     with Eventually

--- a/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
@@ -26,7 +26,9 @@ import org.apache.kafka.clients.producer._
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization.StringSerializer
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.immutable
@@ -35,7 +37,7 @@ import scala.jdk.CollectionConverters._
 
 class CommittingProducerSinkSpec(_system: ActorSystem)
     extends TestKit(_system)
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures

--- a/tests/src/test/scala/akka/kafka/internal/CommittingWithMockSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingWithMockSpec.scala
@@ -23,7 +23,9 @@ import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -49,7 +51,7 @@ object CommittingWithMockSpec {
 
 class CommittingWithMockSpec(_system: ActorSystem)
     extends TestKit(_system)
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll
     with Eventually

--- a/tests/src/test/scala/akka/kafka/internal/ConnectionCheckerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConnectionCheckerSpec.scala
@@ -13,14 +13,15 @@ import akka.kafka.tests.scaladsl.LogCapturing
 import akka.testkit.TestKit
 import com.typesafe.config.ConfigFactory
 import org.apache.kafka.common.errors.TimeoutException
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 
 class ConnectionCheckerSpec
     extends TestKit(ActorSystem("KafkaConnectionCheckerSpec", ConfigFactory.load()))
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with LogCapturing {
 

--- a/tests/src/test/scala/akka/kafka/internal/ConsumerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConsumerSpec.scala
@@ -21,7 +21,9 @@ import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.mockito.Mockito._
 import org.scalatest.concurrent.Eventually
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
 
 import scala.jdk.CollectionConverters._
 import scala.collection.immutable.Seq
@@ -49,7 +51,7 @@ object ConsumerSpec {
 
 class ConsumerSpec(_system: ActorSystem)
     extends TestKit(_system)
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll
     with LogCapturing

--- a/tests/src/test/scala/akka/kafka/internal/EnhancedConfigSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/EnhancedConfigSpec.scala
@@ -7,11 +7,12 @@ package akka.kafka.internal
 
 import akka.kafka.tests.scaladsl.LogCapturing
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 import scala.concurrent.duration._
 
-class EnhancedConfigSpec extends WordSpecLike with Matchers with LogCapturing {
+class EnhancedConfigSpec extends AnyWordSpec with Matchers with LogCapturing {
 
   "EnhancedConfig" must {
 

--- a/tests/src/test/scala/akka/kafka/internal/OffsetAggregationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/OffsetAggregationSpec.scala
@@ -9,9 +9,10 @@ import akka.kafka.tests.scaladsl.LogCapturing
 import org.apache.kafka.clients.consumer.OffsetAndMetadata
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.requests.OffsetFetchResponse
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class OffsetAggregationSpec extends WordSpecLike with Matchers with LogCapturing {
+class OffsetAggregationSpec extends AnyWordSpec with Matchers with LogCapturing {
 
   val topicA = "topicA"
   val topicB = "topicB"

--- a/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
@@ -24,7 +24,9 @@ import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers, OptionValues}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.{BeforeAndAfterAll, OptionValues}
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.jdk.CollectionConverters._
@@ -33,7 +35,7 @@ import scala.concurrent.duration._
 
 class PartitionedSourceSpec(_system: ActorSystem)
     extends TestKit(_system)
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll
     with OptionValues

--- a/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
@@ -29,7 +29,9 @@ import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.mockito.verification.VerificationMode
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
@@ -38,7 +40,7 @@ import scala.util.{Failure, Success, Try}
 
 class ProducerSpec(_system: ActorSystem)
     extends TestKit(_system)
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll
     with LogCapturing {

--- a/tests/src/test/scala/akka/kafka/internal/SubscriptionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/SubscriptionsSpec.scala
@@ -11,9 +11,10 @@ import akka.kafka.tests.scaladsl.LogCapturing
 import akka.kafka.{Subscription, Subscriptions}
 import akka.util.ByteString
 import org.apache.kafka.common.TopicPartition
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
-class SubscriptionsSpec extends WordSpec with Matchers with LogCapturing {
+class SubscriptionsSpec extends AnyWordSpec with Matchers with LogCapturing {
 
   "URL encoded subscription" should {
     "be readable for topics" in {

--- a/tests/src/test/scala/akka/kafka/javadsl/ControlSpec.scala
+++ b/tests/src/test/scala/akka/kafka/javadsl/ControlSpec.scala
@@ -14,7 +14,8 @@ import akka.kafka.internal.ConsumerControlAsJava
 import akka.kafka.tests.scaladsl.LogCapturing
 import org.apache.kafka.common.{Metric, MetricName}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.Future
@@ -37,7 +38,7 @@ object ControlSpec {
   }
 }
 
-class ControlSpec extends WordSpecLike with ScalaFutures with Matchers with LogCapturing {
+class ControlSpec extends AnyWordSpec with ScalaFutures with Matchers with LogCapturing {
   import ControlSpec._
 
   val ec = Executors.newCachedThreadPool()

--- a/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/CommittingSpec.scala
@@ -21,7 +21,7 @@ import akka.testkit.TestProbe
 import akka.{Done, NotUsed}
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
-import org.scalatest._
+import org.scalatest.Inside
 
 import scala.collection.immutable
 import scala.concurrent.Future

--- a/tests/src/test/scala/akka/kafka/scaladsl/ConnectionCheckerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/ConnectionCheckerSpec.scala
@@ -16,12 +16,13 @@ import kafka.server.KafkaConfig
 import net.manub.embeddedkafka.{EmbeddedKafka, EmbeddedKafkaConfig}
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.StringDeserializer
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContextExecutor}
 
-class ConnectionCheckerSpec extends WordSpecLike with Matchers with LogCapturing {
+class ConnectionCheckerSpec extends AnyWordSpec with Matchers with LogCapturing {
 
   implicit val system: ActorSystem = ActorSystem("KafkaConnectionCheckerSpec")
   implicit val ec: ExecutionContextExecutor = system.dispatcher

--- a/tests/src/test/scala/akka/kafka/scaladsl/ControlSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/ControlSpec.scala
@@ -12,7 +12,8 @@ import akka.kafka.scaladsl.Consumer.DrainingControl
 import akka.kafka.tests.scaladsl.LogCapturing
 import org.apache.kafka.common.{Metric, MetricName}
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -33,7 +34,7 @@ object ControlSpec {
   }
 }
 
-class ControlSpec extends WordSpecLike with ScalaFutures with Matchers with LogCapturing {
+class ControlSpec extends AnyWordSpec with ScalaFutures with Matchers with LogCapturing {
   import ControlSpec._
 
   "Control" should {

--- a/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/IntegrationSpec.scala
@@ -21,7 +21,7 @@ import akka.util.Timeout
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
-import org.scalatest._
+import org.scalatest.Inside
 
 import scala.collection.immutable
 import scala.concurrent.duration._

--- a/tests/src/test/scala/akka/kafka/scaladsl/MisconfiguredConsumerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/MisconfiguredConsumerSpec.scala
@@ -15,11 +15,12 @@ import akka.testkit.TestKit
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.should.Matchers
 
 class MisconfiguredConsumerSpec
     extends TestKit(ActorSystem())
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with ScalaFutures
     with Eventually

--- a/tests/src/test/scala/akka/kafka/scaladsl/MisconfiguredProducerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/MisconfiguredProducerSpec.scala
@@ -15,11 +15,12 @@ import akka.testkit.TestKit
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.StringSerializer
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.should.Matchers
 
 class MisconfiguredProducerSpec
     extends TestKit(ActorSystem())
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with ScalaFutures
     with Eventually

--- a/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/PartitionedSourcesSpec.scala
@@ -21,7 +21,7 @@ import akka.testkit.TestProbe
 import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecord}
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.TopicPartition
-import org.scalatest._
+import org.scalatest.{Inside, OptionValues}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Future, Promise}

--- a/tests/src/test/scala/akka/kafka/scaladsl/RebalanceSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/RebalanceSpec.scala
@@ -19,7 +19,7 @@ import akka.{Done, NotUsed}
 import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerPartitionAssignor, ConsumerRecord}
 import org.apache.kafka.clients.consumer.internals.AbstractPartitionAssignor
 import org.apache.kafka.common.TopicPartition
-import org.scalatest._
+import org.scalatest.Inside
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.duration._

--- a/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/SpecBase.scala
@@ -10,11 +10,12 @@ import akka.kafka.tests.scaladsl.LogCapturing
 // #testkit
 import akka.kafka.testkit.scaladsl.ScalatestKafkaSpec
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.scalatest.matchers.should.Matchers
 
 abstract class SpecBase(kafkaPort: Int)
     extends ScalatestKafkaSpec(kafkaPort)
-    with WordSpecLike
+    with AnyWordSpecLike
     with Matchers
     with ScalaFutures
     // #testkit

--- a/tests/src/test/scala/docs/scaladsl/DocsSpecBase.scala
+++ b/tests/src/test/scala/docs/scaladsl/DocsSpecBase.scala
@@ -9,12 +9,14 @@ import akka.NotUsed
 import akka.kafka.testkit.scaladsl.KafkaSpec
 import akka.kafka.testkit.internal.TestFrameworkInterface
 import akka.stream.scaladsl.Flow
-import org.scalatest.{FlatSpecLike, Matchers, Suite}
+import org.scalatest.Suite
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 abstract class DocsSpecBase(kafkaPort: Int)
     extends KafkaSpec(kafkaPort)
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with TestFrameworkInterface.Scalatest
     with Matchers
     with ScalaFutures

--- a/tests/src/test/scala/docs/scaladsl/TestkitSamplesSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/TestkitSamplesSpec.scala
@@ -17,11 +17,13 @@ import akka.{Done, NotUsed}
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 class TestkitSamplesSpec
     extends TestKit(ActorSystem("example"))
-    with FlatSpecLike
+    with AnyFlatSpecLike
     with Matchers
     with BeforeAndAfterAll
     with ScalaFutures


### PR DESCRIPTION
Update to ScalaTest 3.1.4 and apply the new packages/names.