### PR TITLE
Update to akka-stream-alpakka-csv 4.0.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -357,7 +357,7 @@ lazy val benchmarks = project
         "io.dropwizard.metrics" % "metrics-core" % "4.2.12",
         "ch.qos.logback" % "logback-classic" % "1.2.11",
         "org.slf4j" % "log4j-over-slf4j" % slf4jVersion,
-        "com.lightbend.akka" %% "akka-stream-alpakka-csv" % "3.0.4",
+        "com.lightbend.akka" %% "akka-stream-alpakka-csv" % "4.0.0",
         "org.testcontainers" % "kafka" % testcontainersVersion % IntegrationTest,
         "com.typesafe.akka" %% "akka-slf4j" % akkaVersion % IntegrationTest,
         "com.typesafe.akka" %% "akka-stream-testkit" % akkaVersion % IntegrationTest,


### PR DESCRIPTION
It's strange that Fossa complains about:
```
========================================================================
124
  Unlicensed Dependency
125
  ========================================================================
[126](https://github.com/akka/alpakka-kafka/actions/runs/3075267823/jobs/4968540042#step:5:127)
  Dependency           Revision            
[127](https://github.com/akka/alpakka-kafka/actions/runs/3075267823/jobs/4968540042#step:5:128)

[128](https://github.com/akka/alpakka-kafka/actions/runs/3075267823/jobs/4968540042#step:5:129)
  com.lightbend.akka:akka-stream-alpakka-csv_2.13 3.0.4
```