### PR TITLE
ScalaTest 3.1 fixes for it tests

### DIFF
--- a/benchmarks/src/it/scala/akka/kafka/benchmarks/SpecBase.scala
+++ b/benchmarks/src/it/scala/akka/kafka/benchmarks/SpecBase.scala
@@ -7,11 +7,12 @@ package akka.kafka.benchmarks
 
 import akka.kafka.testkit.scaladsl.ScalatestKafkaSpec
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
-import org.scalatest.{FlatSpecLike, Matchers}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 abstract class SpecBase(kafkaPort: Int)
-  extends ScalatestKafkaSpec(kafkaPort)
-    with FlatSpecLike
+    extends ScalatestKafkaSpec(kafkaPort)
+    with AnyFlatSpecLike
     with Matchers
     with ScalaFutures
     with Eventually {

--- a/tests/src/it/scala/akka/kafka/TransactionsPartitionedSourceSpec.scala
+++ b/tests/src/it/scala/akka/kafka/TransactionsPartitionedSourceSpec.scala
@@ -16,7 +16,9 @@ import akka.stream.scaladsl.{Keep, RestartSource, Sink}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import org.scalatest.concurrent.PatienceConfiguration.Interval
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{Ignore, Matchers, WordSpecLike}
+import org.scalatest.Ignore
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.collection.immutable
 import scala.concurrent.duration._
@@ -24,13 +26,14 @@ import scala.concurrent.{Await, Future, TimeoutException}
 import scala.util.{Failure, Success}
 
 @Ignore
-class TransactionsPartitionedSourceSpec extends SpecBase
-  with TestcontainersKafkaPerClassLike
-  with WordSpecLike
-  with ScalaFutures
-  with Matchers
-  with TransactionsOps
-  with Repeated {
+class TransactionsPartitionedSourceSpec
+    extends SpecBase
+    with TestcontainersKafkaPerClassLike
+    with AnyWordSpecLike
+    with ScalaFutures
+    with Matchers
+    with TransactionsOps
+    with Repeated {
 
   val replicationFactor = 2
 
@@ -80,8 +83,7 @@ class TransactionsPartitionedSourceSpec extends SpecBase
                 idleTimeout = 10.seconds,
                 maxPartitions = sourcePartitions,
                 restartAfter = Some(restartAfter)
-              )
-                .recover {
+              ).recover {
                   case e: TimeoutException =>
                     if (completedWithTimeout.incrementAndGet() > 10)
                       "no more messages to copy"

--- a/tests/src/it/scala/akka/kafka/TransactionsSourceSpec.scala
+++ b/tests/src/it/scala/akka/kafka/TransactionsSourceSpec.scala
@@ -18,20 +18,22 @@ import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.scalatest.concurrent.PatienceConfiguration.Interval
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{Matchers, WordSpecLike}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
 
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future, TimeoutException}
 import scala.util.{Failure, Success}
 
-class TransactionsSourceSpec extends SpecBase
-  with TestcontainersKafkaPerClassLike
-  with WordSpecLike
-  with ScalaFutures
-  with Matchers
-  with TransactionsOps
-  with Repeated {
+class TransactionsSourceSpec
+    extends SpecBase
+    with TestcontainersKafkaPerClassLike
+    with AnyWordSpecLike
+    with ScalaFutures
+    with Matchers
+    with TransactionsOps
+    with Repeated {
 
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(45.seconds, 1.second)
 
@@ -71,7 +73,13 @@ class TransactionsSourceSpec extends SpecBase
           .onFailuresWithBackoff(10.millis, 100.millis, 0.2)(
             () => {
               val transactionId = s"$group-$id"
-              transactionalCopyStream(consumerSettings, txProducerDefaults, sourceTopic, sinkTopic, transactionId, 10.seconds, Some(restartAfter))
+              transactionalCopyStream(consumerSettings,
+                                      txProducerDefaults,
+                                      sourceTopic,
+                                      sinkTopic,
+                                      transactionId,
+                                      10.seconds,
+                                      Some(restartAfter))
                 .recover {
                   case e: TimeoutException =>
                     if (completedWithTimeout.incrementAndGet() > 10)
@@ -150,7 +158,7 @@ class TransactionsSourceSpec extends SpecBase
             .source(consumerSettings, Subscriptions.topics(sourceTopic))
             .map { msg =>
               ProducerMessage.single(new ProducerRecord[String, String](sinkTopic, msg.record.value),
-                msg.partitionOffset)
+                                     msg.partitionOffset)
             }
             .take(batchSize.toLong)
             .delay(3.seconds, strategy = DelayOverflowStrategy.backpressure)


### PR DESCRIPTION
I prematurely merged #1207. The `it` tests required the same ScalaTest 3.1 fixes.
