### PR TITLE
Reduce kafka docker version constraint

### DIFF
--- a/testkit/src/main/java/akka/kafka/testkit/internal/KafkaContainerCluster.java
+++ b/testkit/src/main/java/akka/kafka/testkit/internal/KafkaContainerCluster.java
@@ -341,7 +341,7 @@ public class KafkaContainerCluster implements Startable {
 class Version implements Comparable<Version> {
 
   private String version;
-  private boolean comparable = false;
+  private boolean comparable = true;
 
   public final String get() {
     return this.version;

--- a/testkit/src/main/java/akka/kafka/testkit/internal/KafkaContainerCluster.java
+++ b/testkit/src/main/java/akka/kafka/testkit/internal/KafkaContainerCluster.java
@@ -347,6 +347,10 @@ class Version implements Comparable<Version> {
     return this.version;
   }
 
+  public final boolean isComparable() {
+    return this.comparable;
+  }
+
   public Version(String version) {
     if (version == null) throw new IllegalArgumentException("Version can not be null");
     if (!version.matches("[0-9]+(\\.[0-9]+)*")) this.comparable = false;
@@ -356,7 +360,7 @@ class Version implements Comparable<Version> {
   @Override
   public int compareTo(Version that) {
     if (that == null) return 1;
-    if (!this.comparable) return 1;
+    if (!this.comparable || !that.isComparable()) return 1;
     String[] thisParts = this.get().split("\\.");
     String[] thatParts = that.get().split("\\.");
     int length = Math.max(thisParts.length, thatParts.length);

--- a/testkit/src/main/java/akka/kafka/testkit/internal/KafkaContainerCluster.java
+++ b/testkit/src/main/java/akka/kafka/testkit/internal/KafkaContainerCluster.java
@@ -341,6 +341,7 @@ public class KafkaContainerCluster implements Startable {
 class Version implements Comparable<Version> {
 
   private String version;
+  private boolean comparable = false;
 
   public final String get() {
     return this.version;
@@ -349,13 +350,14 @@ class Version implements Comparable<Version> {
   public Version(String version) {
     if (version == null) throw new IllegalArgumentException("Version can not be null");
     if (!version.matches("[0-9]+(\\.[0-9]+)*"))
-      throw new IllegalArgumentException("Invalid version format");
+      comparable = false;
     this.version = version;
   }
 
   @Override
   public int compareTo(Version that) {
     if (that == null) return 1;
+    if (!this.comparable) return 1;
     String[] thisParts = this.get().split("\\.");
     String[] thatParts = that.get().split("\\.");
     int length = Math.max(thisParts.length, thatParts.length);

--- a/testkit/src/main/java/akka/kafka/testkit/internal/KafkaContainerCluster.java
+++ b/testkit/src/main/java/akka/kafka/testkit/internal/KafkaContainerCluster.java
@@ -349,7 +349,7 @@ class Version implements Comparable<Version> {
 
   public Version(String version) {
     if (version == null) throw new IllegalArgumentException("Version can not be null");
-    if (!version.matches("[0-9]+(\\.[0-9]+)*")) comparable = false;
+    if (!version.matches("[0-9]+(\\.[0-9]+)*")) this.comparable = false;
     this.version = version;
   }
 

--- a/testkit/src/main/java/akka/kafka/testkit/internal/KafkaContainerCluster.java
+++ b/testkit/src/main/java/akka/kafka/testkit/internal/KafkaContainerCluster.java
@@ -349,8 +349,7 @@ class Version implements Comparable<Version> {
 
   public Version(String version) {
     if (version == null) throw new IllegalArgumentException("Version can not be null");
-    if (!version.matches("[0-9]+(\\.[0-9]+)*"))
-      comparable = false;
+    if (!version.matches("[0-9]+(\\.[0-9]+)*")) comparable = false;
     this.version = version;
   }
 


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here - but don't use `fixes` notation.
-->
Closes #1424 

I don't know if this is the best solution, but since some people might want to use a custom tag (like building a `cp-kafka` image on M1), a good idea might be to just use the 5.2.0 and above connect param, tested at: https://github.com/akka/alpakka-kafka/blob/9419b5d9cb420026759fc0b11e669c2266934874/testkit/src/main/java/akka/kafka/testkit/internal/KafkaContainerCluster.java#L310

So, if the tag is not "comparable", we will just use the newer connect param
