### PR TITLE
Increase default cluster start timeouts and make configurable (backport)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ test-output
 .project
 .settings/
 .tmpBin
+.bsp

--- a/testkit/src/main/java/akka/kafka/testkit/internal/AlpakkaKafkaContainer.java
+++ b/testkit/src/main/java/akka/kafka/testkit/internal/AlpakkaKafkaContainer.java
@@ -172,7 +172,9 @@ public class AlpakkaKafkaContainer extends GenericContainer<AlpakkaKafkaContaine
   @Override
   protected void doStart() {
     withCommand(
-        "sh", "-c", "while [ ! -f " + STARTER_SCRIPT + " ]; do sleep 0.1; done; " + STARTER_SCRIPT);
+        "sh",
+        "-c",
+        "while [ ! -f " + START_STOP_SCRIPT + " ]; do sleep 0.1; done; " + START_STOP_SCRIPT);
 
     if (externalZookeeperConnect == null) {
       addExposedPort(ZOOKEEPER_PORT);

--- a/testkit/src/main/resources/reference.conf
+++ b/testkit/src/main/resources/reference.conf
@@ -40,5 +40,13 @@ akka.kafka.testkit.testcontainers {
   # set this to true to stream the STDOUT and STDERR of containers to SLF4J loggers
   # this requires the SLF4J dependency to be on the classpath and the loggers enabled in your logging configuration
   container-logging = false
+
+  # set this to the total length of time to wait for a Kafka container cluster to start. this includes all brokers
+  # zookeeper, and schema registry nodes. note that this can take a considerable time in limited resource environments.
+  cluster-start-timeout = 360 s
+
+  # set this to the total length of time to wait for a Kafka container readiness check to complete. note that this can
+  # take a considerable time in limited resource environments.
+  readiness-check-timeout = 360 s
 }
 # // #testkit-testcontainers-settings

--- a/testkit/src/main/scala/akka/kafka/testkit/KafkaTestkitTestcontainersSettings.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/KafkaTestkitTestcontainersSettings.scala
@@ -5,12 +5,15 @@
 
 package akka.kafka.testkit
 
+import java.time.Duration
 import java.util.function.Consumer
 
 import akka.actor.ActorSystem
 import akka.kafka.testkit.internal.AlpakkaKafkaContainer
 import com.typesafe.config.Config
 import org.testcontainers.containers.GenericContainer
+import scala.jdk.DurationConverters._
+import scala.concurrent.duration.FiniteDuration
 
 final class KafkaTestkitTestcontainersSettings private (
     val zooKeeperImage: String,
@@ -23,6 +26,8 @@ final class KafkaTestkitTestcontainersSettings private (
     val internalTopicsReplicationFactor: Int,
     val useSchemaRegistry: Boolean,
     val containerLogging: Boolean,
+    val clusterStartTimeout: FiniteDuration,
+    val readinessCheckTimeout: FiniteDuration,
     val configureKafka: Vector[AlpakkaKafkaContainer] => Unit = _ => (),
     val configureKafkaConsumer: java.util.function.Consumer[java.util.Collection[AlpakkaKafkaContainer]] =
       new Consumer[java.util.Collection[AlpakkaKafkaContainer]]() {
@@ -84,6 +89,16 @@ final class KafkaTestkitTestcontainersSettings private (
    * Java Api
    */
   def getContainerLogging(): Boolean = containerLogging
+
+  /**
+   * Java Api
+   */
+  def getClusterStartTimeout(): Duration = clusterStartTimeout.toJava
+
+  /**
+   * Java Api
+   */
+  def getReadinessCheckTimeout(): Duration = readinessCheckTimeout.toJava
 
   /**
    * Sets the ZooKeeper image
@@ -176,6 +191,34 @@ final class KafkaTestkitTestcontainersSettings private (
   def withContainerLogging(containerLogging: Boolean): KafkaTestkitTestcontainersSettings =
     copy(containerLogging = containerLogging)
 
+  /**
+   * Kafka cluster start up timeout
+   */
+  def withClusterStartTimeout(timeout: FiniteDuration): KafkaTestkitTestcontainersSettings =
+    copy(clusterStartTimeout = timeout)
+
+  /**
+   * Java Api
+   *
+   * Kafka cluster start up timeout
+   */
+  def withClusterStartTimeout(timeout: Duration): KafkaTestkitTestcontainersSettings =
+    copy(clusterStartTimeout = timeout.toScala)
+
+  /**
+   * Kafka cluster readiness check timeout
+   */
+  def withReadinessCheckTimeout(timeout: FiniteDuration): KafkaTestkitTestcontainersSettings =
+    copy(readinessCheckTimeout = timeout)
+
+  /**
+   * Java Api
+   *
+   * Kafka cluster readiness check timeout
+   */
+  def withReadinessCheckTimeout(timeout: Duration): KafkaTestkitTestcontainersSettings =
+    copy(readinessCheckTimeout = timeout.toScala)
+
   private def copy(
       zooKeeperImage: String = zooKeeperImage,
       zooKeeperImageTag: String = zooKeeperImageTag,
@@ -187,6 +230,8 @@ final class KafkaTestkitTestcontainersSettings private (
       internalTopicsReplicationFactor: Int = internalTopicsReplicationFactor,
       useSchemaRegistry: Boolean = useSchemaRegistry,
       containerLogging: Boolean = containerLogging,
+      clusterStartTimeout: FiniteDuration = clusterStartTimeout,
+      readinessCheckTimeout: FiniteDuration = readinessCheckTimeout,
       configureKafka: Vector[AlpakkaKafkaContainer] => Unit = configureKafka,
       configureKafkaConsumer: java.util.function.Consumer[java.util.Collection[AlpakkaKafkaContainer]] =
         configureKafkaConsumer,
@@ -203,6 +248,8 @@ final class KafkaTestkitTestcontainersSettings private (
                                            internalTopicsReplicationFactor,
                                            useSchemaRegistry,
                                            containerLogging,
+                                           clusterStartTimeout,
+                                           readinessCheckTimeout,
                                            configureKafka,
                                            configureKafkaConsumer,
                                            configureZooKeeper,
@@ -219,7 +266,9 @@ final class KafkaTestkitTestcontainersSettings private (
     s"numBrokers=$numBrokers," +
     s"internalTopicsReplicationFactor=$internalTopicsReplicationFactor," +
     s"useSchemaRegistry=$useSchemaRegistry," +
-    s"containerLogging=$containerLogging)"
+    s"containerLogging=$containerLogging, +" +
+    s"clusterStartTimeout=$clusterStartTimeout," +
+    s"readinessCheckTimeout=$readinessCheckTimeout)"
 }
 
 object KafkaTestkitTestcontainersSettings {
@@ -252,6 +301,8 @@ object KafkaTestkitTestcontainersSettings {
     val internalTopicsReplicationFactor = config.getInt("internal-topics-replication-factor")
     val useSchemaRegistry = config.getBoolean("use-schema-registry")
     val containerLogging = config.getBoolean("container-logging")
+    val clusterStartTimeout = config.getDuration("cluster-start-timeout").toScala
+    val readinessCheckTimeout = config.getDuration("readiness-check-timeout").toScala
 
     new KafkaTestkitTestcontainersSettings(zooKeeperImage,
                                            zooKeeperImageTag,
@@ -262,7 +313,9 @@ object KafkaTestkitTestcontainersSettings {
                                            numBrokers,
                                            internalTopicsReplicationFactor,
                                            useSchemaRegistry,
-                                           containerLogging)
+                                           containerLogging,
+                                           clusterStartTimeout,
+                                           readinessCheckTimeout)
   }
 
   /**

--- a/testkit/src/main/scala/akka/kafka/testkit/KafkaTestkitTestcontainersSettings.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/KafkaTestkitTestcontainersSettings.scala
@@ -268,8 +268,8 @@ final class KafkaTestkitTestcontainersSettings private (
     s"internalTopicsReplicationFactor=$internalTopicsReplicationFactor," +
     s"useSchemaRegistry=$useSchemaRegistry," +
     s"containerLogging=$containerLogging, +" +
-    s"clusterStartTimeout=$clusterStartTimeout," +
-    s"readinessCheckTimeout=$readinessCheckTimeout)"
+    s"clusterStartTimeout=${clusterStartTimeout.toCoarsest}," +
+    s"readinessCheckTimeout=${readinessCheckTimeout.toCoarsest})"
 }
 
 object KafkaTestkitTestcontainersSettings {

--- a/testkit/src/main/scala/akka/kafka/testkit/KafkaTestkitTestcontainersSettings.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/KafkaTestkitTestcontainersSettings.scala
@@ -10,9 +10,10 @@ import java.util.function.Consumer
 
 import akka.actor.ActorSystem
 import akka.kafka.testkit.internal.AlpakkaKafkaContainer
+import akka.util.JavaDurationConverters._
 import com.typesafe.config.Config
 import org.testcontainers.containers.GenericContainer
-import scala.jdk.DurationConverters._
+
 import scala.concurrent.duration.FiniteDuration
 
 final class KafkaTestkitTestcontainersSettings private (
@@ -93,12 +94,12 @@ final class KafkaTestkitTestcontainersSettings private (
   /**
    * Java Api
    */
-  def getClusterStartTimeout(): Duration = clusterStartTimeout.toJava
+  def getClusterStartTimeout(): Duration = clusterStartTimeout.asJava
 
   /**
    * Java Api
    */
-  def getReadinessCheckTimeout(): Duration = readinessCheckTimeout.toJava
+  def getReadinessCheckTimeout(): Duration = readinessCheckTimeout.asJava
 
   /**
    * Sets the ZooKeeper image
@@ -203,7 +204,7 @@ final class KafkaTestkitTestcontainersSettings private (
    * Kafka cluster start up timeout
    */
   def withClusterStartTimeout(timeout: Duration): KafkaTestkitTestcontainersSettings =
-    copy(clusterStartTimeout = timeout.toScala)
+    copy(clusterStartTimeout = timeout.asScala)
 
   /**
    * Kafka cluster readiness check timeout
@@ -217,7 +218,7 @@ final class KafkaTestkitTestcontainersSettings private (
    * Kafka cluster readiness check timeout
    */
   def withReadinessCheckTimeout(timeout: Duration): KafkaTestkitTestcontainersSettings =
-    copy(readinessCheckTimeout = timeout.toScala)
+    copy(readinessCheckTimeout = timeout.asScala)
 
   private def copy(
       zooKeeperImage: String = zooKeeperImage,
@@ -301,8 +302,8 @@ object KafkaTestkitTestcontainersSettings {
     val internalTopicsReplicationFactor = config.getInt("internal-topics-replication-factor")
     val useSchemaRegistry = config.getBoolean("use-schema-registry")
     val containerLogging = config.getBoolean("container-logging")
-    val clusterStartTimeout = config.getDuration("cluster-start-timeout").toScala
-    val readinessCheckTimeout = config.getDuration("readiness-check-timeout").toScala
+    val clusterStartTimeout = config.getDuration("cluster-start-timeout").asScala
+    val readinessCheckTimeout = config.getDuration("readiness-check-timeout").asScala
 
     new KafkaTestkitTestcontainersSettings(zooKeeperImage,
                                            zooKeeperImageTag,

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/TestcontainersKafka.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/TestcontainersKafka.scala
@@ -7,11 +7,11 @@ package akka.kafka.testkit.internal
 
 import akka.kafka.testkit.KafkaTestkitTestcontainersSettings
 import akka.kafka.testkit.scaladsl.{KafkaSpec, ScalatestKafkaSpec}
+import akka.util.JavaDurationConverters._
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.utility.DockerImageName
 
 import scala.compat.java8.OptionConverters._
-import scala.jdk.DurationConverters._
 import scala.jdk.CollectionConverters._
 
 object TestcontainersKafka {
@@ -66,8 +66,8 @@ object TestcontainersKafka {
           internalTopicsReplicationFactor,
           settings.useSchemaRegistry,
           settings.containerLogging,
-          settings.clusterStartTimeout.toJava,
-          settings.readinessCheckTimeout.toJava
+          settings.clusterStartTimeout.asJava,
+          settings.readinessCheckTimeout.asJava
         )
         configureKafka(brokerContainers)
         configureKafkaConsumer.accept(brokerContainers.asJavaCollection)

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/TestcontainersKafka.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/TestcontainersKafka.scala
@@ -11,6 +11,7 @@ import org.testcontainers.containers.GenericContainer
 import org.testcontainers.utility.DockerImageName
 
 import scala.compat.java8.OptionConverters._
+import scala.jdk.DurationConverters._
 import scala.jdk.CollectionConverters._
 
 object TestcontainersKafka {
@@ -64,7 +65,9 @@ object TestcontainersKafka {
           numBrokers,
           internalTopicsReplicationFactor,
           settings.useSchemaRegistry,
-          settings.containerLogging
+          settings.containerLogging,
+          settings.clusterStartTimeout.toJava,
+          settings.readinessCheckTimeout.toJava
         )
         configureKafka(brokerContainers)
         configureKafkaConsumer.accept(brokerContainers.asJavaCollection)


### PR DESCRIPTION
Fixes #1269

Increase default cluster start timeouts and make configurable.

Based on #1310 
