### PR TITLE
Increase consumer group summary timeout in build

### DIFF
--- a/tests/src/it/resources/reference.conf
+++ b/tests/src/it/resources/reference.conf
@@ -18,7 +18,13 @@ akka {
     single-expect-default = 10s
   }
 
-  kafka.testkit.testcontainers.container-logging = true
+  kafka.testkit {
+    # waitUntilConsumerSummary timeout
+    consumer-group-timeout = 60 seconds
+    # amount of time to wait in-between state checks
+    check-interval = 500 ms
+    testcontainers.container-logging = true
+  }
 
   kafka.consumer {
     stop-timeout = 3 s


### PR DESCRIPTION
Hopefully reduces this will reduce the occurrence of #1126.
