### PR TITLE
Maximum number of transient failures for Transactions integration tests

### DIFF
--- a/tests/src/it/scala/akka/kafka/TransactionsPartitionedSourceSpec.scala
+++ b/tests/src/it/scala/akka/kafka/TransactionsPartitionedSourceSpec.scala
@@ -45,6 +45,12 @@ class TransactionsPartitionedSourceSpec
 
   "A multi-broker consume-transform-produce cycle" must {
     "provide consistency when multiple partitioned transactional streams are being restarted" in assertAllStagesStopped {
+      // It's possible to get into a livelock situation where the `restartAfter` interval causes transactions to abort
+      // over and over.  This can happen when there are a few partitions left to process and they can never be fully
+      // processed because we always restart the stream before the transaction can be completed successfully.
+      // The `maxRestarts` provides an upper bound for the maximum number of times we restart the stream so if we get
+      // into a livelock it can eventually be resolved by not restarting any more.
+      val maxRestarts = new AtomicInteger(1000)
       val sourcePartitions = 4
       val destinationPartitions = 4
       val consumers = 3
@@ -82,7 +88,8 @@ class TransactionsPartitionedSourceSpec
                 transactionalId,
                 idleTimeout = 10.seconds,
                 maxPartitions = sourcePartitions,
-                restartAfter = Some(restartAfter)
+                restartAfter = Some(restartAfter),
+                maxRestarts = Some(maxRestarts)
               ).recover {
                 case e: TimeoutException =>
                   if (completedWithTimeout.incrementAndGet() > 10)


### PR DESCRIPTION
Add a maximum restart condition to transactions integration tests.

It's possible to get into a livelock situation where the `restartAfter` interval causes transactions to abort continuously until a timeout.  This can happen when there are a few partitions left to process and they can never be fully processed because we always restart the stream before the transaction can be completed successfully. The `maxRestarts` provides an upper bound for the maximum number of times we restart the stream so if we get into a livelock it can eventually be resolved by not restarting any more.

Originally implemented in #1109