### PR TITLE
TestKit: make consumerDefaults parameterless again

### DIFF
--- a/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
@@ -40,7 +40,7 @@ trait KafkaTestKit {
     ProducerSettings(system, keySerializer, valueSerializer)
       .withBootstrapServers(bootstrapServers)
 
-  def consumerDefaults(): ConsumerSettings[String, String] = consumerDefaults(StringDeserializer, StringDeserializer)
+  def consumerDefaults: ConsumerSettings[String, String] = consumerDefaults(StringDeserializer, StringDeserializer)
 
   def consumerDefaults[K, V](keyDeserializer: Deserializer[K],
                              valueDeserializer: Deserializer[V]): ConsumerSettings[K, V] =


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
By mistake the `def consumerDefaults` in `KafkaTestKit` got parenthesis added in #1099 which got released in Alpakka Kafka 2.0.3.
As Scala 2.13.4 started to warn about the inconsistent use of parens, we should go back to not having the parenthesis on this method.

References https://github.com/akka/alpakka-kafka/pull/1288#issuecomment-749015437
