### PR TITLE
Keep cancellation cause around

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/BaseSingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/BaseSingleSourceLogic.scala
@@ -111,7 +111,7 @@ import scala.concurrent.{ExecutionContext, Future}
   setHandler(shape.out, new OutHandler {
     override def onPull(): Unit = pump()
     override def onDownstreamFinish(cause: Throwable): Unit =
-      performShutdown()
+      performShutdown(cause)
   })
 
   override def postStop(): Unit = {
@@ -119,6 +119,6 @@ import scala.concurrent.{ExecutionContext, Future}
     super.postStop()
   }
 
-  def performShutdown(): Unit =
-    log.info("Completing")
+  def performShutdown(cause: Throwable): Unit =
+    log.info("Completing ({})", cause)
 }

--- a/core/src/main/scala/akka/kafka/internal/BaseSingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/BaseSingleSourceLogic.scala
@@ -108,11 +108,16 @@ import scala.concurrent.{ExecutionContext, Future}
     consumerActor.tell(KafkaConsumerActor.Internal.RequestMessages(requestId, tps), sourceActor.ref)
   }
 
-  setHandler(shape.out, new OutHandler {
-    override def onPull(): Unit = pump()
-    override def onDownstreamFinish(cause: Throwable): Unit =
-      performShutdown(cause)
-  })
+  setHandler(
+    shape.out,
+    new OutHandler {
+      override def onPull(): Unit = pump()
+      override def onDownstreamFinish(cause: Throwable): Unit = {
+        super.onDownstreamFinish(cause)
+        performShutdown(cause)
+      }
+    }
+  )
 
   override def postStop(): Unit = {
     onShutdown()

--- a/core/src/main/scala/akka/kafka/internal/ExternalSingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/ExternalSingleSourceLogic.scala
@@ -32,8 +32,8 @@ import scala.concurrent.Future
   final def configureSubscription(): Unit =
     configureManualSubscription(subscription)
 
-  final override def performShutdown(): Unit = {
-    super.performShutdown()
+  final override def performShutdown(cause: Throwable): Unit = {
+    super.performShutdown(cause)
     completeStage()
   }
 

--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -10,7 +10,7 @@ import akka.annotation.InternalApi
 import akka.kafka.internal.KafkaConsumerActor.Internal.Messages
 import akka.kafka.scaladsl.PartitionAssignmentHandler
 import akka.kafka.{ConsumerSettings, RestrictedConsumer, Subscription}
-import akka.stream.SourceShape
+import akka.stream.{SourceShape, SubscriptionWithCancelException}
 import org.apache.kafka.common.TopicPartition
 
 import scala.concurrent.{Future, Promise}
@@ -73,7 +73,8 @@ import scala.concurrent.{Future, Promise}
     def performImmediateShutdown(): Unit =
       consumerActor.tell(KafkaConsumerActor.Internal.StopFromStage(id), sourceActor.ref)
 
-    // TODO immediate shutdown for SubscriptionWithCancelException.NonFailureCancellation
+    // TODO faster shutdown for SubscriptionWithCancelException.NonFailureCancellation
+    // but ensure commits are submitted
     materializer.scheduleOnce(settings.stopTimeout, () => performImmediateShutdown())
   }
 

--- a/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
@@ -221,7 +221,10 @@ private class SubSourceLogic[K, V, Msg](
     new OutHandler {
       override def onPull(): Unit =
         emitSubSourcesForPendingPartitions()
-      override def onDownstreamFinish(cause: Throwable): Unit = performShutdown(cause)
+      override def onDownstreamFinish(cause: Throwable): Unit = {
+        super.onDownstreamFinish(cause)
+        performShutdown(cause)
+      }
     }
   )
 

--- a/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
@@ -288,7 +288,8 @@ private class SubSourceLogic[K, V, Msg](
     def performImmediateShutdown(): Unit =
       consumerActor.tell(KafkaConsumerActor.Internal.StopFromStage(id), sourceActor.ref)
 
-    // TODO immediate shutdown for SubscriptionWithCancelException.NonFailureCancellation
+    // TODO faster shutdown for SubscriptionWithCancelException.NonFailureCancellation
+    // but ensure commits are submitted
     materializer.scheduleOnce(
       settings.stopTimeout,
       () => performImmediateShutdown()

--- a/core/src/main/scala/akka/kafka/internal/TransactionalSources.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalSources.scala
@@ -145,7 +145,7 @@ private[internal] abstract class TransactionalSourceLogic[K, V, Msg](shape: Sour
   override def onMessage(rec: ConsumerRecord[K, V]): Unit =
     inFlightRecords.add(Map(new TopicPartition(rec.topic(), rec.partition()) -> rec.offset()))
 
-  override protected def stopConsumerActor(): Unit =
+  override protected def stopConsumerActor(cause: Throwable): Unit =
     sourceActor.ref
       .tell(Drain(
               inFlightRecords.assigned(),
@@ -394,8 +394,8 @@ private final class TransactionalSubSourceStageLogic[K, V](
           failStage(new ConsumerFailed())
       }
 
-  override def performShutdown(): Unit = {
-    log.debug("#{} Completing SubSource for partition {}", actorNumber, tp)
+  override def performShutdown(cause: Throwable): Unit = {
+    log.debug("#{} Completing ({}) SubSource for partition {}", actorNumber, cause, tp)
     setKeepGoing(true)
     if (!isClosed(shape.out)) {
       complete(shape.out) // initiate shutdown of SubSource


### PR DESCRIPTION
* Adapt `onDownstreamFinish` with cause (by Akka 2.6)
* Delay consumer actor stop only for non-failure cancellations

References #1228
