### PR TITLE
chore: fix links and use correct site-link-validator version

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -34,4 +34,4 @@ jobs:
         run: curl -fLo cs https://git.io/coursier-cli-linux && chmod +x cs && ./cs
 
       - name: Run Link Validator
-        run: ./cs launch net.runne::site-link-validator:0.2.0 -- scripts/link-validator.conf
+        run: ./cs launch net.runne::site-link-validator:0.2.1 -- scripts/link-validator.conf

--- a/docs/src/main/paradox/home.md
+++ b/docs/src/main/paradox/home.md
@@ -13,10 +13,10 @@ This **Alpakka Kafka connector** lets you connect [Apache Kafka](https://kafka.a
 |Kafka client | Scala Versions | Akka version | Alpakka Kafka Connector
 |-------------|----------------|--------------|-------------------------
 |[2.7.0](https://dist.apache.org/repos/dist/release/kafka/2.7.0/RELEASE_NOTES.html) | 2.13, 2.12       | 2.6.14+         | @ref:[release 2.1.0](release-notes/2.1.x.md)
-|[2.4.1](https://dist.apache.org/repos/dist/release/kafka/2.4.1/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.31+, 2.6.6+ | @ref:[release 2.0.5](release-notes/2.0.x.md)
-|[2.4.1](https://dist.apache.org/repos/dist/release/kafka/2.4.1/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.30+, 2.6.6+ | @ref:[release 2.0.4](release-notes/2.0.x.md)
-|[2.4.1](https://dist.apache.org/repos/dist/release/kafka/2.4.1/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.30+, 2.6.3+ | @ref:[release 2.0.3](release-notes/2.0.x.md)
-|[2.4.0](https://dist.apache.org/repos/dist/release/kafka/2.4.0/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.23+, 2.6.x | @ref:[release 2.0.0](release-notes/2.0.x.md)
+|[2.4.1](https://archive.apache.org/dist/kafka/2.4.1/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.31+, 2.6.6+ | @ref:[release 2.0.5](release-notes/2.0.x.md)
+|[2.4.1](https://archive.apache.org/dist/kafka/2.4.1/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.30+, 2.6.6+ | @ref:[release 2.0.4](release-notes/2.0.x.md)
+|[2.4.1](https://archive.apache.org/dist/kafka/2.4.1/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.30+, 2.6.3+ | @ref:[release 2.0.3](release-notes/2.0.x.md)
+|[2.4.0](https://archive.apache.org/dist/kafka/2.4.0/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.23+, 2.6.x | @ref:[release 2.0.0](release-notes/2.0.x.md)
 |[2.1.1](https://archive.apache.org/dist/kafka/2.1.1/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.x        | @ref:[release 1.0.4](release-notes/1.0.x.md#1-0-4)
 |[2.1.1](https://archive.apache.org/dist/kafka/2.1.1/RELEASE_NOTES.html) | 2.12, 2.11       | 2.5.x        | @ref:[release 1.0.1](release-notes/1.0.x.md#1-0-1)
 |[2.1.0](https://archive.apache.org/dist/kafka/2.1.0/RELEASE_NOTES.html) | 2.12, 2.11       | 2.5.x        | @ref:[release 1.0](release-notes/1.0.x.md#1-0)

--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -20,7 +20,7 @@ site-link-validator {
 
   ignore-prefixes = [
     # runtime is part of the published Scaladoc
-    "https://www.scala-lang.org/api/2.13.2/scala/runtime/AbstractFunction2.html"
+    "https://www.scala-lang.org/api/2.13.4/scala/runtime/AbstractFunction2.html"
     # GitHub will block with "429 Too Many Requests"
     "https://github.com/"
     # MVN repository forbids access after a few requests

--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -22,9 +22,11 @@ site-link-validator {
     # runtime is part of the published Scaladoc
     "https://www.scala-lang.org/api/2.13.2/scala/runtime/AbstractFunction2.html"
     # GitHub will block with "429 Too Many Requests"
-    "https://github.com/akka/alpakka-kafka/"
+    "https://github.com/"
     # MVN repository forbids access after a few requests
     "https://mvnrepository.com/artifact/"
+    # gives: javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure requests
+    "https://javadoc.io/static/"
   ]
 
   non-https-whitelist = [


### PR DESCRIPTION
As it turns out, the update by @seglo was not promoted to be acutally used.﻿
https://github.com/ennru/site-link-validator/releases/tag/v0.2.1

