### PR TITLE
chore: current GH actions; coursier/setup-action

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -9,6 +9,9 @@ on:
       - release-*
     tags-ignore: [ v.* ]
 
+permissions:
+  contents: read # allow actions/checkout
+
 env:
   AKKA_TEST_TIMEFACTOR: 10.0
   EVENT_NAME: ${{ github.event_name }}

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -30,14 +30,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v13
-        with:
-          java-version: adopt@1.11.0-9
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1
+        with:
+          jvm: adopt:1.11
 
       - name: Code style check and binary-compatibility check
         # Run locally with: sbt 'verifyCodeStyle ; mimaReportBinaryIssues'
@@ -48,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -58,13 +57,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v13
-        with:
-          java-version: adopt@1.11.0-9
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1
+        with:
+          jvm: adopt:1.11
 
       - name: Compile all code with fatal warnings for Java 11 and all Scala versions
         # Run locally with: env CI=true sbt 'clean ; Test/compile ; It/compile'
@@ -75,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -85,13 +84,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v13
-        with:
-          java-version: adopt@1.11.0-9
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1
+        with:
+          jvm: adopt:1.11
 
       - name: Create all API docs for artifacts/website and all reference docs
         # Run locally with: sbt verifyDocs
@@ -105,11 +104,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { java-version: adopt@1.8,      sbt-opts: '' }
-          - { java-version: adopt@1.11.0-9, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { java-version: adopt:1.8,  sbt-opts: '' }
+          - { java-version: adopt:1.11, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -119,13 +118,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Setup Scala with Java ${{ matrix.java-version }}
-        uses: olafurpg/setup-scala@v13
-        with:
-          java-version: ${{ matrix.java-version }}
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
+
+      - name: Set up JDK ${{ matrix.java-version }}
+        uses: coursier/setup-action@v1
+        with:
+          jvm: ${{ matrix.java-version }}
 
       - name: Run tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
         run: sbt ${{ matrix.sbt-opts }} "test"
@@ -140,7 +139,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -150,11 +149,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Setup Scala with JDK 8
-        uses: olafurpg/setup-scala@v13
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
+
+      - name: Set up JDK 8
+        uses: coursier/setup-action@v1
+        with:
+          jvm: adopt:8
 
       - name: Run multi-broker and long running integration tests
         run: sbt "tests/IntegrationTest/test"
@@ -168,7 +169,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -178,11 +179,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Setup Scala with JDK 8
-        uses: olafurpg/setup-scala@v13
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
+
+      - name: Set up JDK 8
+        uses: coursier/setup-action@v1
+        with:
+          jvm: adopt:8
 
       - name: "Compile benchmark tests"
         run: sbt "benchmarks/IntegrationTest/compile"

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -104,8 +104,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { java-version: adopt:1.8,  sbt-opts: '' }
-          - { java-version: adopt:1.11, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { java-version: 'adopt:1.8',  sbt-opts: '' }
+          - { java-version: 'adopt:1.11', sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -19,10 +19,10 @@ env:
 jobs:
   check-code-style:
     name: Check Code Style
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -34,12 +34,12 @@ jobs:
           git checkout scratch
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v6.4.0
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.11
+          jvm: temurin:1.11
 
       - name: Code style check and binary-compatibility check
         # Run locally with: sbt 'verifyCodeStyle ; mimaReportBinaryIssues'
@@ -47,10 +47,10 @@ jobs:
 
   check-code-compilation:
     name: Check Code Compilation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -61,12 +61,12 @@ jobs:
           git checkout scratch
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v6.4.0
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.11
+          jvm: temurin:1.11
 
       - name: Compile all code with fatal warnings for Java 11 and all Scala versions
         # Run locally with: env CI=true sbt 'clean ; Test/compile ; It/compile'
@@ -74,10 +74,10 @@ jobs:
 
   check-docs:
     name: Check Docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -88,12 +88,12 @@ jobs:
           git checkout scratch
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v6.4.0
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.11
+          jvm: temurin:1.11
 
       - name: Create all API docs for artifacts/website and all reference docs
         # Run locally with: sbt verifyDocs
@@ -107,11 +107,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { java-version: 'adopt:1.8',  sbt-opts: '' }
-          - { java-version: 'adopt:1.11', sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { java-version: 'temurin:1.8',  sbt-opts: '' }
+          - { java-version: 'temurin:1.11', sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -122,10 +122,10 @@ jobs:
           git checkout scratch
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v6.4.0
 
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v1.3.0
         with:
           jvm: ${{ matrix.java-version }}
 
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -153,12 +153,12 @@ jobs:
           git checkout scratch
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v6.4.0
 
       - name: Set up JDK 8
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:8
+          jvm: temurin:1.8
 
       - name: Run multi-broker and long running integration tests
         run: sbt "tests/IntegrationTest/test"
@@ -169,10 +169,10 @@ jobs:
   build-benchmark:
     name: Build benchmarks
     needs: [check-code-style, check-code-compilation, check-docs]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
 
@@ -183,12 +183,12 @@ jobs:
           git checkout scratch
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v6.4.0
 
       - name: Set up JDK 8
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:8
+          jvm: temurin:1.8
 
       - name: "Compile benchmark tests"
         run: sbt "benchmarks/IntegrationTest/compile"

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 0 * * 0' # At 00:00 on Sunday
 
+permissions:
+  contents: read # allow actions/checkout
+
 jobs:
   fossa:
     name: Fossa

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -11,22 +11,22 @@ permissions:
 jobs:
   fossa:
     name: Fossa
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/alpakka-kafka'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v6.4.0
 
-      - name: Set up JDK 11
-        uses: coursier/setup-action@v1
+      - name: Set up JDK 17
+        uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.11
+          jvm: temurin:1.17
 
       - name: FOSSA policy check
         run: |-

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up JDK 11
         uses: coursier/setup-action@v1
         with:
-          jvm: adopt:11
+          jvm: adopt:1.11
 
       - name: FOSSA policy check
         run: |-

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron:  '0 6 * * 1'
 
+permissions:
+  contents: read # allow actions/checkout
+
 jobs:
   validate-links:
     runs-on: ubuntu-latest

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -11,11 +11,11 @@ permissions:
 
 jobs:
   validate-links:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/alpakka-kafka'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           # See https://github.com/actions/checkout/issues/299#issuecomment-677674415
           ref: ${{ github.event.pull_request.head.sha }}
@@ -25,12 +25,12 @@ jobs:
         run: git fetch --depth=100 origin +refs/tags/*:refs/tags/*
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v6.4.0
 
-      - name: Set up JDK 11 and Coursier
-        uses: coursier/setup-action@v1
+      - name: Set up JDK 17
+        uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:1.11
+          jvm: temurin:1.17
           apps: cs
 
       - name: sbt site

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Set up JDK 11 and Coursier
         uses: coursier/setup-action@v1
         with:
-          jvm: adopt:11
+          jvm: adopt:1.11
           apps: cs
 
       - name: sbt site

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,16 +12,15 @@ permissions:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'akka/alpakka-kafka'
     permissions:
       # write permission is required to create a github release
       contents: write
-      # write permission is required for autolabeler
-      # otherwise, read permission is required at least
-      pull-requests: write
     steps:
       # Drafts your next Release notes as Pull Requests are merged
-      - uses: release-drafter/release-drafter@v5
+      # https://github.com/release-drafter/release-drafter/releases
+      # v5.21.1
+      - uses: release-drafter/release-drafter@6df64e4ba4842c203c604c1f45246c5863410adb
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,10 +7,19 @@ on:
     - main
     - release-*
 
+permissions:
+  contents: read # allow actions/checkout
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     if: github.repository == 'akka/alpakka-kafka'
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
     steps:
       # Drafts your next Release notes as Pull Requests are merged
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -30,13 +30,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Setup Scala with JDK 8
-        uses: olafurpg/setup-scala@v13
-        with:
-          java-version: adopt@1.8.0-275
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
+
+      - name: Set up JDK 8
+        uses: coursier/setup-action@v1
+        with:
+          jvm: adopt:8
 
       - name: Publish artifacts for all Scala versions
         env:
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -67,13 +67,13 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
-      - name: Setup Scala with JDK 11
-        uses: olafurpg/setup-scala@v13
-        with:
-          java-version: adopt@1.11.0-9
-
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
+
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1
+        with:
+          jvm: adopt:1.11
 
       - name: Publish API and reference documentation
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
       - release-*
     tags: ["*"]
 
+permissions:
+  contents: read # allow actions/checkout
+
 jobs:
   release:
     # runs on main repo only

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -34,12 +34,12 @@ jobs:
           git checkout scratch
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v6.4.0
 
-      - name: Set up JDK 8
-        uses: coursier/setup-action@v1
+      - name: Set up JDK 11
+        uses: coursier/setup-action@v1.3.0
         with:
-          jvm: adopt:8
+          jvm: temurin:1.11.0.17
 
       - name: Publish artifacts for all Scala versions
         env:
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
@@ -71,10 +71,10 @@ jobs:
           git checkout scratch
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6
+        uses: coursier/cache-action@v6.4.0
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1
+        uses: coursier/setup-action@v1.3.0
         with:
           jvm: adopt:1.11
 

--- a/build.sbt
+++ b/build.sbt
@@ -82,6 +82,8 @@ val commonSettings = Def.settings(
   scalacOptions ++= Seq(
       "-encoding",
       "UTF-8", // yes, this is 2 args
+      "-release",
+      "8",
       "-Wconf:cat=feature:w,cat=deprecation&msg=.*JavaConverters.*:s,cat=unchecked:w,cat=lint:w,cat=unused:w,cat=w-flag:w"
     ) ++ {
       if (insideCI.value && !Nightly && scalaVersion.value != Scala212) Seq("-Werror")


### PR DESCRIPTION
GitHub workflow housekeeping (to not hit Node 12 EOL):
- checkout v3
- coursier/setup-action instead of olafurpg/setup-scala