### PR TITLE
bump: Akka 2.6.19

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ val Nightly = sys.env.get("EVENT_NAME").contains("schedule")
 val Scala213 = "2.13.8"
 
 val AkkaBinaryVersionForDocs = "2.6"
-val akkaVersion = "2.6.18"
+val akkaVersion = "2.6.19"
 
 // Keep .scala-steward.conf pin in sync
 val kafkaVersion = "3.0.0"


### PR DESCRIPTION
Use latest version of akka/akka-streams. Not sure why scala-steward didn't pick it up so I am creating the PR manually