### PR TITLE
feat: simpler access to partition assignment strategies

### DIFF
--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -300,6 +300,26 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
     withProperty(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, groupInstanceId)
 
   /**
+   * A list of class names or class types, ordered by preference, of supported
+   * partition assignment strategies that the client will use to distribute
+   * partition ownership amongst consumer instances when group management is used.
+   *
+   * See https://kafka.apache.org/documentation/#consumerconfigs_partition.assignment.strategy
+   */
+  def withPartitionAssignmentStrategy(strategy: String): ConsumerSettings[K, V] =
+    withProperty(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, strategy)
+
+  /**
+   * Sets the `CooperativeStickyAssignor` assignment strategy.
+   *
+   * @see https://kafka.apache.org/documentation/#consumerconfigs_partition.assignment.strategy
+   * @see https://kafka.apache.org/33/documentation.html#upgrade_300_notable
+   */
+  def withPartitionAssignmentStrategyCooperativeStickyAssignor(): ConsumerSettings[K, V] =
+    withProperty(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG,
+      classOf[org.apache.kafka.clients.consumer.CooperativeStickyAssignor].getName)
+
+  /**
    * Scala API:
    * The raw properties of the kafka-clients driver, see constants in
    * [[org.apache.kafka.clients.consumer.ConsumerConfig]].

--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -306,8 +306,8 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
    *
    * See https://kafka.apache.org/documentation/#consumerconfigs_partition.assignment.strategy
    */
-  def withPartitionAssignmentStrategy(strategy: String): ConsumerSettings[K, V] =
-    withProperty(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, strategy)
+  def withPartitionAssignmentStrategies(strategies: Array[String]): ConsumerSettings[K, V] =
+    withProperty(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, strategies.mkString(","))
 
   /**
    * Sets the `CooperativeStickyAssignor` assignment strategy.

--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -317,7 +317,7 @@ class ConsumerSettings[K, V] @InternalApi private[kafka] (
    */
   def withPartitionAssignmentStrategyCooperativeStickyAssignor(): ConsumerSettings[K, V] =
     withProperty(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG,
-      classOf[org.apache.kafka.clients.consumer.CooperativeStickyAssignor].getName)
+                 classOf[org.apache.kafka.clients.consumer.CooperativeStickyAssignor].getName)
 
   /**
    * Scala API:

--- a/docs/src/main/paradox/consumer.md
+++ b/docs/src/main/paradox/consumer.md
@@ -49,6 +49,7 @@ When creating a consumer source you need to pass in @apidoc[ConsumerSettings] th
 * bootstrap servers of the Kafka cluster (see @ref:[Service discovery](discovery.md) to defer the server configuration)
 * group id for the consumer, note that offsets are always committed for a given consumer group
 * Kafka consumer tuning parameters
+* assignment strategies
 
 Alpakka Kafka's defaults for all settings are defined in `reference.conf` which is included in the library JAR.
 
@@ -58,6 +59,8 @@ Important consumer settings
 | stop-timeout | The stage will delay stopping the internal actor to allow processing of messages already in the stream (required for successful committing). This can be set to 0 for streams using @apidoc[Consumer.DrainingControl] |
 | kafka-clients | Section for properties passed unchanged to the Kafka client (see @extref:[Kafka's Consumer Configs](kafka:/documentation.html#consumerconfigs)) |
 | connection-checker | Configuration to let the stream fail if the connection to the Kafka broker fails. |
+
+Explicitly selecting a [Consumer Assignment Strategy](https://kafka.apache.org/documentation/#consumerconfigs_partition.assignment.strategy) such as @javadoc[CooperativeStickyAssignor](org.apache.kafka.clients.consumer.CooperativeStickyAssignor) is recommended. They were introduced in [Kafka 3.0](https://kafka.apache.org/33/documentation.html#upgrade_300_notable). Please check the [Kafka upgrade guide](https://cwiki.apache.org/confluence/display/KAFKA/KIP-429:+Kafka+Consumer+Incremental+Rebalance+Protocol#KIP429:KafkaConsumerIncrementalRebalanceProtocol-Consumer) before changing it.
 
 reference.conf (HOCON)
 : @@ snip [snip](/core/src/main/resources/reference.conf) { #consumer-settings }

--- a/tests/src/test/java/docs/javadsl/ConsumerSettingsTest.java
+++ b/tests/src/test/java/docs/javadsl/ConsumerSettingsTest.java
@@ -14,8 +14,11 @@ import akka.kafka.javadsl.DiscoverySupport;
 import akka.testkit.javadsl.TestKit;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ConsumerSettingsTest {
 
@@ -36,5 +39,18 @@ public class ConsumerSettingsTest {
                 DiscoverySupport.consumerBootstrapServers(consumerConfig, system));
     // #discovery-settings
     TestKit.shutdownActorSystem(system);
+  }
+
+  @Test
+  public void setAssignor() throws Exception {
+    ActorSystem system = ActorSystem.create("ConsumerSettingsTest");
+    ConsumerSettings<String, String> settings = ConsumerSettings.create(system, new StringDeserializer(), new StringDeserializer())
+            .withPartitionAssignmentStrategies(new String[] {
+                    org.apache.kafka.clients.consumer.CooperativeStickyAssignor.class.getName(),
+                    org.apache.kafka.clients.consumer.StickyAssignor.class.getName()
+            });
+    assertEquals(
+            settings.getProperty(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG),
+            "org.apache.kafka.clients.consumer.CooperativeStickyAssignor,org.apache.kafka.clients.consumer.StickyAssignor");
   }
 }


### PR DESCRIPTION
Add direct access to control partition assignment strategies and specifically the `CooperativeStickyAssignor`.

References #943 