### PR TITLE
Rollback Confluent Platform version; add Jackson Databind

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,10 +15,12 @@ val AkkaBinaryVersion26 = "2.6"
 val AkkaBinaryVersion = if (Nightly) AkkaBinaryVersion26 else AkkaBinaryVersion25
 
 val kafkaVersion = "2.6.0"
+// TODO Jackson is now a provided dependency of kafka-clients
+// https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients/2.6.0
 val jacksonVersion = "2.10.5"
 val embeddedKafkaVersion = "2.6.0"
 val embeddedKafka = "io.github.embeddedkafka" %% "embedded-kafka" % embeddedKafkaVersion
-val kafkaVersionForDocs = "24"
+val kafkaVersionForDocs = "26"
 val scalatestVersion = "3.1.4"
 val testcontainersVersion = "1.14.3"
 val slf4jVersion = "1.7.30"

--- a/build.sbt
+++ b/build.sbt
@@ -15,6 +15,7 @@ val AkkaBinaryVersion26 = "2.6"
 val AkkaBinaryVersion = if (Nightly) AkkaBinaryVersion26 else AkkaBinaryVersion25
 
 val kafkaVersion = "2.6.0"
+val jacksonVersion = "2.10.5"
 val embeddedKafkaVersion = "2.6.0"
 val embeddedKafka = "io.github.embeddedkafka" %% "embedded-kafka" % embeddedKafkaVersion
 val kafkaVersionForDocs = "24"
@@ -293,7 +294,7 @@ lazy val tests = project
         "org.testcontainers" % "kafka" % testcontainersVersion % Test,
         "org.scalatest" %% "scalatest" % scalatestVersion % Test,
         "io.spray" %% "spray-json" % "1.3.5" % Test,
-        "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.5" % Test, // ApacheV2
+        "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion % Test, // ApacheV2
         "org.junit.vintage" % "junit-vintage-engine" % JupiterKeys.junitVintageVersion.value % Test,
         // See http://hamcrest.org/JavaHamcrest/distributables#upgrading-from-hamcrest-1x
         "org.hamcrest" % "hamcrest-library" % "2.2" % Test,
@@ -423,6 +424,7 @@ lazy val benchmarks = project
         "ch.qos.logback" % "logback-classic" % "1.2.3",
         "org.slf4j" % "log4j-over-slf4j" % slf4jVersion,
         "com.lightbend.akka" %% "akka-stream-alpakka-csv" % "2.0.1",
+        "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion % IntegrationTest,
         "org.testcontainers" % "kafka" % testcontainersVersion % IntegrationTest,
         "com.typesafe.akka" %% "akka-slf4j" % akkaVersion % IntegrationTest,
         "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % IntegrationTest,

--- a/testkit/src/main/java/akka/kafka/testkit/internal/AlpakkaKafkaContainer.java
+++ b/testkit/src/main/java/akka/kafka/testkit/internal/AlpakkaKafkaContainer.java
@@ -32,7 +32,10 @@ public class AlpakkaKafkaContainer extends GenericContainer<AlpakkaKafkaContaine
   private static final String STARTER_SCRIPT = "/testcontainers_start.sh";
 
   // Align this with testkit/src/main/resources/reference.conf
-  public static final String DEFAULT_CP_PLATFORM_VERSION = "6.0.0";
+  public static final String DEFAULT_CONFLUENT_PLATFORM_VERSION = "5.4.0";
+
+  @Deprecated(since = "2.1.0")
+  public static final String DEFAULT_CP_PLATFORM_VERSION = DEFAULT_CONFLUENT_PLATFORM_VERSION;
 
   public static final int KAFKA_PORT = 9093;
 
@@ -52,7 +55,7 @@ public class AlpakkaKafkaContainer extends GenericContainer<AlpakkaKafkaContaine
   private boolean enableRemoteJmxService = false;
 
   public AlpakkaKafkaContainer() {
-    this(DEFAULT_CP_PLATFORM_VERSION);
+    this(DEFAULT_CONFLUENT_PLATFORM_VERSION);
   }
 
   public AlpakkaKafkaContainer(String confluentPlatformVersion) {

--- a/testkit/src/main/java/akka/kafka/testkit/internal/AlpakkaKafkaContainer.java
+++ b/testkit/src/main/java/akka/kafka/testkit/internal/AlpakkaKafkaContainer.java
@@ -34,9 +34,6 @@ public class AlpakkaKafkaContainer extends GenericContainer<AlpakkaKafkaContaine
   // Align this with testkit/src/main/resources/reference.conf
   public static final String DEFAULT_CONFLUENT_PLATFORM_VERSION = "5.4.0";
 
-  @Deprecated(since = "2.1.0")
-  public static final String DEFAULT_CP_PLATFORM_VERSION = DEFAULT_CONFLUENT_PLATFORM_VERSION;
-
   public static final int KAFKA_PORT = 9093;
 
   public static final int KAFKA_JMX_PORT = 49999;

--- a/testkit/src/main/java/akka/kafka/testkit/internal/KafkaContainerCluster.java
+++ b/testkit/src/main/java/akka/kafka/testkit/internal/KafkaContainerCluster.java
@@ -33,7 +33,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 public class KafkaContainerCluster implements Startable {
 
   public static final String CONFLUENT_PLATFORM_VERSION =
-      AlpakkaKafkaContainer.DEFAULT_CP_PLATFORM_VERSION;
+      AlpakkaKafkaContainer.DEFAULT_CONFLUENT_PLATFORM_VERSION;
   public static final int START_TIMEOUT_SECONDS = 120;
 
   private static final String READINESS_CHECK_SCRIPT = "/testcontainers_readiness_check.sh";

--- a/testkit/src/main/java/akka/kafka/testkit/internal/SchemaRegistryContainer.java
+++ b/testkit/src/main/java/akka/kafka/testkit/internal/SchemaRegistryContainer.java
@@ -14,7 +14,7 @@ public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryCont
   public static int SCHEMA_REGISTRY_PORT = 8081;
 
   public SchemaRegistryContainer() {
-    this(AlpakkaKafkaContainer.DEFAULT_CP_PLATFORM_VERSION);
+    this(AlpakkaKafkaContainer.DEFAULT_CONFLUENT_PLATFORM_VERSION);
   }
 
   public SchemaRegistryContainer(String confluentPlatformVersion) {

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -18,7 +18,7 @@ akka.kafka.testkit.testcontainers {
   # define this to select a different Kafka version by choosing the desired version of Confluent Platform
   # available Docker images: https://hub.docker.com/r/confluentinc/cp-kafka/tags
   # Kafka versions in Confluent Platform: https://docs.confluent.io/current/installation/versions-interoperability.html
-  confluent-platform-version = "6.0.0"
+  confluent-platform-version = "5.4.0"
 
   # the number of Kafka brokers to include in a test cluster
   num-brokers = 1


### PR DESCRIPTION
The Kafka client depends on Jackson Databind but marks it as provided.
https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients/2.6.0

Roll back the Confluent Platform as 6.0.0 requires changes to Testcontainers #1225