### PR TITLE
Lock scalafmt version

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -2,6 +2,7 @@ pullRequests.frequency = "@monthly"
 
 updates.ignore = [
   { groupId = "com.typesafe.akka" }
+  { groupId = "org.scalameta", artifactId = "scalafmt-core" }
 ]
 updates.pin = [
   { groupId = "org.apache.kafka", artifactId="kafka-clients", version="2.6." }


### PR DESCRIPTION
It's not useful to reformat the code as later scalafmt versions would as it hinders comparisons across multiple versions.

Refs #1221 