### PR TITLE
bump: run validations on Ubuntu 22.04 (was 18.04)

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -99,7 +99,7 @@ jobs:
 
   test:
     name: Build and Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     needs: [check-code-style, check-code-compilation, check-docs]
     strategy:
       fail-fast: false
@@ -137,7 +137,7 @@ jobs:
   integration-test:
     name: Integration tests
     needs: [check-code-style, check-code-compilation, check-docs]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     # the release environment provides access to secrets required in the release process
     # https://github.com/akka/alpakka-kafka/settings/environments/84275678/edit
     environment: release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -26,7 +26,9 @@ site-link-validator {
     # MVN repository forbids access after a few requests
     "https://mvnrepository.com/artifact/"
     # gives: javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure requests
-    "https://javadoc.io/static/"
+    "https://javadoc.io/static/",
+    # The address is hit too often and blocked
+    "https://opensource.org/licenses/Apache-2.0"
   ]
 
   non-https-whitelist = [


### PR DESCRIPTION
Other actions use ubuntu-latest, but these are convenient to have on a fixed version.