### PR TITLE
Testkit: enable Mima

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -231,7 +231,7 @@ lazy val core = project
 lazy val testkit = project
   .dependsOn(core)
   .enablePlugins(AutomateHeaderPlugin)
-  .disablePlugins(MimaPlugin, SitePlugin)
+  .disablePlugins(SitePlugin)
   .settings(commonSettings)
   .settings(
     name := "akka-stream-kafka-testkit",
@@ -250,7 +250,8 @@ lazy val testkit = project
     mimaPreviousArtifacts := Set(
         organization.value %% name.value % previousStableVersion.value
           .getOrElse(throw new Error("Unable to determine previous version"))
-      )
+      ),
+    mimaBinaryIssueFilters += ProblemFilters.exclude[Problem]("akka.kafka.testkit.internal.*")
   )
 
 /**

--- a/testkit/src/main/mima-filters/2.0.x.backwards.excludes
+++ b/testkit/src/main/mima-filters/2.0.x.backwards.excludes
@@ -1,0 +1,5 @@
+# Inherited methods removed in ScalaTest 3.1 (#1207)
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.testkit.scaladsl.ScalatestKafkaSpec.execute")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.testkit.scaladsl.ScalatestKafkaSpec.newAssertionFailedException")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.testkit.scaladsl.ScalatestKafkaSpec.trap")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.testkit.scaladsl.ScalatestKafkaSpec.assertionsHelper")


### PR DESCRIPTION
Even though Akka testkits do not promise binary compatibilty nor source compatibility we should use Mima to detect changes to the API.﻿
