### PR TITLE
Update protobuf-java to 3.21.1, in tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -251,7 +251,7 @@ lazy val tests = project
     name := "akka-stream-kafka-tests",
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-discovery" % akkaVersion,
-        "com.google.protobuf" % "protobuf-java" % "3.19.5", // use the same version as in scalapb
+        "com.google.protobuf" % "protobuf-java" % "3.21.1", // use the same, or later, version as in scalapb
         "io.confluent" % "kafka-avro-serializer" % confluentAvroSerializerVersion % Test excludeAll (confluentLibsExclusionRules: _*),
         // See https://github.com/sbt/sbt/issues/3618#issuecomment-448951808
         "javax.ws.rs" % "javax.ws.rs-api" % "2.1.1" artifacts Artifact("javax.ws.rs-api", "jar", "jar"),


### PR DESCRIPTION
https://github.com/akka/alpakka-kafka/pull/1537 wasn't enough, must also override the protobuf-java dependency
This is same version that is currently in use in akka-grpc.