### PR TITLE
Update default CP version and make docker image/tag configurable

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ val kafkaVersion = "2.6.0"
 // https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients/2.6.0
 val jacksonVersion = "2.10.5.1"
 val scalatestVersion = "3.1.4"
-val testcontainersVersion = "1.15.0"
+val testcontainersVersion = "1.15.1"
 val slf4jVersion = "1.7.30"
 // this depends on Kafka, and should be upgraded to such latest version
 // that depends on the same Kafka version, as is defined above

--- a/docs/src/main/paradox/testing-testcontainers.md
+++ b/docs/src/main/paradox/testing-testcontainers.md
@@ -12,7 +12,7 @@ Testcontainers also allow you to create a complete Kafka cluster (using Docker c
 You can override testcontainers settings to create multi-broker Kafka clusters, or to finetune Kafka Broker and ZooKeeper configuration, by updating @apidoc[KafkaTestkitTestcontainersSettings] in code or configuration.
 The @apidoc[KafkaTestkitTestcontainersSettings] type can be used to perform actions such as:
 
-* Set the version of Confluent Platform docker images to use
+* Set the docker image and tag of Kafka, ZooKeeper, and Schema Registry version to use (a recent Confluent Platform version is used by default)
 * Define number of Kafka brokers
 * Overriding container settings and environment variables (i.e. to change default Broker config)
 * Apply custom docker configuration to the Kafka and ZooKeeper containers used to create a cluster

--- a/testkit/src/main/java/akka/kafka/testkit/internal/AlpakkaKafkaContainer.java
+++ b/testkit/src/main/java/akka/kafka/testkit/internal/AlpakkaKafkaContainer.java
@@ -32,7 +32,8 @@ public class AlpakkaKafkaContainer extends GenericContainer<AlpakkaKafkaContaine
 
   private static final String STARTER_SCRIPT = "/testcontainers_start.sh";
 
-  private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("confluentinc/cp-kafka");
+  private static final DockerImageName DEFAULT_IMAGE_NAME =
+      DockerImageName.parse("confluentinc/cp-kafka");
   // Align this with testkit/src/main/resources/reference.conf
   public static final String DEFAULT_CONFLUENT_PLATFORM_VERSION = "6.0.1";
 

--- a/testkit/src/main/java/akka/kafka/testkit/internal/AlpakkaKafkaContainer.java
+++ b/testkit/src/main/java/akka/kafka/testkit/internal/AlpakkaKafkaContainer.java
@@ -64,10 +64,6 @@ public class AlpakkaKafkaContainer extends GenericContainer<AlpakkaKafkaContaine
     this(DEFAULT_KAFKA_IMAGE_NAME);
   }
 
-  public AlpakkaKafkaContainer(String confluentPlatformVersion) {
-    this(DEFAULT_KAFKA_IMAGE_NAME.withTag(confluentPlatformVersion));
-  }
-
   public AlpakkaKafkaContainer(final DockerImageName dockerImageName) {
     super(dockerImageName);
 

--- a/testkit/src/main/java/akka/kafka/testkit/internal/AlpakkaKafkaContainer.java
+++ b/testkit/src/main/java/akka/kafka/testkit/internal/AlpakkaKafkaContainer.java
@@ -12,7 +12,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
-import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -32,10 +31,15 @@ public class AlpakkaKafkaContainer extends GenericContainer<AlpakkaKafkaContaine
 
   private static final String STARTER_SCRIPT = "/testcontainers_start.sh";
 
-  private static final DockerImageName DEFAULT_IMAGE_NAME =
-      DockerImageName.parse("confluentinc/cp-kafka");
-  // Align this with testkit/src/main/resources/reference.conf
+  // Align these confluent platform constants with testkit/src/main/resources/reference.conf
   public static final String DEFAULT_CONFLUENT_PLATFORM_VERSION = "6.0.1";
+
+  public static final DockerImageName DEFAULT_ZOOKEEPER_IMAGE_NAME =
+      DockerImageName.parse("confluentinc/cp-zookeeper")
+          .withTag(DEFAULT_CONFLUENT_PLATFORM_VERSION);
+
+  public static final DockerImageName DEFAULT_KAFKA_IMAGE_NAME =
+      DockerImageName.parse("confluentinc/cp-kafka").withTag(DEFAULT_CONFLUENT_PLATFORM_VERSION);
 
   public static final int KAFKA_PORT = 9093;
 
@@ -57,11 +61,11 @@ public class AlpakkaKafkaContainer extends GenericContainer<AlpakkaKafkaContaine
   private boolean enableRemoteJmxService = false;
 
   public AlpakkaKafkaContainer() {
-    this(DEFAULT_IMAGE_NAME.withTag(DEFAULT_CONFLUENT_PLATFORM_VERSION));
+    this(DEFAULT_KAFKA_IMAGE_NAME);
   }
 
   public AlpakkaKafkaContainer(String confluentPlatformVersion) {
-    this(DEFAULT_IMAGE_NAME.withTag(confluentPlatformVersion));
+    this(DEFAULT_KAFKA_IMAGE_NAME.withTag(confluentPlatformVersion));
   }
 
   public AlpakkaKafkaContainer(final DockerImageName dockerImageName) {

--- a/testkit/src/main/java/akka/kafka/testkit/internal/AlpakkaKafkaContainer.java
+++ b/testkit/src/main/java/akka/kafka/testkit/internal/AlpakkaKafkaContainer.java
@@ -11,6 +11,7 @@ import com.github.dockerjava.api.model.ContainerNetwork;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.TestcontainersConfiguration;
 
 import java.nio.charset.StandardCharsets;
@@ -31,8 +32,9 @@ public class AlpakkaKafkaContainer extends GenericContainer<AlpakkaKafkaContaine
 
   private static final String STARTER_SCRIPT = "/testcontainers_start.sh";
 
+  private static final DockerImageName DEFAULT_IMAGE_NAME = DockerImageName.parse("confluentinc/cp-kafka");
   // Align this with testkit/src/main/resources/reference.conf
-  public static final String DEFAULT_CONFLUENT_PLATFORM_VERSION = "6.0.0";
+  public static final String DEFAULT_CONFLUENT_PLATFORM_VERSION = "6.0.1";
 
   public static final int KAFKA_PORT = 9093;
 
@@ -54,12 +56,15 @@ public class AlpakkaKafkaContainer extends GenericContainer<AlpakkaKafkaContaine
   private boolean enableRemoteJmxService = false;
 
   public AlpakkaKafkaContainer() {
-    this(DEFAULT_CONFLUENT_PLATFORM_VERSION);
+    this(DEFAULT_IMAGE_NAME.withTag(DEFAULT_CONFLUENT_PLATFORM_VERSION));
   }
 
   public AlpakkaKafkaContainer(String confluentPlatformVersion) {
-    super(
-        TestcontainersConfiguration.getInstance().getKafkaImage() + ":" + confluentPlatformVersion);
+    this(DEFAULT_IMAGE_NAME.withTag(confluentPlatformVersion));
+  }
+
+  public AlpakkaKafkaContainer(final DockerImageName dockerImageName) {
+    super(dockerImageName);
 
     super.withNetwork(Network.SHARED);
 

--- a/testkit/src/main/java/akka/kafka/testkit/internal/SchemaRegistryContainer.java
+++ b/testkit/src/main/java/akka/kafka/testkit/internal/SchemaRegistryContainer.java
@@ -7,9 +7,13 @@ package akka.kafka.testkit.internal;
 
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.utility.DockerImageName;
 
 public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryContainer> {
-  public static final String ConfluentSchemaRegistryImage = "confluentinc/cp-schema-registry";
+  // Align these confluent platform constants with testkit/src/main/resources/reference.conf
+  public static final DockerImageName DEFAULT_SCHEMA_REGISTRY_IMAGE_NAME =
+      DockerImageName.parse("confluentinc/cp-schema-registry")
+          .withTag(AlpakkaKafkaContainer.DEFAULT_CONFLUENT_PLATFORM_VERSION);
 
   public static int SCHEMA_REGISTRY_PORT = 8081;
 
@@ -18,7 +22,11 @@ public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryCont
   }
 
   public SchemaRegistryContainer(String confluentPlatformVersion) {
-    super(ConfluentSchemaRegistryImage + ":" + confluentPlatformVersion);
+    this(DEFAULT_SCHEMA_REGISTRY_IMAGE_NAME.withTag(confluentPlatformVersion));
+  }
+
+  public SchemaRegistryContainer(DockerImageName schemaRegistryImage) {
+    super(schemaRegistryImage);
 
     withNetwork(Network.SHARED);
     withExposedPorts(SCHEMA_REGISTRY_PORT);

--- a/testkit/src/main/java/akka/kafka/testkit/internal/SchemaRegistryContainer.java
+++ b/testkit/src/main/java/akka/kafka/testkit/internal/SchemaRegistryContainer.java
@@ -18,14 +18,10 @@ public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryCont
   public static int SCHEMA_REGISTRY_PORT = 8081;
 
   public SchemaRegistryContainer() {
-    this(AlpakkaKafkaContainer.DEFAULT_CONFLUENT_PLATFORM_VERSION);
+    this(DEFAULT_SCHEMA_REGISTRY_IMAGE_NAME);
   }
 
-  public SchemaRegistryContainer(String confluentPlatformVersion) {
-    this(DEFAULT_SCHEMA_REGISTRY_IMAGE_NAME.withTag(confluentPlatformVersion));
-  }
-
-  public SchemaRegistryContainer(DockerImageName schemaRegistryImage) {
+  public SchemaRegistryContainer(final DockerImageName schemaRegistryImage) {
     super(schemaRegistryImage);
 
     withNetwork(Network.SHARED);

--- a/testkit/src/main/java/akka/kafka/testkit/javadsl/TestcontainersKafkaJunit4Test.java
+++ b/testkit/src/main/java/akka/kafka/testkit/javadsl/TestcontainersKafkaJunit4Test.java
@@ -38,25 +38,9 @@ public abstract class TestcontainersKafkaJunit4Test extends KafkaJunit4Test {
     super(system, startKafka(settings));
   }
 
-  /** @deprecated Use constructor with `testcontainersSettings` instead. since 2.0.0 */
-  @Deprecated
-  protected TestcontainersKafkaJunit4Test(ActorSystem system, String confluentPlatformVersion) {
-    super(system, startKafka(confluentPlatformVersion));
-  }
-
   protected TestcontainersKafkaJunit4Test(
       ActorSystem system, KafkaTestkitTestcontainersSettings settings) {
     super(system, startKafka(settings));
-  }
-
-  /** @deprecated Use method with `testcontainersSettings` instead. since 2.0.0 */
-  @Deprecated
-  protected static String startKafka(String confluentPlatformVersion) {
-    KafkaTestkitTestcontainersSettings settings =
-        TestcontainersKafka.Singleton()
-            .testcontainersSettings()
-            .withConfluentPlatformVersion(confluentPlatformVersion);
-    return TestcontainersKafka.Singleton().startCluster(settings);
   }
 
   protected static String startKafka(KafkaTestkitTestcontainersSettings settings) {

--- a/testkit/src/main/java/akka/kafka/testkit/javadsl/TestcontainersKafkaTest.java
+++ b/testkit/src/main/java/akka/kafka/testkit/javadsl/TestcontainersKafkaTest.java
@@ -45,23 +45,6 @@ public abstract class TestcontainersKafkaTest extends KafkaTest {
     super(system, startKafka(settings));
   }
 
-  /** @deprecated Use constructor with `testcontainersSettings` instead. since 2.0.0 */
-  @Deprecated
-  protected TestcontainersKafkaTest(
-      ActorSystem system, Materializer materializer, String confluentPlatformVersion) {
-    super(system, startKafka(confluentPlatformVersion));
-  }
-
-  /** @deprecated Use method with `testcontainersSettings` instead. since 2.0.0 */
-  @Deprecated
-  protected static String startKafka(String confluentPlatformVersion) {
-    KafkaTestkitTestcontainersSettings settings =
-        TestcontainersKafka.Singleton()
-            .testcontainersSettings()
-            .withConfluentPlatformVersion(confluentPlatformVersion);
-    return TestcontainersKafka.Singleton().startCluster(settings);
-  }
-
   protected static String startKafka(KafkaTestkitTestcontainersSettings settings) {
     return TestcontainersKafka.Singleton().startCluster(settings);
   }

--- a/testkit/src/main/mima-filters/2.1.0-M1.backwards.excludes/PR1287-testcontainer-docker-images.excludes
+++ b/testkit/src/main/mima-filters/2.1.0-M1.backwards.excludes/PR1287-testcontainer-docker-images.excludes
@@ -1,0 +1,3 @@
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.testkit.KafkaTestkitTestcontainersSettings.confluentPlatformVersion")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.testkit.KafkaTestkitTestcontainersSettings.getConfluentPlatformVersion")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.testkit.KafkaTestkitTestcontainersSettings.withConfluentPlatformVersion")

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -15,12 +15,16 @@ akka.kafka.testkit {
 # // #testkit-testcontainers-settings
 akka.kafka.testkit.testcontainers {
 
-  # define these settings to select a different Kafka/ZooKeeper docker image and version of Confluent Platform
+  # define these settings to select a different Kafka/ZooKeeper docker image
+  # we recommend using Confluent Platform docker images and using the same version across all images
   # Confluent publishes images on DockerHub: https://hub.docker.com/r/confluentinc/cp-kafka/tags
   # Kafka versions in Confluent Platform: https://docs.confluent.io/current/installation/versions-interoperability.html
-  confluent-platform-zookeeper-image = "confluentinc/cp-zookeeper"
-  confluent-platform-kafka-image = "confluentinc/cp-kafka"
-  confluent-platform-schema-registry-image = "confluentinc/cp-schema-registry"
+  zookeeper-image = "confluentinc/cp-zookeeper"
+  zookeeper-image-tag = ${akka.kafka.testkit.testcontainers.confluent-platform-version}
+  kafka-image = "confluentinc/cp-kafka"
+  kafka-image-tag = ${akka.kafka.testkit.testcontainers.confluent-platform-version}
+  schema-registry-image = "confluentinc/cp-schema-registry"
+  schema-registry-image-tag = ${akka.kafka.testkit.testcontainers.confluent-platform-version}
   confluent-platform-version = "6.0.1"
 
   # the number of Kafka brokers to include in a test cluster

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -18,7 +18,7 @@ akka.kafka.testkit.testcontainers {
   # define this to select a different Kafka version by choosing the desired version of Confluent Platform
   # available Docker images: https://hub.docker.com/r/confluentinc/cp-kafka/tags
   # Kafka versions in Confluent Platform: https://docs.confluent.io/current/installation/versions-interoperability.html
-  confluent-platform-version = "6.0.0"
+  confluent-platform-version = "6.0.1"
 
   # the number of Kafka brokers to include in a test cluster
   num-brokers = 1

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -15,9 +15,12 @@ akka.kafka.testkit {
 # // #testkit-testcontainers-settings
 akka.kafka.testkit.testcontainers {
 
-  # define this to select a different Kafka version by choosing the desired version of Confluent Platform
-  # available Docker images: https://hub.docker.com/r/confluentinc/cp-kafka/tags
+  # define these settings to select a different Kafka/ZooKeeper docker image and version of Confluent Platform
+  # Confluent publishes images on DockerHub: https://hub.docker.com/r/confluentinc/cp-kafka/tags
   # Kafka versions in Confluent Platform: https://docs.confluent.io/current/installation/versions-interoperability.html
+  confluent-platform-zookeeper-image = "confluentinc/cp-zookeeper"
+  confluent-platform-kafka-image = "confluentinc/cp-kafka"
+  confluent-platform-schema-registry-image = "confluentinc/cp-schema-registry"
   confluent-platform-version = "6.0.1"
 
   # the number of Kafka brokers to include in a test cluster

--- a/testkit/src/main/scala/akka/kafka/testkit/KafkaTestkitTestcontainersSettings.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/KafkaTestkitTestcontainersSettings.scala
@@ -13,6 +13,9 @@ import com.typesafe.config.Config
 import org.testcontainers.containers.GenericContainer
 
 final class KafkaTestkitTestcontainersSettings private (
+    val confluentPlatformZooKeeperImage: String,
+    val confluentPlatformKafkaImage: String,
+    val confluentPlatformSchemaRegistryImage: String,
     val confluentPlatformVersion: String,
     val numBrokers: Int,
     val internalTopicsReplicationFactor: Int,
@@ -29,6 +32,21 @@ final class KafkaTestkitTestcontainersSettings private (
         override def accept(arg: GenericContainer[_]): Unit = ()
       }
 ) {
+
+  /**
+   * Java Api
+   */
+  def getConfluentPlatformZooKeeperImage(): String = confluentPlatformZooKeeperImage
+
+  /**
+   * Java Api
+   */
+  def getConfluentPlatformKafkaImage(): String = confluentPlatformKafkaImage
+
+  /**
+   * Java Api
+   */
+  def getConfluentPlatformSchemaRegistryImage(): String = confluentPlatformSchemaRegistryImage
 
   /**
    * Java Api
@@ -54,6 +72,26 @@ final class KafkaTestkitTestcontainersSettings private (
    * Java Api
    */
   def getContainerLogging(): Boolean = containerLogging
+
+  /**
+   * Sets the Confluent Platform ZooKeeper Image
+   */
+  def withConfluentPlatformZooKeeperImage(confluentPlatformZooKeeperImage: String): KafkaTestkitTestcontainersSettings =
+    copy(confluentPlatformZooKeeperImage = confluentPlatformZooKeeperImage)
+
+  /**
+   * Sets the Confluent Platform Kafka Image
+   */
+  def withConfluentPlatformKafkaImage(confluentPlatformKafkaImage: String): KafkaTestkitTestcontainersSettings =
+    copy(confluentPlatformKafkaImage = confluentPlatformKafkaImage)
+
+  /**
+   * Sets the Confluent Platform Schema Registry Image
+   */
+  def withConfluentPlatformSchemaRegistryImage(
+      confluentPlatformSchemaRegistryImage: String
+  ): KafkaTestkitTestcontainersSettings =
+    copy(confluentPlatformSchemaRegistryImage = confluentPlatformSchemaRegistryImage)
 
   /**
    * Sets the Confluent Platform Version
@@ -117,6 +155,9 @@ final class KafkaTestkitTestcontainersSettings private (
     copy(containerLogging = containerLogging)
 
   private def copy(
+      confluentPlatformZooKeeperImage: String = confluentPlatformZooKeeperImage,
+      confluentPlatformKafkaImage: String = confluentPlatformKafkaImage,
+      confluentPlatformSchemaRegistryImage: String = confluentPlatformSchemaRegistryImage,
       confluentPlatformVersion: String = confluentPlatformVersion,
       numBrokers: Int = numBrokers,
       internalTopicsReplicationFactor: Int = internalTopicsReplicationFactor,
@@ -128,7 +169,10 @@ final class KafkaTestkitTestcontainersSettings private (
       configureZooKeeper: GenericContainer[_] => Unit = configureZooKeeper,
       configureZooKeeperConsumer: java.util.function.Consumer[GenericContainer[_]] = configureZooKeeperConsumer
   ): KafkaTestkitTestcontainersSettings =
-    new KafkaTestkitTestcontainersSettings(confluentPlatformVersion,
+    new KafkaTestkitTestcontainersSettings(confluentPlatformZooKeeperImage,
+                                           confluentPlatformKafkaImage,
+                                           confluentPlatformSchemaRegistryImage,
+                                           confluentPlatformVersion,
                                            numBrokers,
                                            internalTopicsReplicationFactor,
                                            useSchemaRegistry,
@@ -140,6 +184,9 @@ final class KafkaTestkitTestcontainersSettings private (
 
   override def toString: String =
     "KafkaTestkitTestcontainersSettings(" +
+    s"confluentPlatformZooKeeperImage=$confluentPlatformZooKeeperImage," +
+    s"confluentPlatformKafkaImage=$confluentPlatformKafkaImage," +
+    s"confluentPlatformSchemaRegistryImage=$confluentPlatformSchemaRegistryImage," +
     s"confluentPlatformVersion=$confluentPlatformVersion," +
     s"numBrokers=$numBrokers," +
     s"internalTopicsReplicationFactor=$internalTopicsReplicationFactor," +
@@ -167,13 +214,19 @@ object KafkaTestkitTestcontainersSettings {
    * Create testkit testcontainres settings from a Config.
    */
   def apply(config: Config): KafkaTestkitTestcontainersSettings = {
+    val confluentPlatformZooKeeperImage = config.getString("confluent-platform-zookeeper-image")
+    val confluentPlatformKafkaImage = config.getString("confluent-platform-kafka-image")
+    val confluentPlatformSchemaRegistryImage = config.getString("confluent-platform-schema-registry-image")
     val confluentPlatformVersion = config.getString("confluent-platform-version")
     val numBrokers = config.getInt("num-brokers")
     val internalTopicsReplicationFactor = config.getInt("internal-topics-replication-factor")
     val useSchemaRegistry = config.getBoolean("use-schema-registry")
     val containerLogging = config.getBoolean("container-logging")
 
-    new KafkaTestkitTestcontainersSettings(confluentPlatformVersion,
+    new KafkaTestkitTestcontainersSettings(confluentPlatformZooKeeperImage,
+                                           confluentPlatformKafkaImage,
+                                           confluentPlatformSchemaRegistryImage,
+                                           confluentPlatformVersion,
                                            numBrokers,
                                            internalTopicsReplicationFactor,
                                            useSchemaRegistry,

--- a/testkit/src/main/scala/akka/kafka/testkit/KafkaTestkitTestcontainersSettings.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/KafkaTestkitTestcontainersSettings.scala
@@ -13,10 +13,12 @@ import com.typesafe.config.Config
 import org.testcontainers.containers.GenericContainer
 
 final class KafkaTestkitTestcontainersSettings private (
-    val confluentPlatformZooKeeperImage: String,
-    val confluentPlatformKafkaImage: String,
-    val confluentPlatformSchemaRegistryImage: String,
-    val confluentPlatformVersion: String,
+    val zooKeeperImage: String,
+    val zooKeeperImageTag: String,
+    val kafkaImage: String,
+    val kafkaImageTag: String,
+    val schemaRegistryImage: String,
+    val schemaRegistryImageTag: String,
     val numBrokers: Int,
     val internalTopicsReplicationFactor: Int,
     val useSchemaRegistry: Boolean,
@@ -36,22 +38,32 @@ final class KafkaTestkitTestcontainersSettings private (
   /**
    * Java Api
    */
-  def getConfluentPlatformZooKeeperImage(): String = confluentPlatformZooKeeperImage
+  def getZooKeeperImage(): String = zooKeeperImage
 
   /**
    * Java Api
    */
-  def getConfluentPlatformKafkaImage(): String = confluentPlatformKafkaImage
+  def getZooKeeperImageTag(): String = zooKeeperImageTag
 
   /**
    * Java Api
    */
-  def getConfluentPlatformSchemaRegistryImage(): String = confluentPlatformSchemaRegistryImage
+  def getKafkaImage(): String = kafkaImage
 
   /**
    * Java Api
    */
-  def getConfluentPlatformVersion(): String = confluentPlatformVersion
+  def getKafkaImageTag(): String = kafkaImageTag
+
+  /**
+   * Java Api
+   */
+  def getSchemaRegistryImage(): String = schemaRegistryImage
+
+  /**
+   * Java Api
+   */
+  def getSchemaRegistryImageTag(): String = schemaRegistryImageTag
 
   /**
    * Java Api
@@ -74,30 +86,40 @@ final class KafkaTestkitTestcontainersSettings private (
   def getContainerLogging(): Boolean = containerLogging
 
   /**
-   * Sets the Confluent Platform ZooKeeper Image
+   * Sets the ZooKeeper image
    */
-  def withConfluentPlatformZooKeeperImage(confluentPlatformZooKeeperImage: String): KafkaTestkitTestcontainersSettings =
-    copy(confluentPlatformZooKeeperImage = confluentPlatformZooKeeperImage)
+  def withZooKeeperImage(zooKeeperImage: String): KafkaTestkitTestcontainersSettings =
+    copy(zooKeeperImage = zooKeeperImage)
 
   /**
-   * Sets the Confluent Platform Kafka Image
+   * Sets the ZooKeeper image tag
    */
-  def withConfluentPlatformKafkaImage(confluentPlatformKafkaImage: String): KafkaTestkitTestcontainersSettings =
-    copy(confluentPlatformKafkaImage = confluentPlatformKafkaImage)
+  def withZooKeeperImageTag(zooKeeperImageTag: String): KafkaTestkitTestcontainersSettings =
+    copy(zooKeeperImageTag = zooKeeperImageTag)
 
   /**
-   * Sets the Confluent Platform Schema Registry Image
+   * Sets the Kafka image
    */
-  def withConfluentPlatformSchemaRegistryImage(
-      confluentPlatformSchemaRegistryImage: String
-  ): KafkaTestkitTestcontainersSettings =
-    copy(confluentPlatformSchemaRegistryImage = confluentPlatformSchemaRegistryImage)
+  def withKafkaImage(kafkaImage: String): KafkaTestkitTestcontainersSettings =
+    copy(kafkaImage = kafkaImage)
 
   /**
-   * Sets the Confluent Platform Version
+   * Sets the Kafka image tag
    */
-  def withConfluentPlatformVersion(confluentPlatformVersion: String): KafkaTestkitTestcontainersSettings =
-    copy(confluentPlatformVersion = confluentPlatformVersion)
+  def withKafkaImageTag(kafkaImageTag: String): KafkaTestkitTestcontainersSettings =
+    copy(kafkaImageTag = kafkaImageTag)
+
+  /**
+   * Sets the Schema Registry image
+   */
+  def withSchemaRegistryImage(schemaRegistryImage: String): KafkaTestkitTestcontainersSettings =
+    copy(schemaRegistryImage = schemaRegistryImage)
+
+  /**
+   * Sets the Schema Registry image tag
+   */
+  def withSchemaRegistryImageTag(schemaRegistryImageTag: String): KafkaTestkitTestcontainersSettings =
+    copy(schemaRegistryImageTag = schemaRegistryImageTag)
 
   /**
    * Replaces the default number of Kafka brokers
@@ -155,10 +177,12 @@ final class KafkaTestkitTestcontainersSettings private (
     copy(containerLogging = containerLogging)
 
   private def copy(
-      confluentPlatformZooKeeperImage: String = confluentPlatformZooKeeperImage,
-      confluentPlatformKafkaImage: String = confluentPlatformKafkaImage,
-      confluentPlatformSchemaRegistryImage: String = confluentPlatformSchemaRegistryImage,
-      confluentPlatformVersion: String = confluentPlatformVersion,
+      zooKeeperImage: String = zooKeeperImage,
+      zooKeeperImageTag: String = zooKeeperImageTag,
+      kafkaImage: String = kafkaImage,
+      kafkaImageTag: String = kafkaImageTag,
+      schemaRegistryImage: String = schemaRegistryImage,
+      schemaRegistryImageTag: String = schemaRegistryImageTag,
       numBrokers: Int = numBrokers,
       internalTopicsReplicationFactor: Int = internalTopicsReplicationFactor,
       useSchemaRegistry: Boolean = useSchemaRegistry,
@@ -169,10 +193,12 @@ final class KafkaTestkitTestcontainersSettings private (
       configureZooKeeper: GenericContainer[_] => Unit = configureZooKeeper,
       configureZooKeeperConsumer: java.util.function.Consumer[GenericContainer[_]] = configureZooKeeperConsumer
   ): KafkaTestkitTestcontainersSettings =
-    new KafkaTestkitTestcontainersSettings(confluentPlatformZooKeeperImage,
-                                           confluentPlatformKafkaImage,
-                                           confluentPlatformSchemaRegistryImage,
-                                           confluentPlatformVersion,
+    new KafkaTestkitTestcontainersSettings(zooKeeperImage,
+                                           zooKeeperImageTag,
+                                           kafkaImage,
+                                           kafkaImageTag,
+                                           schemaRegistryImage,
+                                           schemaRegistryImageTag,
                                            numBrokers,
                                            internalTopicsReplicationFactor,
                                            useSchemaRegistry,
@@ -184,10 +210,12 @@ final class KafkaTestkitTestcontainersSettings private (
 
   override def toString: String =
     "KafkaTestkitTestcontainersSettings(" +
-    s"confluentPlatformZooKeeperImage=$confluentPlatformZooKeeperImage," +
-    s"confluentPlatformKafkaImage=$confluentPlatformKafkaImage," +
-    s"confluentPlatformSchemaRegistryImage=$confluentPlatformSchemaRegistryImage," +
-    s"confluentPlatformVersion=$confluentPlatformVersion," +
+    s"zooKeeperImage=$zooKeeperImage," +
+    s"zooKeeperImageTag=$zooKeeperImageTag," +
+    s"kafkaImage=$kafkaImage," +
+    s"kafkaImageTag=$kafkaImageTag," +
+    s"schemaRegistryImage=$schemaRegistryImage," +
+    s"schemaRegistryImageTag=$schemaRegistryImageTag," +
     s"numBrokers=$numBrokers," +
     s"internalTopicsReplicationFactor=$internalTopicsReplicationFactor," +
     s"useSchemaRegistry=$useSchemaRegistry," +
@@ -214,19 +242,23 @@ object KafkaTestkitTestcontainersSettings {
    * Create testkit testcontainres settings from a Config.
    */
   def apply(config: Config): KafkaTestkitTestcontainersSettings = {
-    val confluentPlatformZooKeeperImage = config.getString("confluent-platform-zookeeper-image")
-    val confluentPlatformKafkaImage = config.getString("confluent-platform-kafka-image")
-    val confluentPlatformSchemaRegistryImage = config.getString("confluent-platform-schema-registry-image")
-    val confluentPlatformVersion = config.getString("confluent-platform-version")
+    val zooKeeperImage = config.getString("zookeeper-image")
+    val zooKeeperImageTag = config.getString("zookeeper-image-tag")
+    val kafkaImage = config.getString("kafka-image")
+    val kafkaImageTag = config.getString("kafka-image-tag")
+    val schemaRegistryImage = config.getString("schema-registry-image")
+    val schemaRegistryImageTag = config.getString("schema-registry-image-tag")
     val numBrokers = config.getInt("num-brokers")
     val internalTopicsReplicationFactor = config.getInt("internal-topics-replication-factor")
     val useSchemaRegistry = config.getBoolean("use-schema-registry")
     val containerLogging = config.getBoolean("container-logging")
 
-    new KafkaTestkitTestcontainersSettings(confluentPlatformZooKeeperImage,
-                                           confluentPlatformKafkaImage,
-                                           confluentPlatformSchemaRegistryImage,
-                                           confluentPlatformVersion,
+    new KafkaTestkitTestcontainersSettings(zooKeeperImage,
+                                           zooKeeperImageTag,
+                                           kafkaImage,
+                                           kafkaImageTag,
+                                           schemaRegistryImage,
+                                           schemaRegistryImageTag,
                                            numBrokers,
                                            internalTopicsReplicationFactor,
                                            useSchemaRegistry,

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/TestcontainersKafka.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/TestcontainersKafka.scala
@@ -8,6 +8,7 @@ package akka.kafka.testkit.internal
 import akka.kafka.testkit.KafkaTestkitTestcontainersSettings
 import akka.kafka.testkit.scaladsl.{KafkaSpec, ScalatestKafkaSpec}
 import org.testcontainers.containers.GenericContainer
+import org.testcontainers.utility.DockerImageName
 
 import scala.compat.java8.OptionConverters._
 import scala.jdk.CollectionConverters._
@@ -66,11 +67,16 @@ object TestcontainersKafka {
       import settings._
       // check if already initialized
       if (kafkaPortInternal == -1) {
-        cluster = new KafkaContainerCluster(settings.confluentPlatformVersion,
-                                            numBrokers,
-                                            internalTopicsReplicationFactor,
-                                            settings.useSchemaRegistry,
-                                            settings.containerLogging)
+        cluster = new KafkaContainerCluster(
+          DockerImageName.parse(settings.confluentPlatformZooKeeperImage),
+          DockerImageName.parse(settings.confluentPlatformKafkaImage),
+          DockerImageName.parse(settings.confluentPlatformSchemaRegistryImage),
+          settings.confluentPlatformVersion,
+          numBrokers,
+          internalTopicsReplicationFactor,
+          settings.useSchemaRegistry,
+          settings.containerLogging
+        )
         configureKafka(brokerContainers)
         configureKafkaConsumer.accept(brokerContainers.asJavaCollection)
         configureZooKeeper(zookeeperContainer)

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/TestcontainersKafka.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/TestcontainersKafka.scala
@@ -23,16 +23,6 @@ object TestcontainersKafka {
       require(kafkaPortInternal != -1, "Testcontainers Kafka hasn't been started via `setUp`")
 
     /**
-     * Override this to select a different Kafka version be choosing the desired version of Confluent Platform:
-     * [[https://hub.docker.com/r/confluentinc/cp-kafka/tags Available Docker images]],
-     * [[https://docs.confluent.io/current/installation/versions-interoperability.html Kafka versions in Confluent Platform]]
-     *
-     * Deprecated: set Confluent Platform version in [[KafkaTestkitTestcontainersSettings]]
-     */
-    @deprecated("Use testcontainersSettings instead.", "2.0.0")
-    def confluentPlatformVersion: String = KafkaContainerCluster.CONFLUENT_PLATFORM_VERSION
-
-    /**
      * Override this to change default settings for starting the Kafka testcontainers cluster.
      */
     val testcontainersSettings: KafkaTestkitTestcontainersSettings = KafkaTestkitTestcontainersSettings(system)
@@ -68,10 +58,9 @@ object TestcontainersKafka {
       // check if already initialized
       if (kafkaPortInternal == -1) {
         cluster = new KafkaContainerCluster(
-          DockerImageName.parse(settings.confluentPlatformZooKeeperImage),
-          DockerImageName.parse(settings.confluentPlatformKafkaImage),
-          DockerImageName.parse(settings.confluentPlatformSchemaRegistryImage),
-          settings.confluentPlatformVersion,
+          DockerImageName.parse(settings.zooKeeperImage).withTag(settings.zooKeeperImageTag),
+          DockerImageName.parse(settings.kafkaImage).withTag(settings.kafkaImageTag),
+          DockerImageName.parse(settings.schemaRegistryImage).withTag(settings.schemaRegistryImageTag),
           numBrokers,
           internalTopicsReplicationFactor,
           settings.useSchemaRegistry,

--- a/tests/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
@@ -20,13 +20,15 @@ import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
 class RetentionPeriodSpec extends SpecBase with TestcontainersKafkaPerClassLike {
+  private final val confluentPlatformVersion = "5.0.0"
 
   override val testcontainersSettings = KafkaTestkitTestcontainersSettings(system)
   // The bug commit refreshing circumvents was fixed in Kafka 2.1.0
   // https://issues.apache.org/jira/browse/KAFKA-4682
   // Confluent Platform 5.0.0 bundles Kafka 2.0.0
   // https://docs.confluent.io/current/installation/versions-interoperability.html
-    .withConfluentPlatformVersion("5.0.0")
+    .withKafkaImageTag(confluentPlatformVersion)
+    .withZooKeeperImageTag(confluentPlatformVersion)
     .withInternalTopicsReplicationFactor(1)
     .withConfigureKafka { brokerContainers =>
       brokerContainers.foreach {


### PR DESCRIPTION
`TestcontainersConfiguration.getInstance().getKafkaImage()` is deprecated and returns an image and tag (instead of just an image). I'm not sure when this changed, but we expect only an image name so we can append an image tag ourself.  The result is that `latest` (the default tag) is always used Kafka testcontainers 1.15.0+.

Confluent is now unpublishing older minor releases of docker images, so we need to update our default image to `6.0.1`.