### PR TITLE
Add getProperty to ProducerSettings

### DIFF
--- a/core/src/main/scala/akka/kafka/ProducerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ProducerSettings.scala
@@ -280,6 +280,11 @@ class ProducerSettings[K, V] @InternalApi private[kafka] (
     copy(properties = properties.updated(key, value))
 
   /**
+   * Java API: Get a raw property. `null` if it is not defined.
+   */
+  def getProperty(key: String): String = properties.getOrElse(key, null)
+
+  /**
    * Duration to wait for `KafkaProducer.close` to finish.
    */
   def withCloseTimeout(closeTimeout: FiniteDuration): ProducerSettings[K, V] =


### PR DESCRIPTION
This PR adds the equivalent `getProperty` from `ConsumerSettings` (see https://github.com/akka/alpakka-kafka/blob/eb5246d3e03992ce60a1f33fefe75dadc58bc866/core/src/main/scala/akka/kafka/ConsumerSettings.scala#L333-L336) into `ProducerSettings`