### PR TITLE
Start & stop Kafka process within running container

### DIFF
--- a/testkit/src/main/java/akka/kafka/testkit/internal/AlpakkaKafkaContainer.java
+++ b/testkit/src/main/java/akka/kafka/testkit/internal/AlpakkaKafkaContainer.java
@@ -99,11 +99,8 @@ public class AlpakkaKafkaContainer extends GenericContainer<AlpakkaKafkaContaine
 
   public void stopKafka() {
     try {
-      // System.out.println(execInContainer("sh", "-c", "/usr/bin/kafka-server-stop").getStdout());
       ExecResult execResult = execInContainer("sh", "-c", "touch /tmp/stop");
-      System.out.println(execResult.getStdout());
-      System.out.println(execResult.getStderr());
-      System.out.println(execResult.getExitCode());
+      if (execResult.getExitCode() != 0) throw new Exception(execResult.getStderr());
     } catch (Exception ex) {
       throw new RuntimeException(ex);
     }
@@ -111,11 +108,8 @@ public class AlpakkaKafkaContainer extends GenericContainer<AlpakkaKafkaContaine
 
   public void startKafka() {
     try {
-      // System.out.println(execInContainer("sh", "-c", "'" + STARTER_SCRIPT + " &'").getStdout());
       ExecResult execResult = execInContainer("sh", "-c", "touch /tmp/start");
-      System.out.println(execResult.getStdout());
-      System.out.println(execResult.getStderr());
-      System.out.println(execResult.getExitCode());
+      if (execResult.getExitCode() != 0) throw new Exception(execResult.getStderr());
     } catch (Exception ex) {
       throw new RuntimeException(ex);
     }
@@ -233,11 +227,9 @@ public class AlpakkaKafkaContainer extends GenericContainer<AlpakkaKafkaContaine
               + "'\n"
               + "touch /tmp/start\n"
               + "while :; do\n"
-              + "\techo 'tick1'\n"
               + "\tif [ -f $STARTER_SCRIPT ]; then\n"
-              + "\t\techo 'tick2'\n"
-              + "\t\tif [ -f /tmp/stop ]; then rm /tmp/stop; echo 'calling kafka-server-stop'; /usr/bin/kafka-server-stop; echo 'called kafka-server-stop';\n"
-              + "\t\telif [ -f /tmp/start ]; then rm /tmp/start; echo 'calling start script'; bash -c \"$STARTER_SCRIPT &\"; echo 'called start script';fi\n"
+              + "\t\tif [ -f /tmp/stop ]; then rm /tmp/stop; /usr/bin/kafka-server-stop;\n"
+              + "\t\telif [ -f /tmp/start ]; then rm /tmp/start; bash -c \"$STARTER_SCRIPT &\";fi\n"
               + "\tfi\n"
               + "\tsleep 0.1\n"
               + "done\n";

--- a/testkit/src/main/java/akka/kafka/testkit/javadsl/TestcontainersKafkaJunit4Test.java
+++ b/testkit/src/main/java/akka/kafka/testkit/javadsl/TestcontainersKafkaJunit4Test.java
@@ -56,15 +56,15 @@ public abstract class TestcontainersKafkaJunit4Test extends KafkaJunit4Test {
         TestcontainersKafka.Singleton()
             .testcontainersSettings()
             .withConfluentPlatformVersion(confluentPlatformVersion);
-    return TestcontainersKafka.Singleton().startKafka(settings);
+    return TestcontainersKafka.Singleton().startCluster(settings);
   }
 
   protected static String startKafka(KafkaTestkitTestcontainersSettings settings) {
-    return TestcontainersKafka.Singleton().startKafka(settings);
+    return TestcontainersKafka.Singleton().startCluster(settings);
   }
 
   protected static void stopKafka() {
-    TestcontainersKafka.Singleton().stopKafka();
+    TestcontainersKafka.Singleton().stopCluster();
   }
 
   @Before

--- a/testkit/src/main/java/akka/kafka/testkit/javadsl/TestcontainersKafkaTest.java
+++ b/testkit/src/main/java/akka/kafka/testkit/javadsl/TestcontainersKafkaTest.java
@@ -59,15 +59,15 @@ public abstract class TestcontainersKafkaTest extends KafkaTest {
         TestcontainersKafka.Singleton()
             .testcontainersSettings()
             .withConfluentPlatformVersion(confluentPlatformVersion);
-    return TestcontainersKafka.Singleton().startKafka(settings);
+    return TestcontainersKafka.Singleton().startCluster(settings);
   }
 
   protected static String startKafka(KafkaTestkitTestcontainersSettings settings) {
-    return TestcontainersKafka.Singleton().startKafka(settings);
+    return TestcontainersKafka.Singleton().startCluster(settings);
   }
 
   protected static void stopKafka() {
-    TestcontainersKafka.Singleton().stopKafka();
+    TestcontainersKafka.Singleton().stopCluster();
   }
 
   protected String getSchemaRegistryUrl() {

--- a/testkit/src/main/mima-filters/2.0.5.backwards.excludes/PR1235-start_stop_kafka_process.excludes
+++ b/testkit/src/main/mima-filters/2.0.5.backwards.excludes/PR1235-start_stop_kafka_process.excludes
@@ -1,0 +1,2 @@
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("akka.kafka.testkit.scaladsl.TestcontainersKafkaLike.startKafka")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("akka.kafka.testkit.scaladsl.TestcontainersKafkaLike.startKafka")

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/TestcontainersKafka.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/TestcontainersKafka.scala
@@ -60,9 +60,9 @@ object TestcontainersKafka {
           throw new RuntimeException("Did you enable schema registry in your KafkaTestkitTestcontainersSettings?")
         )
 
-    def startKafka(): String = startKafka(testcontainersSettings)
+    def startCluster(): String = startCluster(testcontainersSettings)
 
-    def startKafka(settings: KafkaTestkitTestcontainersSettings): String = {
+    def startCluster(settings: KafkaTestkitTestcontainersSettings): String = {
       import settings._
       // check if already initialized
       if (kafkaPortInternal == -1) {
@@ -83,12 +83,16 @@ object TestcontainersKafka {
       kafkaBootstrapServersInternal
     }
 
-    def stopKafka(): Unit =
+    def stopCluster(): Unit =
       if (kafkaPortInternal != -1) {
         cluster.stop()
         kafkaPortInternal = -1
         cluster = null
       }
+
+    def startKafka(): Unit = cluster.startKafka()
+
+    def stopKafka(): Unit = cluster.stopKafka()
 
     def schemaRegistryUrl: String =
       schemaRegistryContainer

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/TestcontainersKafkaLike.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/TestcontainersKafkaLike.scala
@@ -24,13 +24,15 @@ trait TestcontainersKafkaLike extends TestcontainersKafka.Spec {
   override def schemaRegistryContainer: Option[SchemaRegistryContainer] =
     TestcontainersKafka.Singleton.schemaRegistryContainer
   override def schemaRegistryUrl: String = TestcontainersKafka.Singleton.schemaRegistryUrl
-  override def startKafka(): String = TestcontainersKafka.Singleton.startKafka()
-  override def startKafka(settings: KafkaTestkitTestcontainersSettings): String =
-    TestcontainersKafka.Singleton.startKafka(settings)
+  override def startCluster(): String = TestcontainersKafka.Singleton.startCluster()
+  override def startCluster(settings: KafkaTestkitTestcontainersSettings): String =
+    TestcontainersKafka.Singleton.startCluster(settings)
+  override def stopCluster(): Unit = TestcontainersKafka.Singleton.stopCluster()
+  override def startKafka(): Unit = TestcontainersKafka.Singleton.startKafka()
   override def stopKafka(): Unit = TestcontainersKafka.Singleton.stopKafka()
 
   override def setUp(): Unit = {
-    startKafka(testcontainersSettings)
+    startCluster(testcontainersSettings)
     super.setUp()
   }
 

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/TestcontainersKafkaPerClassLike.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/TestcontainersKafkaPerClassLike.scala
@@ -13,12 +13,12 @@ import akka.kafka.testkit.internal.TestcontainersKafka
  */
 trait TestcontainersKafkaPerClassLike extends TestcontainersKafka.Spec {
   override def setUp(): Unit = {
-    startKafka()
+    startCluster()
     super.setUp()
   }
 
   override def cleanUp(): Unit = {
     super.cleanUp()
-    stopKafka()
+    stopCluster()
   }
 }

--- a/tests/src/test/scala/akka/kafka/scaladsl/ConnectionCheckerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/ConnectionCheckerSpec.scala
@@ -24,8 +24,8 @@ class ConnectionCheckerSpec extends SpecBase with TestcontainersKafkaPerClassLik
 
   override def cleanUp(): Unit = Try(super.cleanUp())
 
-  override def startKafka(): String = {
-    val bootstrapServers = super.startKafka()
+  override def startCluster(): String = {
+    val bootstrapServers = super.startCluster()
     testProducer = Await.result(producerDefaults.createKafkaProducerAsync(), 2.seconds)
     setUpAdminClient()
     bootstrapServers
@@ -65,7 +65,7 @@ class ConnectionCheckerSpec extends SpecBase with TestcontainersKafkaPerClassLik
     }
 
     "fail stream and control.isShutdown when kafka down and not recover during max retries exceeded" in assertAllStagesStopped {
-      startKafka()
+      startCluster()
 
       val msg = "hello"
       produceString(topic, scala.collection.immutable.Seq(msg))
@@ -77,7 +77,7 @@ class ConnectionCheckerSpec extends SpecBase with TestcontainersKafkaPerClassLik
 
       probe.ensureSubscription().requestNext().value() shouldBe msg
 
-      stopKafka()
+      stopCluster()
       Await.ready(control.isShutdown, failingDetectionTime)
       probe.request(1).expectError().getClass shouldBe classOf[KafkaConnectionFailed]
     }

--- a/tests/src/test/scala/akka/kafka/scaladsl/ReconnectSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/ReconnectSpec.scala
@@ -93,10 +93,6 @@ class ReconnectSpec extends SpecBase with TestcontainersKafkaLike {
       Await.ready(control.shutdown(), remainingOrDefault)
     }
 
-    /**
-     * This test works, but doesn't truly recreate a broker disconnect like it did when it used embedded-kafka
-     * Details: https://github.com/akka/alpakka-kafka/issues/1233
-     */
     "pick up again when the Kafka server comes back up" in assertAllStagesStopped {
       val topic1 = createTopic(1)
       val group1 = createGroupId(1)
@@ -112,7 +108,7 @@ class ReconnectSpec extends SpecBase with TestcontainersKafkaLike {
       // expect an element and make Kafka brokers unavailable
       probe.requestNext() should be("1")
       // stop Kafka broker process
-      this.brokerContainers.foreach(_.stopKafka())
+      stopKafka()
       sleep(1.second)
 
       // by now all messages have arrived in the consumer
@@ -124,7 +120,7 @@ class ReconnectSpec extends SpecBase with TestcontainersKafkaLike {
       probe.expectNoMessage(1.second)
 
       // start Kafka broker process produce another round
-      this.brokerContainers.foreach(_.startKafka())
+      startKafka()
 
       sleep(1.second) // Got some messages dropped during startup
       produce(topic1, messagesProduced + 1 to messagesProduced * 2)

--- a/tests/src/test/scala/akka/kafka/scaladsl/ReconnectSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/ReconnectSpec.scala
@@ -112,7 +112,7 @@ class ReconnectSpec extends SpecBase with TestcontainersKafkaLike {
       // expect an element and make Kafka brokers unavailable
       probe.requestNext() should be("1")
       // pause Kafka brokers
-      this.brokerContainers.foreach(c => c.getDockerClient.pauseContainerCmd(c.getContainerId).exec())
+      this.brokerContainers.foreach(_.stopKafka())
       sleep(1.second)
 
       // by now all messages have arrived in the consumer
@@ -124,7 +124,7 @@ class ReconnectSpec extends SpecBase with TestcontainersKafkaLike {
       probe.expectNoMessage(1.second)
 
       // unpause Kafka brokers and produce another round
-      this.brokerContainers.foreach(c => c.getDockerClient.unpauseContainerCmd(c.getContainerId).exec())
+      this.brokerContainers.foreach(_.startKafka())
 
       sleep(1.second) // Got some messages dropped during startup
       produce(topic1, messagesProduced + 1 to messagesProduced * 2)

--- a/tests/src/test/scala/akka/kafka/scaladsl/ReconnectSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/ReconnectSpec.scala
@@ -6,7 +6,7 @@
 package akka.kafka.scaladsl
 
 import akka.Done
-import akka.kafka.testkit.scaladsl.TestcontainersKafkaPerClassLike
+import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
 import akka.stream.scaladsl.{Keep, Sink, Source, SourceQueueWithComplete, Tcp}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.{KillSwitches, OverflowStrategy, UniqueKillSwitch}
@@ -15,7 +15,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-class ReconnectSpec extends SpecBase with TestcontainersKafkaPerClassLike {
+class ReconnectSpec extends SpecBase with TestcontainersKafkaLike {
 
   val proxyPort = 9034
 
@@ -109,7 +109,7 @@ class ReconnectSpec extends SpecBase with TestcontainersKafkaPerClassLike {
       probe.requestNext() should be("1")
       // stop Kafka broker process
       stopKafka()
-      sleep(1.second)
+      sleep(10.second)
 
       // by now all messages have arrived in the consumer
       probe.request(messagesProduced.toLong - 1)

--- a/tests/src/test/scala/akka/kafka/scaladsl/ReconnectSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/ReconnectSpec.scala
@@ -111,7 +111,7 @@ class ReconnectSpec extends SpecBase with TestcontainersKafkaLike {
 
       // expect an element and make Kafka brokers unavailable
       probe.requestNext() should be("1")
-      // pause Kafka brokers
+      // stop Kafka broker process
       this.brokerContainers.foreach(_.stopKafka())
       sleep(1.second)
 
@@ -123,7 +123,7 @@ class ReconnectSpec extends SpecBase with TestcontainersKafkaLike {
       probe.request(1)
       probe.expectNoMessage(1.second)
 
-      // unpause Kafka brokers and produce another round
+      // start Kafka broker process produce another round
       this.brokerContainers.foreach(_.startKafka())
 
       sleep(1.second) // Got some messages dropped during startup

--- a/tests/src/test/scala/akka/kafka/scaladsl/ReconnectSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/ReconnectSpec.scala
@@ -6,7 +6,7 @@
 package akka.kafka.scaladsl
 
 import akka.Done
-import akka.kafka.testkit.scaladsl.TestcontainersKafkaLike
+import akka.kafka.testkit.scaladsl.TestcontainersKafkaPerClassLike
 import akka.stream.scaladsl.{Keep, Sink, Source, SourceQueueWithComplete, Tcp}
 import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.{KillSwitches, OverflowStrategy, UniqueKillSwitch}
@@ -15,7 +15,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
-class ReconnectSpec extends SpecBase with TestcontainersKafkaLike {
+class ReconnectSpec extends SpecBase with TestcontainersKafkaPerClassLike {
 
   val proxyPort = 9034
 


### PR DESCRIPTION
Fixes #1233

Add support to stop and start the Kafka broker programmatically without having to stop or start the container (see #1233 for issues with managing container lifetime).