### PR TITLE
retry committing for transient exceptions

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -27,7 +27,11 @@ import akka.kafka.KafkaConsumerActor.{StopLike, StoppingException}
 import akka.kafka._
 import akka.kafka.scaladsl.PartitionAssignmentHandler
 import org.apache.kafka.clients.consumer._
-import org.apache.kafka.common.errors.{RebalanceInProgressException, TimeoutException}
+import org.apache.kafka.common.errors.{
+  CoordinatorLoadInProgressException,
+  RebalanceInProgressException,
+  TimeoutException
+}
 import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
 
 import scala.annotation.nowarn
@@ -588,7 +592,8 @@ import scala.util.control.NonFatal
               progressTracker.committed(offsets)
               replyTo.foreach(_ ! Done)
 
-            case e @ (_: RebalanceInProgressException | _: TimeoutException) => retryCommits(duration, e)
+            case e @ (_: RebalanceInProgressException | _: TimeoutException | _: CoordinatorLoadInProgressException) =>
+              retryCommits(duration, e)
             case e: RetriableCommitFailedException => retryCommits(duration, e.getCause)
 
             case commitException =>

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -27,7 +27,7 @@ import akka.kafka.KafkaConsumerActor.{StopLike, StoppingException}
 import akka.kafka._
 import akka.kafka.scaladsl.PartitionAssignmentHandler
 import org.apache.kafka.clients.consumer._
-import org.apache.kafka.common.errors.RebalanceInProgressException
+import org.apache.kafka.common.errors.{RebalanceInProgressException, TimeoutException}
 import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
 
 import scala.annotation.nowarn
@@ -588,7 +588,7 @@ import scala.util.control.NonFatal
               progressTracker.committed(offsets)
               replyTo.foreach(_ ! Done)
 
-            case e: RebalanceInProgressException => retryCommits(duration, e)
+            case e @ (_: RebalanceInProgressException | _: TimeoutException) => retryCommits(duration, e)
             case e: RetriableCommitFailedException => retryCommits(duration, e.getCause)
 
             case commitException =>

--- a/tests/src/test/scala/akka/kafka/internal/CommittingWithMockSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingWithMockSpec.scala
@@ -22,7 +22,7 @@ import akka.testkit.TestKit
 import com.typesafe.config.ConfigFactory
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.errors.RebalanceInProgressException
+import org.apache.kafka.common.errors.{RebalanceInProgressException, TimeoutException}
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.BeforeAndAfterAll
@@ -196,6 +196,7 @@ class CommittingWithMockSpec(_system: ActorSystem)
   }
 
   val exceptions = List(new RebalanceInProgressException(),
+                        new TimeoutException(),
                         new RetriableCommitFailedException(new CommitTimeoutException("injected15")))
   for (exception <- exceptions) {
     it should s"retry commit on ${exception.getClass.getSimpleName}" in assertAllStagesStopped {

--- a/tests/src/test/scala/akka/kafka/internal/CommittingWithMockSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingWithMockSpec.scala
@@ -22,7 +22,11 @@ import akka.testkit.TestKit
 import com.typesafe.config.ConfigFactory
 import org.apache.kafka.clients.consumer._
 import org.apache.kafka.common.TopicPartition
-import org.apache.kafka.common.errors.{RebalanceInProgressException, TimeoutException}
+import org.apache.kafka.common.errors.{
+  CoordinatorLoadInProgressException,
+  RebalanceInProgressException,
+  TimeoutException
+}
 import org.apache.kafka.common.serialization.StringDeserializer
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.BeforeAndAfterAll
@@ -195,9 +199,12 @@ class CommittingWithMockSpec(_system: ActorSystem)
     Await.result(control.shutdown(), remainingOrDefault)
   }
 
-  val exceptions = List(new RebalanceInProgressException(),
-                        new TimeoutException(),
-                        new RetriableCommitFailedException(new CommitTimeoutException("injected15")))
+  val exceptions = List(
+    new RebalanceInProgressException(),
+    new TimeoutException(),
+    new CoordinatorLoadInProgressException("coordinator-load-in-progress-exception"),
+    new RetriableCommitFailedException(new CommitTimeoutException("injected15"))
+  )
   for (exception <- exceptions) {
     it should s"retry commit on ${exception.getClass.getSimpleName}" in assertAllStagesStopped {
       val retries = 4


### PR DESCRIPTION
### Background
Offset commits might fail due to timeout on the Kafka broker, in which case the broker returns an error stating the [operation timed out](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/consumer/internals/ConsumerCoordinator.java#L1383). Timeouts are transient in nature, so it might be worth to retry the commit.
### Changes 

- Attempt to retry a commit that failed due to `TimeoutException` exception.
- Add timeout exception scenario to the commit retry test.

References #1111
