### PR TITLE
DiscoverySupport: remove deprecation

### DIFF
--- a/core/src/main/scala/akka/kafka/javadsl/DiscoverySupport.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/DiscoverySupport.scala
@@ -37,7 +37,6 @@ object DiscoverySupport {
   }
 
   // kept for bin-compatibility
-  @deprecated("use the variant with ClassicActorSystemProvider instead", "2.0.5")
   def consumerBootstrapServers[K, V](
       config: Config,
       system: ActorSystem
@@ -61,7 +60,6 @@ object DiscoverySupport {
   }
 
   // kept for bin-compatibility
-  @deprecated("use the variant with ClassicActorSystemProvider instead", "2.0.5")
   def producerBootstrapServers[K, V](
       config: Config,
       system: ActorSystem

--- a/core/src/main/scala/akka/kafka/scaladsl/DiscoverySupport.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/DiscoverySupport.scala
@@ -85,7 +85,6 @@ object DiscoverySupport {
   }
 
   // kept for bin-compatibility
-  @deprecated("use the variant with ClassicActorSystemProvider instead", "2.0.5")
   def consumerBootstrapServers[K, V](
       config: Config
   )(system: ActorSystem): ConsumerSettings[K, V] => Future[ConsumerSettings[K, V]] = {
@@ -110,7 +109,6 @@ object DiscoverySupport {
   }
 
   // kept for bin-compatibility
-  @deprecated("use the variant with ClassicActorSystemProvider instead", "2.0.5")
   def producerBootstrapServers[K, V](config: Config)(
       system: ActorSystem
   ): ProducerSettings[K, V] => Future[ProducerSettings[K, V]] = {

--- a/testkit/src/main/mima-filters/2.0.x.backwards.excludes
+++ b/testkit/src/main/mima-filters/2.0.x.backwards.excludes
@@ -3,3 +3,6 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.testkit.scaladsl.
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.testkit.scaladsl.ScalatestKafkaSpec.newAssertionFailedException")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.testkit.scaladsl.ScalatestKafkaSpec.trap")
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.testkit.scaladsl.ScalatestKafkaSpec.assertionsHelper")
+
+# Changed signature, but EmbeddedKafka will be removed with #1229
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.testkit.javadsl.EmbeddedKafkaJunit4Test.this")

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
@@ -16,6 +16,7 @@ import akka.kafka._
 import akka.kafka.scaladsl.Consumer.Control
 import akka.kafka.scaladsl.{Consumer, Producer}
 import akka.kafka.testkit.internal.{KafkaTestKit, KafkaTestKitChecks}
+import akka.stream.{Materializer, SystemMaterializer}
 import akka.stream.scaladsl.{Keep, Source}
 import akka.stream.testkit.TestSubscriber
 import akka.stream.testkit.scaladsl.TestSink
@@ -45,6 +46,7 @@ abstract class KafkaSpec(_kafkaPort: Int, val zooKeeperPort: Int, actorSystem: A
   implicit val adapter: LoggingAdapter = new Slf4jToAkkaLoggingAdapter(log)
 
   implicit val ec: ExecutionContext = system.dispatcher
+  implicit val mat: Materializer = SystemMaterializer(system).materializer
   implicit val scheduler: akka.actor.Scheduler = system.scheduler
 
   var testProducer: KProducer[String, String] = _

--- a/tests/src/test/java/docs/javadsl/ConsumerSettingsTest.java
+++ b/tests/src/test/java/docs/javadsl/ConsumerSettingsTest.java
@@ -30,9 +30,6 @@ public class ConsumerSettingsTest {
     // #discovery-settings
 
     Config consumerConfig = system.settings().config().getConfig("discovery-consumer");
-    // #discovery-settings
-    @SuppressWarnings("deprecation")
-    // #discovery-settings
     ConsumerSettings<String, String> settings =
         ConsumerSettings.create(consumerConfig, new StringDeserializer(), new StringDeserializer())
             .withEnrichCompletionStage(

--- a/tests/src/test/java/docs/javadsl/ProducerSettingsTest.java
+++ b/tests/src/test/java/docs/javadsl/ProducerSettingsTest.java
@@ -30,9 +30,6 @@ public class ProducerSettingsTest {
     // #discovery-settings
 
     Config producerConfig = system.settings().config().getConfig("discovery-producer");
-    // #discovery-settings
-    @SuppressWarnings("deprecation")
-    // #discovery-settings
     ProducerSettings<String, String> settings =
         ProducerSettings.create(producerConfig, new StringSerializer(), new StringSerializer())
             .withEnrichCompletionStage(


### PR DESCRIPTION
With the deprecation warning in place it became impossible to avoid it in user code without doing effort as the compiler prefers the exact type of the classic actor system.

This removes the deprecation so that a classic actor system can be passed in.﻿

See https://github.com/akka/alpakka-kafka/pull/1209#discussion_r504450434
