### PR TITLE
bump: kafka-clients 3.3.1

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -5,7 +5,7 @@ updates.ignore = [
   { groupId = "org.scalameta", artifactId = "scalafmt-core" }
 ]
 updates.pin = [
-  { groupId = "org.apache.kafka", artifactId="kafka-clients", version="3.0." }
+  { groupId = "org.apache.kafka", artifactId="kafka-clients", version="3.3." }
   # To be updated in tandem with upstream Akka
   { groupId = "org.scalatest", artifactId = "scalatest", version = "3.1." }
 ]

--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,8 @@ val AkkaBinaryVersionForDocs = "2.7"
 val akkaVersion = "2.7.0-M3"
 
 // Keep .scala-steward.conf pin in sync
-val kafkaVersion = "3.0.1"
-val KafkaVersionForDocs = "30"
+val kafkaVersion = "3.3.1"
+val KafkaVersionForDocs = "33"
 // This should align with the ScalaTest version used in the Akka 2.7.x testkit
 // https://github.com/akka/akka/blob/main/project/Dependencies.scala#L41
 val scalatestVersion = "3.1.4"

--- a/docs/src/main/paradox/home.md
+++ b/docs/src/main/paradox/home.md
@@ -12,7 +12,7 @@ This **Alpakka Kafka connector** lets you connect [Apache Kafka](https://kafka.a
 
 | Kafka client                                                            | Scala Versions   | Akka version    | Alpakka Kafka Connector
 |-------------------------------------------------------------------------|------------------|-----------------|-------------------------
-| 3.3.1                                                                   | 2.13             | 2.7.0+          | [release 4.0.0](https://github.com/akka/alpakka-kafka/releases/tag/v4.0.0-M1)
+| 3.3.1                                                                   | 2.13, 2.12       | 2.7.0+          | [release 4.0.0](https://github.com/akka/alpakka-kafka/releases/tag/v4.0.0-M1)
 | 3.0.1                                                                   | 2.13             | 2.6.18+         | [release 3.0.1](https://github.com/akka/alpakka-kafka/releases/tag/v3.0.0)
 | [3.0.0](https://blogs.apache.org/kafka/entry/what-s-new-in-apache6)     | 2.13             | 2.6.18+         | [release 3.0.0 RC1](https://github.com/akka/alpakka-kafka/releases/tag/v3.0.0-RC1)
 | [2.7.0](https://archive.apache.org/dist/kafka/2.7.0/RELEASE_NOTES.html) | 2.13, 2.12       | 2.6.14+         | @ref:[release 2.1.0](release-notes/2.1.x.md)

--- a/docs/src/main/paradox/home.md
+++ b/docs/src/main/paradox/home.md
@@ -10,21 +10,22 @@ This **Alpakka Kafka connector** lets you connect [Apache Kafka](https://kafka.a
 
 ## Matching Kafka Versions
 
-|Kafka client | Scala Versions | Akka version | Alpakka Kafka Connector
-|-------------|----------------|--------------|-------------------------
-|3.0.1                                                                   | 2.13             | 2.6.18+         | [release 3.0.1](https://github.com/akka/alpakka-kafka/releases/tag/v3.0.0)
-|[3.0.0](https://blogs.apache.org/kafka/entry/what-s-new-in-apache6)     | 2.13             | 2.6.18+         | [release 3.0.0 RC1](https://github.com/akka/alpakka-kafka/releases/tag/v3.0.0-RC1)
-|[2.7.0](https://archive.apache.org/dist/kafka/2.7.0/RELEASE_NOTES.html) | 2.13, 2.12       | 2.6.14+         | @ref:[release 2.1.0](release-notes/2.1.x.md)
-|[2.4.1](https://archive.apache.org/dist/kafka/2.4.1/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.31+, 2.6.6+ | @ref:[release 2.0.5](release-notes/2.0.x.md)
-|[2.4.1](https://archive.apache.org/dist/kafka/2.4.1/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.30+, 2.6.6+ | @ref:[release 2.0.4](release-notes/2.0.x.md)
-|[2.4.1](https://archive.apache.org/dist/kafka/2.4.1/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.30+, 2.6.3+ | @ref:[release 2.0.3](release-notes/2.0.x.md)
-|[2.4.0](https://archive.apache.org/dist/kafka/2.4.0/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.23+, 2.6.x | @ref:[release 2.0.0](release-notes/2.0.x.md)
-|[2.1.1](https://archive.apache.org/dist/kafka/2.1.1/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.x        | @ref:[release 1.0.4](release-notes/1.0.x.md#1-0-4)
-|[2.1.1](https://archive.apache.org/dist/kafka/2.1.1/RELEASE_NOTES.html) | 2.12, 2.11       | 2.5.x        | @ref:[release 1.0.1](release-notes/1.0.x.md#1-0-1)
-|[2.1.0](https://archive.apache.org/dist/kafka/2.1.0/RELEASE_NOTES.html) | 2.12, 2.11       | 2.5.x        | @ref:[release 1.0](release-notes/1.0.x.md#1-0)
-|1.1.x        | 2.12, 2.11 | 2.5.x        | [release 0.20+](https://github.com/akka/alpakka-kafka/releases)
-|1.0.x        | 2.12, 2.11 | 2.5.x        | [release 0.20+](https://github.com/akka/alpakka-kafka/releases)
-|0.11.x       | 2.12, 2.11 | 2.5.x        | [release 0.19](https://github.com/akka/alpakka-kafka/milestone/19?closed=1)
+| Kafka client                                                            | Scala Versions   | Akka version    | Alpakka Kafka Connector
+|-------------------------------------------------------------------------|------------------|-----------------|-------------------------
+| 3.3.1                                                                   | 2.13             | 2.7.0+          | [release 4.0.0](https://github.com/akka/alpakka-kafka/releases/tag/v4.0.0-M1)
+| 3.0.1                                                                   | 2.13             | 2.6.18+         | [release 3.0.1](https://github.com/akka/alpakka-kafka/releases/tag/v3.0.0)
+| [3.0.0](https://blogs.apache.org/kafka/entry/what-s-new-in-apache6)     | 2.13             | 2.6.18+         | [release 3.0.0 RC1](https://github.com/akka/alpakka-kafka/releases/tag/v3.0.0-RC1)
+| [2.7.0](https://archive.apache.org/dist/kafka/2.7.0/RELEASE_NOTES.html) | 2.13, 2.12       | 2.6.14+         | @ref:[release 2.1.0](release-notes/2.1.x.md)
+| [2.4.1](https://archive.apache.org/dist/kafka/2.4.1/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.31+, 2.6.6+ | @ref:[release 2.0.5](release-notes/2.0.x.md)
+| [2.4.1](https://archive.apache.org/dist/kafka/2.4.1/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.30+, 2.6.6+ | @ref:[release 2.0.4](release-notes/2.0.x.md)
+| [2.4.1](https://archive.apache.org/dist/kafka/2.4.1/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.30+, 2.6.3+ | @ref:[release 2.0.3](release-notes/2.0.x.md)
+| [2.4.0](https://archive.apache.org/dist/kafka/2.4.0/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.23+, 2.6.x  | @ref:[release 2.0.0](release-notes/2.0.x.md)
+| [2.1.1](https://archive.apache.org/dist/kafka/2.1.1/RELEASE_NOTES.html) | 2.13, 2.12, 2.11 | 2.5.x           | @ref:[release 1.0.4](release-notes/1.0.x.md#1-0-4)
+| [2.1.1](https://archive.apache.org/dist/kafka/2.1.1/RELEASE_NOTES.html) | 2.12, 2.11       | 2.5.x           | @ref:[release 1.0.1](release-notes/1.0.x.md#1-0-1)
+| [2.1.0](https://archive.apache.org/dist/kafka/2.1.0/RELEASE_NOTES.html) | 2.12, 2.11       | 2.5.x           | @ref:[release 1.0](release-notes/1.0.x.md#1-0)
+| 1.1.x                                                                   | 2.12, 2.11       | 2.5.x           | [release 0.20+](https://github.com/akka/alpakka-kafka/releases)
+| 1.0.x                                                                   | 2.12, 2.11       | 2.5.x           | [release 0.20+](https://github.com/akka/alpakka-kafka/releases)
+| 0.11.x                                                                  | 2.12, 2.11       | 2.5.x           | [release 0.19](https://github.com/akka/alpakka-kafka/milestone/19?closed=1)
 
 @@@ note
 

--- a/tests/src/test/scala/akka/kafka/internal/ConsumerDummy.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConsumerDummy.scala
@@ -94,5 +94,6 @@ abstract class ConsumerDummy[K, V] extends Consumer[K, V] {
   override def poll(timeout: java.time.Duration): ConsumerRecords[K, V] = ???
   override def groupMetadata(): ConsumerGroupMetadata = ???
   override def enforceRebalance(): Unit = ???
+  override def enforceRebalance(reason: String): Unit = ???
   override def currentLag(partition: TopicPartition): java.util.OptionalLong = ???
 }


### PR DESCRIPTION
A new method `Consumer.enforceRebalance(reason)` got introduced, so the client library is not compatible with earlier versions.

https://kafka.apache.org/33/documentation.html
https://archive.apache.org/dist/kafka/3.3.1/RELEASE_NOTES.html
