### PR TITLE
bump: kafka-clients 3.0.1 (was 3.0.0)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val AkkaBinaryVersionForDocs = "2.6"
 val akkaVersion = "2.6.19"
 
 // Keep .scala-steward.conf pin in sync
-val kafkaVersion = "3.0.0"
+val kafkaVersion = "3.0.1"
 val KafkaVersionForDocs = "30"
 // This should align with the ScalaTest version used in the Akka 2.6.x testkit
 // https://github.com/akka/akka/blob/main/project/Dependencies.scala#L41

--- a/docs/src/main/paradox/home.md
+++ b/docs/src/main/paradox/home.md
@@ -12,7 +12,8 @@ This **Alpakka Kafka connector** lets you connect [Apache Kafka](https://kafka.a
 
 |Kafka client | Scala Versions | Akka version | Alpakka Kafka Connector
 |-------------|----------------|--------------|-------------------------
-|[3.0.0](https://dist.apache.org/repos/dist/release/kafka/3.0.0/RELEASE_NOTES.html) | 2.13             | 2.6.18+         | [release 3.0.0 RC1](https://github.com/akka/alpakka-kafka/releases/tag/v3.0.0-RC1)
+|[3.0.1](https://dist.apache.org/repos/dist/release/kafka/3.0.1/RELEASE_NOTES.html) | 2.13             | 2.6.18+         | [release 3.0.1](https://github.com/akka/alpakka-kafka/releases/tag/v3.0.0)
+|[3.0.0](https://blogs.apache.org/kafka/entry/what-s-new-in-apache6)                | 2.13             | 2.6.18+         | [release 3.0.0 RC1](https://github.com/akka/alpakka-kafka/releases/tag/v3.0.0-RC1)
 |[2.8.1](https://dist.apache.org/repos/dist/release/kafka/2.8.1/RELEASE_NOTES.html) | 2.13, 2.12       | 2.6.14+         | @ref:[release 2.1.0](release-notes/2.1.x.md)
 |[2.8.0](https://archive.apache.org/dist/kafka/2.8.0/RELEASE_NOTES.html) | 2.13, 2.12       | 2.6.14+         | @ref:[release 2.1.0](release-notes/2.1.x.md)
 |[2.7.0](https://archive.apache.org/dist/kafka/2.7.0/RELEASE_NOTES.html) | 2.13, 2.12       | 2.6.14+         | @ref:[release 2.1.0](release-notes/2.1.x.md)


### PR DESCRIPTION
Replaces #1485 and fixes the link to the removed 3.0.0 release notes.