### PR TITLE
Update scaladex badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 Alpakka Kafka Connector [![scaladex-badge][]][scaladex] [![maven-central-badge][]][maven-central] [![gh-actions-badge][]][gh-actions] [![gitter-badge][]][gitter]
 =======================
 
-[scaladex]:            https://index.scala-lang.org/akka/alpakka-kafka
-[scaladex-badge]:      https://index.scala-lang.org/akka/alpakka-kafka/latest.svg
-[maven-central]:       https://maven-badges.herokuapp.com/maven-central/com.typesafe.akka/akka-stream-kafka_2.12
-[maven-central-badge]: https://maven-badges.herokuapp.com/maven-central/com.typesafe.akka/akka-stream-kafka_2.12/badge.svg
+[scaladex]:            https://index.scala-lang.org/akka/alpakka-kafka/akka-stream-kafka/
+[scaladex-badge]:      https://index.scala-lang.org/akka/alpakka-kafka/akka-stream-kafka/latest.svg?target=_2.13
+[maven-central]:       https://maven-badges.herokuapp.com/maven-central/com.typesafe.akka/akka-stream-kafka_2.13
+[maven-central-badge]: https://maven-badges.herokuapp.com/maven-central/com.typesafe.akka/akka-stream-kafka_2.13/badge.svg
 [gh-actions]:          https://github.com/akka/alpakka-kafka/actions
 [gh-actions-badge]:    https://github.com/akka/alpakka-kafka/workflows/CI/badge.svg?branch=master
 [gitter]:              https://gitter.im/akka/alpakka-kafka


### PR DESCRIPTION
The default scaladex artifact doesn't exist any more (`reactive-kafka`) so it was always pointing to an old version `0.7.2`. Including the main dependency in the badge URL gets the latest non-pre-release (`2.0.7`). Since it's not showing the latest pre-release it's out of sync with the maven central badge which is `2.1.0-M1`. I'm not sure if this is something we really need to address.