### PR TITLE
chore: trigger releasing from GitHub UI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
       - main
       - release-*
     tags: ["*"]
+  release:
+    types: [published]
 
 jobs:
   release:


### PR DESCRIPTION
As it turns out, the tag creation from the release UI does not trigger the workflow.
