### PR TITLE
Upgrade scalatest to 3.2.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ val kafkaVersion = "2.7.0"
 // This should align with the Jackson minor version used in Akka 2.6.x
 // https://github.com/akka/akka/blob/master/project/Dependencies.scala#L23
 val jacksonVersion = "2.11.4"
-val scalatestVersion = "3.1.4"
+val scalatestVersion = "3.2.10"
 val testcontainersVersion = "1.15.3"
 val slf4jVersion = "1.7.30"
 // this depends on Kafka, and should be upgraded to such latest version


### PR DESCRIPTION
Upgrades scalatest to 3.2.10. 

Please let me know if you'd prefer a split between 3.1 and 3.2 depending on the scala version
