### PR TITLE
Remove parameterless methods

### DIFF
--- a/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
@@ -34,13 +34,13 @@ trait KafkaTestKit {
   val StringSerializer = new StringSerializer
   val StringDeserializer = new StringDeserializer
 
-  def producerDefaults: ProducerSettings[String, String] = producerDefaults(StringSerializer, StringSerializer)
+  def producerDefaults(): ProducerSettings[String, String] = producerDefaults(StringSerializer, StringSerializer)
 
   def producerDefaults[K, V](keySerializer: Serializer[K], valueSerializer: Serializer[V]): ProducerSettings[K, V] =
     ProducerSettings(system, keySerializer, valueSerializer)
       .withBootstrapServers(bootstrapServers)
 
-  def consumerDefaults: ConsumerSettings[String, String] = consumerDefaults(StringDeserializer, StringDeserializer)
+  def consumerDefaults(): ConsumerSettings[String, String] = consumerDefaults(StringDeserializer, StringDeserializer)
 
   def consumerDefaults[K, V](keyDeserializer: Deserializer[K],
                              valueDeserializer: Deserializer[V]): ConsumerSettings[K, V] =


### PR DESCRIPTION
I noticed when upgrading from 2.0.5 to 2.1.0-M1 that if you reference `consumerDefaults` or `producerDefaults` with parens you will get a compile time error because they were dropped.  Should we keep the params for parameterless methods for 2.1.0?
