### PR TITLE
Refactor KafkaAsyncConsumerCommitterRef

### DIFF
--- a/testkit/src/main/scala/akka/kafka/testkit/ConsumerResultFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/ConsumerResultFactory.scala
@@ -9,8 +9,9 @@ import akka.Done
 import akka.annotation.ApiMayChange
 import akka.kafka.ConsumerMessage
 import akka.kafka.ConsumerMessage.{CommittableOffset, GroupTopicPartition, PartitionOffsetCommittedMarker}
-import akka.kafka.internal.{CommittableOffsetImpl, KafkaAsyncConsumerCommitterRef}
-import org.apache.kafka.clients.consumer.ConsumerRecord
+import akka.kafka.internal.{CommittableOffsetBatchImpl, CommittableOffsetImpl, KafkaAsyncConsumerCommitterRef}
+import org.apache.kafka.clients.consumer.{ConsumerRecord, OffsetAndMetadata}
+import org.apache.kafka.common.TopicPartition
 
 import scala.concurrent.Future
 
@@ -20,10 +21,16 @@ import scala.concurrent.Future
 @ApiMayChange
 object ConsumerResultFactory {
 
-  val fakeCommitter: KafkaAsyncConsumerCommitterRef = new KafkaAsyncConsumerCommitterRef(null, null)(ec = null) {
-    override def commitSingle(offset: CommittableOffsetImpl): Future[Done] = Future.successful(Done)
-    override def commit(batch: ConsumerMessage.CommittableOffsetBatch): Future[Done] =
-      Future.successful(Done)
+  val fakeCommitter: KafkaAsyncConsumerCommitterRef = new KafkaAsyncConsumerCommitterRef(null, null)(
+    ec = scala.concurrent.ExecutionContext.global
+  ) {
+    private val done = Future.successful(Done)
+
+    override def commitSingle(topicPartition: TopicPartition, offset: OffsetAndMetadata): Future[Done] = done
+
+    override def commitOneOfMulti(topicPartition: TopicPartition, offset: OffsetAndMetadata): Future[Done] = done
+
+    override def tellCommit(topicPartition: TopicPartition, offset: OffsetAndMetadata, emergency: Boolean): Unit = ()
   }
 
   def partitionOffset(groupId: String, topic: String, partition: Int, offset: Long): ConsumerMessage.PartitionOffset =

--- a/tests/src/test/scala/akka/kafka/internal/CommitCollectorStageSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommitCollectorStageSpec.scala
@@ -10,7 +10,7 @@ import java.util.concurrent.atomic.AtomicLong
 import akka.Done
 import akka.actor.ActorSystem
 import akka.event.LoggingAdapter
-import akka.kafka.ConsumerMessage.{CommittableOffset, CommittableOffsetBatch, PartitionOffset}
+import akka.kafka.ConsumerMessage.{CommittableOffset, CommittableOffsetBatch}
 import akka.kafka.scaladsl.{Committer, Consumer}
 import akka.kafka.testkit.ConsumerResultFactory
 import akka.kafka.testkit.scaladsl.{ConsumerControlFactory, Slf4jToAkkaLoggingAdapter}
@@ -21,6 +21,8 @@ import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import akka.stream.testkit.scaladsl.{TestSink, TestSource}
 import akka.stream.testkit.{TestPublisher, TestSubscriber}
 import akka.testkit.TestKit
+import org.apache.kafka.clients.consumer.OffsetAndMetadata
+import org.apache.kafka.common.TopicPartition
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -220,7 +222,8 @@ class CommitCollectorStageSpec(_system: ActorSystem)
 
         val commits = factory.committer.commits
 
-        commits.last.offset shouldBe 10 withClue "last offset commit should be exactly the one preceeding the error"
+        val (tp, offset) = commits.last
+        offset shouldBe 10 withClue "last offset commit should be exactly the one preceeding the error"
 
         control.shutdown().futureValue shouldBe Done
       }
@@ -362,7 +365,7 @@ class CommitCollectorStageSpec(_system: ActorSystem)
       implicit system: ActorSystem
   ) {
 
-    var commits = List.empty[PartitionOffset]
+    var commits = List.empty[(TopicPartition, Long)]
 
     private def completeCommit(): Future[Done] = {
       val promisedCommit = Promise[Done]()
@@ -374,18 +377,25 @@ class CommitCollectorStageSpec(_system: ActorSystem)
 
     private[akka] val underlying =
       new KafkaAsyncConsumerCommitterRef(consumerActor = null, commitSettings.maxInterval) {
-        override def commitSingle(offset: CommittableOffsetImpl): Future[Done] = {
-          commits = commits :+ offset.partitionOffset
+
+        override def commitSingle(topicPartition: TopicPartition, offset: OffsetAndMetadata): Future[Done] = {
+          val commit = (topicPartition, offset.offset())
+          commits = commits :+ commit
           completeCommit()
         }
 
-        override def commit(batch: CommittableOffsetBatch): Future[Done] = {
-          val offsets = batch.offsets.toList.map { case (partition, offset) => PartitionOffset(partition, offset) }
-          commits = commits ++ offsets
+        override def commitOneOfMulti(topicPartition: TopicPartition, offset: OffsetAndMetadata): Future[Done] = {
+          // CommittableOffsetBatchImpl.offsetsAndMetadata points the next committed message.
+          // So to get committed message offset we need to subtract 1
+          val commitOffset = offset.offset() - 1
+          val commit = (topicPartition, commitOffset)
+          commits = commits :+ commit
           completeCommit()
         }
 
-        override def tellCommit(batch: CommittableOffsetBatch, emergency: Boolean): Unit = commit(batch)
+        override def tellCommit(topicPartition: TopicPartition, offset: OffsetAndMetadata, emergency: Boolean): Unit = {
+          commitOneOfMulti(topicPartition, offset)
+        }
       }
   }
 }


### PR DESCRIPTION
I made this PR to refactor `KafkaAsyncConsumerCommitterRef` class a little bit so:
- `CommittableOffsetBatchImpl` won't need to obtain `committers.head._2` reference just to iterate over committers. In the current implementation we are taking`head._2` commiter but it doesn't really matter which one we chose. It could be the first one or the last one. Internally `KafkaAsyncConsumerCommitterRef` was iterating over commiter list anyway. It was quite confusing for the reader.
- `CommittableOffsetBatchImpl` won't need to check `isEmpty` or `batchSize != 0L`. Its encapsulated in `KafkaAsyncConsumerCommitterRef` now
- `KafkaAsyncConsumerCommitterRef` move some commiter independent methods to the object. So they will be covered by in tests even if we use fake `KafkaAsyncConsumerCommitterRef` implementations. 
- make `KafkaAsyncConsumerCommitterRef` more type safe by removing `failForUnexpectedImplementation`
- move some common iteration code to `private def forBatch`

After those changes `KafkaAsyncConsumerCommitterRef` object is responsible for creating `TopicPartition`, `OffsetAndMetadata` and iterating over batch, where `KafkaAsyncConsumerCommitterRef` class instance is responsible for constructing consumerActor messages and comutication with it.