### PR TITLE
CI: No need to run extra Whitesource step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,6 @@ jobs:
 
     - stage: whitesource
       env: CMD=";whitesourceCheckPolicies ;whitesourceUpdate"
-    - env: CMD=";clusterSharding/whitesourceCheckPolicies ;clusterSharding/whitesourceUpdate"
 
     - stage: publish
       env: CMD="+publish"


### PR DESCRIPTION
The regular Whitesource commands run for all sub-projects that are configured for Whitesource.﻿
