### PR TITLE
ci: cover JDK 17 via scheduled build

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -107,13 +107,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # other combinations are covered in `scheduled-builds.yml`
-          - { scalaVersion: "2.12", jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
-          # { scalaVersion: "2.12", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
-          # { scalaVersion: "2.12", jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
-          # { scalaVersion: "2.13", jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0", extraOpts: '' }
-          - { scalaVersion: "2.13", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
-          # { scalaVersion: "2.13", jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
+          # other JDKs are covered in `scheduled-builds.yml`
+          - { jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
+          - { jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          # { jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
     steps:
       - name: Checkout
         uses: actions/checkout@v3.1.0
@@ -135,7 +132,7 @@ jobs:
           jvm: ${{ matrix.jvmName }}
 
       - name: sbt test
-        run: sbt ++${{ matrix.scalaVersion }} test ${{ matrix.extraOpts }}
+        run: sbt test ${{ matrix.extraOpts }}
 
       - name: Print logs on failure
         if: ${{ failure() }}

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -107,8 +107,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { java-version: 'temurin:1.8',  sbt-opts: '' }
-          - { java-version: 'temurin:1.11', sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          # other combinations are covered in `scheduled-builds.yml`
+          - { scalaVersion: "2.12", jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
+          # { scalaVersion: "2.12", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          # { scalaVersion: "2.12", jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
+          # { scalaVersion: "2.13", jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0", extraOpts: '' }
+          - { scalaVersion: "2.13", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          # { scalaVersion: "2.13", jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
     steps:
       - name: Checkout
         uses: actions/checkout@v3.1.0
@@ -124,13 +129,13 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.4.0
 
-      - name: Set up JDK ${{ matrix.java-version }}
+      - name: Set up JDK ${{ matrix.jdkVersion }}
         uses: coursier/setup-action@v1.3.0
         with:
-          jvm: ${{ matrix.java-version }}
+          jvm: ${{ matrix.jvmName }}
 
-      - name: Run tests with Scala ${{ matrix.scala-version }} and Java ${{ matrix.java-version }}
-        run: sbt ${{ matrix.sbt-opts }} "test"
+      - name: sbt test
+        run: sbt ++${{ matrix.scalaVersion }} test ${{ matrix.extraOpts }}
 
       - name: Print logs on failure
         if: ${{ failure() }}

--- a/.github/workflows/scheduled-builds.yml
+++ b/.github/workflows/scheduled-builds.yml
@@ -17,13 +17,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # cover relevant combinations not covered in `check-build-test.yml`
-          # { scalaVersion: "2.12", jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
-          - { scalaVersion: "2.12", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
-          - { scalaVersion: "2.12", jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
-          - { scalaVersion: "2.13", jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0", extraOpts: '' }
-          # { scalaVersion: "2.13", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
-          - { scalaVersion: "2.13", jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
+          # cover JDKs not covered in `check-build-test.yml`
+          # { jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
+          # { jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
     steps:
       - name: Checkout
         uses: actions/checkout@v3.1.0
@@ -38,9 +35,8 @@ jobs:
         with:
           jvm: ${{ matrix.jvmName }}
 
-      - name: sbt test on Scala ${{ matrix.scalaVersion }}
-        run: sbt ++${{ matrix.scalaVersion }} \
-          test ${{ matrix.extraOpts }}
+      - name: sbt test
+        run: sbt test ${{ matrix.extraOpts }}
 
       - name: Print logs on failure
         if: ${{ failure() }}

--- a/.github/workflows/scheduled-builds.yml
+++ b/.github/workflows/scheduled-builds.yml
@@ -1,0 +1,47 @@
+name: Scheduled Build
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0' # At 00:00 on Sunday
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-22.04
+    if: github.repository == 'akka/alpakka-kafka'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # cover relevant combinations not covered in `check-build-test.yml`
+          # { scalaVersion: "2.12", jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0",  extraOpts: '' }
+          - { scalaVersion: "2.12", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { scalaVersion: "2.12", jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
+          - { scalaVersion: "2.13", jdkVersion: "1.8.0",  jvmName: "temurin:1.8.0", extraOpts: '' }
+          # { scalaVersion: "2.13", jdkVersion: "1.11.0", jvmName: "temurin:1.11.0", extraOpts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { scalaVersion: "2.13", jdkVersion: "1.17.0", jvmName: "temurin:1.17.0", extraOpts: '' }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
+
+      - name: Cache Coursier cache
+        uses: coursier/cache-action@v6.4.0
+
+      - name: Set up JDK ${{ matrix.jdkVersion }}
+        uses: coursier/setup-action@v1.3.0
+        with:
+          jvm: ${{ matrix.jvmName }}
+
+      - name: sbt test
+        run: sbt ++${{ matrix.scalaVersion }} \
+          test ${{ matrix.extraOpts }}
+
+      - name: Print logs on failure
+        if: ${{ failure() }}
+        run: find . -name "*.log" -exec ./scripts/cat-log.sh {} \;

--- a/.github/workflows/scheduled-builds.yml
+++ b/.github/workflows/scheduled-builds.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-22.04
-    if: github.repository == 'akka/alpakka-kafka'
+    if: github.event.repository.fork == false
     strategy:
       fail-fast: false
       matrix:
@@ -38,7 +38,7 @@ jobs:
         with:
           jvm: ${{ matrix.jvmName }}
 
-      - name: sbt test
+      - name: sbt test on Scala ${{ matrix.scalaVersion }}
         run: sbt ++${{ matrix.scalaVersion }} \
           test ${{ matrix.extraOpts }}
 


### PR DESCRIPTION
Full matrix to cover even JDK17 via a scheduled build.
It looks as if Scala 2.12 wasn't actually covered in any CI build.

Follow-up to #1574 