### PR TITLE
Ensure write and order guarantees with Producer.committableSink

### DIFF
--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/AlpakkaCommittableSinkFixtures.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/AlpakkaCommittableSinkFixtures.scala
@@ -18,7 +18,7 @@ import akka.stream.scaladsl.{Keep, Sink, Source}
 import com.codahale.metrics.Meter
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.kafka.clients.consumer.ConsumerConfig
-import org.apache.kafka.clients.producer.ProducerRecord
+import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
 import org.apache.kafka.common.serialization.{
   ByteArrayDeserializer,
   ByteArraySerializer,
@@ -54,6 +54,7 @@ object AlpakkaCommittableSinkFixtures extends PerfFixtureHelpers {
   )(implicit actorSystem: ActorSystem): ProducerSettings[Array[Byte], String] =
     ProducerSettings(actorSystem, new ByteArraySerializer, new StringSerializer)
       .withBootstrapServers(kafkaHost)
+      .withProperty(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "1")
 
   def producerSink(c: RunTestCommand)(implicit actorSystem: ActorSystem) =
     FixtureGen[AlpakkaCommittableSinkTestFixture[Message, ProducerMessage]](

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/AlpakkaCommittableSinkFixtures.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/AlpakkaCommittableSinkFixtures.scala
@@ -18,7 +18,7 @@ import akka.stream.scaladsl.{Keep, Sink, Source}
 import com.codahale.metrics.Meter
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.kafka.clients.consumer.ConsumerConfig
-import org.apache.kafka.clients.producer.{ProducerConfig, ProducerRecord}
+import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.{
   ByteArrayDeserializer,
   ByteArraySerializer,
@@ -54,7 +54,6 @@ object AlpakkaCommittableSinkFixtures extends PerfFixtureHelpers {
   )(implicit actorSystem: ActorSystem): ProducerSettings[Array[Byte], String] =
     ProducerSettings(actorSystem, new ByteArraySerializer, new StringSerializer)
       .withBootstrapServers(kafkaHost)
-      .withProperty(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, "1")
 
   def producerSink(c: RunTestCommand)(implicit actorSystem: ActorSystem) =
     FixtureGen[AlpakkaCommittableSinkTestFixture[Message, ProducerMessage]](

--- a/core/src/main/scala/akka/kafka/internal/CommittingProducerSinkStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/CommittingProducerSinkStage.scala
@@ -63,6 +63,9 @@ private final class CommittingProducerSinkStageLogic[K, V, IN <: Envelope[K, V, 
 
   override protected def logSource: Class[_] = classOf[CommittingProducerSinkStage[_, _, _]]
 
+  // The `enable.idempotence` configuration is set to true to ensure message write and order guarantees.
+  // This is necessary because we don't enforce the order of results when retries occur.
+  // https://github.com/akka/alpakka-kafka/issues/1242
   override protected val producerSettings: ProducerSettings[K, V] =
     stage.producerSettings.withProperties(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG -> true.toString)
 

--- a/docs/src/main/paradox/consumer.md
+++ b/docs/src/main/paradox/consumer.md
@@ -240,7 +240,17 @@ Java
 
 There is a risk that something fails after publishing, but before committing, so `committableSink` has "at-least-once" delivery semantics.
 
-To get delivery guarantees, please read about @ref[transactions](transactions.md).
+The `Producer.committableSink` will immediately commit an offset when a produced message's callback has been acknowledged.
+This is a different behavior from using the combination of `Producer.flexiFlow` with `Committer.flow` because `Producer.flexiFlow` passes results downstream in the order they're received.
+In situations where a message must be retried by the Producer it's possible to commit a message before an earlier message has been produced, potentially causing messages to be skipped.
+This situation may occur in rebalance or shutdown scenarios.
+To avoid this problem the `enable.idempotence` Producer property has been enforced when using this sink.
+This has limited impact on internally run benchmarks, but could have performance implications for clusters at scale.
+To better understand the consequences of using `enable.idempotence` consult the [Kafka documentation](https://kafka.apache.org/documentation/#enable.idempotence).
+
+To ensure ordering guarantees for `Producer.committableSink` with brokers older than `0.11` you must set the Kafka producer property [`max.in.flight.requests.per.connection`](https://kafka.apache.org/documentation/#max.in.flight.requests.per.connection) to `1`.
+
+For even stronger delivery guarantees, please read about @ref[transactions](transactions.md).
 
 @@@
 


### PR DESCRIPTION
References #1242 

Enforce `enable.idempotence` when using the `Producer.committableSink`. This will ensure that produced messages are recorded once and in the order they were sent to the broker.  Some caveats with this solution:

* The broker must be version 0.11 or greater
* `max.in.flight.connections` must be `<= 5` (enforced by setting `enable.idempotence=true`)
* `acks` must be set to `all` (enforced by setting `enable.idempotence=true`)

