### PR TITLE
Fix context propagation in CommitCollectorStage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ val Scala213 = "2.13.4"
 val AkkaBinaryVersionForDocs = "2.6"
 val KafkaVersionForDocs = "27"
 
-val akkaVersion = "2.6.14"
+val akkaVersion = "2.6.15"
 val kafkaVersion = "2.7.0"
 // Jackson is now a provided dependency of kafka-clients
 // This should align with the Jackson minor version used in Akka 2.6.x

--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -56,7 +56,7 @@ import scala.concurrent.{Future, Promise}
       case (_, Messages(requestId, messages)) =>
         // Prevent stage failure during shutdown by ignoring Messages
         if (messages.hasNext)
-          log.debug("Unexpected message `Messages` received with requestId={} and a non-empty message iterator: {}",
+          log.debug("Unexpected `Messages` received with requestId={} and a non-empty message iterator: {}",
                     requestId,
                     messages.mkString(", "))
     })

--- a/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SingleSourceLogic.scala
@@ -7,6 +7,7 @@ package akka.kafka.internal
 
 import akka.actor.{ActorRef, ExtendedActorSystem, Terminated}
 import akka.annotation.InternalApi
+import akka.kafka.internal.KafkaConsumerActor.Internal.Messages
 import akka.kafka.scaladsl.PartitionAssignmentHandler
 import akka.kafka.{ConsumerSettings, RestrictedConsumer, Subscription}
 import akka.stream.SourceShape
@@ -51,7 +52,14 @@ import scala.concurrent.{Future, Promise}
     if (!isClosed(shape.out)) {
       complete(shape.out)
     }
-    sourceActor.become(shuttingDownReceive)
+    sourceActor.become(shuttingDownReceive.orElse {
+      case (_, Messages(requestId, messages)) =>
+        // Prevent stage failure during shutdown by ignoring Messages
+        if (messages.hasNext)
+          log.debug("Unexpected message `Messages` received with requestId={} and a non-empty message iterator: {}",
+                    requestId,
+                    messages.mkString(", "))
+    })
     stopConsumerActor()
   }
 

--- a/tests/src/it/scala/akka/kafka/TransactionsSourceSpec.scala
+++ b/tests/src/it/scala/akka/kafka/TransactionsSourceSpec.scala
@@ -155,6 +155,7 @@ class TransactionsSourceSpec
 
       val elements = 100
       val batchSize = 10
+      val maxBufferSize = 16 // must be power of two
       Await.result(produce(sourceTopic, 1 to elements), remainingOrDefault)
 
       val elementsWrote = new AtomicInteger(0)
@@ -171,7 +172,7 @@ class TransactionsSourceSpec
             }
             .take(batchSize.toLong)
             .delay(3.seconds, strategy = DelayOverflowStrategy.backpressure)
-            .addAttributes(Attributes.inputBuffer(batchSize, batchSize + 1))
+            .addAttributes(Attributes.inputBuffer(10, maxBufferSize))
             .via(Transactional.flow(producerDefaults, s"$group-$id"))
             .map(_ => elementsWrote.incrementAndGet())
             .toMat(Sink.ignore)(Keep.left)

--- a/tests/src/test/resources/application.conf
+++ b/tests/src/test/resources/application.conf
@@ -10,13 +10,13 @@ akka {
 
   test {
     # https://github.com/akka/alpakka-kafka/pull/994
-    timefactor = 3.0
+    timefactor = 4.0
     timefactor = ${?AKKA_TEST_TIMEFACTOR}
-    single-expect-default = 20s
+    single-expect-default = 10s
   }
 
   kafka.consumer {
-    stop-timeout = 20ms
+    stop-timeout = 10ms
   }
 }
 

--- a/tests/src/test/resources/application.conf
+++ b/tests/src/test/resources/application.conf
@@ -10,7 +10,7 @@ akka {
 
   test {
     # https://github.com/akka/alpakka-kafka/pull/994
-    timefactor = 4.0
+    timefactor = 3.0
     timefactor = ${?AKKA_TEST_TIMEFACTOR}
     single-expect-default = 10s
   }

--- a/tests/src/test/resources/application.conf
+++ b/tests/src/test/resources/application.conf
@@ -12,11 +12,11 @@ akka {
     # https://github.com/akka/alpakka-kafka/pull/994
     timefactor = 3.0
     timefactor = ${?AKKA_TEST_TIMEFACTOR}
-    single-expect-default = 10s
+    single-expect-default = 20s
   }
 
   kafka.consumer {
-    stop-timeout = 10ms
+    stop-timeout = 20ms
   }
 }
 

--- a/tests/src/test/scala/akka/kafka/internal/CommitCollectorStageSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommitCollectorStageSpec.scala
@@ -132,7 +132,9 @@ class CommitCollectorStageSpec(_system: ActorSystem)
         val msg = factory.makeOffset()
         sourceProbe.sendNext(msg)
         // triggered by interval
-        val committedBatch = sinkProbe.requestNext(80.millis)
+        val committedBatch = eventually {
+          sinkProbe.requestNext(80.millis)
+        }
 
         val msg2 = factory.makeOffset()
         sourceProbe.sendNext(msg2)

--- a/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
@@ -79,7 +79,9 @@ class PartitionedSourceSpec(_system: ActorSystem)
     dummy.tpsPaused should be(Symbol("empty"))
     dummy.assignWithCallback(tp0, tp1)
     dummy.setNextPollData(tp0 -> singleRecord)
-    sink.requestNext().record.value() should be("value")
+    eventually {
+      sink.requestNext().record.value() should be("value")
+    }
     dummy.setNextPollData(tp1 -> singleRecord)
     sink.requestNext().record.value() should be("value")
 


### PR DESCRIPTION
References https://github.com/lightbend/cinnamon/issues/2874

Lightbend Telemetry tests: https://github.com/lightbend/cinnamon/pull/2875

+ support context propagation in CommitCollectorStage for Lightbend Telemetry
+ bump Akka to 2.6.15
+ fixed MatchError resulting in the stage failure