### PR TITLE
Use restart script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ test-output
 .project
 .settings/
 .tmpBin
+.bsp

--- a/testkit/src/main/java/akka/kafka/testkit/internal/AlpakkaKafkaContainer.java
+++ b/testkit/src/main/java/akka/kafka/testkit/internal/AlpakkaKafkaContainer.java
@@ -172,7 +172,9 @@ public class AlpakkaKafkaContainer extends GenericContainer<AlpakkaKafkaContaine
   @Override
   protected void doStart() {
     withCommand(
-        "sh", "-c", "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT);
+        "sh",
+        "-c",
+        "while [ ! -f " + START_STOP_SCRIPT + " ]; do sleep 0.1; done; " + START_STOP_SCRIPT);
 
     if (externalZookeeperConnect == null) {
       addExposedPort(ZOOKEEPER_PORT);


### PR DESCRIPTION
This was meant to be a part of the testcontainer refresh for 2.0.6, but it was omitted.  The restart script lets the user control instance of Kafka in a container, without managing containers directly.