### PR TITLE
CI: actually compile cluster sharding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
       name: "Code style check. Run locally with: sbt verifyCodeStyle"
     - env: CMD=";++2.13.1 Test/compile ;++2.13.1 It/compile"
       name: "Compile all code with fatal warnings for Scala 2.13. Run locally with: env CI=true sbt ';++2.13.1 Test/compile ;++2.13.1 It/compile'"
-    - env: CMD="+clusterSharding/Test/compile
+    - env: CMD="+clusterSharding/Test/compile"
       name: "Compile cluster-sharding module for all supported Scala versions. Run locally with: env CI=true sbt '+clusterSharding/Test/compile'"
     - env: CMD="verifyDocs"
       name: "Create all API docs for artifacts/website and all reference docs. Run locally with: sbt verifyDocs"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
+version: ~> 1.0
 language: scala
-sudo: false
 
 services:
   - docker


### PR DESCRIPTION
As it turns out, the build step to compile cluster sharding didn't run anything in sbt as the environment variable wasn't correctly set.