### PR TITLE
bump(sbt): sbt 1.8, sbt-site 1.5 and others

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -284,7 +284,7 @@ lazy val tests = project
   )
 
 lazy val docs = project
-  .enablePlugins(AkkaParadoxPlugin, ParadoxSitePlugin, PreprocessPlugin, PublishRsyncPlugin)
+  .enablePlugins(AkkaParadoxPlugin, ParadoxSitePlugin, SitePreviewPlugin, PreprocessPlugin, PublishRsyncPlugin)
   .disablePlugins(MimaPlugin)
   .settings(commonSettings)
   .settings(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.2
+sbt.version=1.8.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,13 @@
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
+addSbtPlugin(
+  "com.github.sbt" % "sbt-ci-release" % "1.5.11"
+  // even sbt-site 1.5 pulls Scala Parser Combinators, but version 2
+  exclude ("org.scala-lang.modules", "scala-parser-combinators_2.12")
+)
 addSbtPlugin("net.aichler" % "sbt-jupiter-interface" % "0.11.1")
 // discipline
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.7.0")
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.9.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.1")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.7.0")
 // docs
@@ -11,8 +15,7 @@ addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.45")
 addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-dependencies" % "0.2.2")
 addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.2")
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
-// Java 11 module names are not added https://github.com/ThoughtWorksInc/sbt-api-mappings/issues/58
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.1")
+addSbtPlugin("com.github.sbt" % "sbt-site-paradox" % "1.5.0-RC2")
 
 resolvers += Resolver.jcenterRepo

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,9 +1,5 @@
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
-addSbtPlugin(
-  "com.github.sbt" % "sbt-ci-release" % "1.5.11"
-  // even sbt-site 1.5 pulls Scala Parser Combinators, but version 2
-  exclude ("org.scala-lang.modules", "scala-parser-combinators_2.12")
-)
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.11")
 addSbtPlugin("net.aichler" % "sbt-jupiter-interface" % "0.11.1")
 // discipline
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.9.0")


### PR DESCRIPTION
Move sbt-site to use sbt-site-paradox 1.5.0-RC2 to sort Scala XML and Scala Parser Combinators dependencies in the build.

- sbt 1.8.2
- sbt-ci-release 1.5.11
- sbt-header 5.9.0
- sbt-scalafmt 2.5.0