### PR TITLE
chore: remove ScalaDoc flag for 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -123,9 +123,9 @@ val commonSettings = Def.settings(
   Compile / doc / scalacOptions ++= {
     if (scalaBinaryVersion.value.startsWith("3")) {
       Seq(s"-external-mappings:https://docs.oracle.com/en/java/javase/${JavaDocLinkVersion}/docs/api/java.base/") // different usage in scala3
-    } else {
+    } else if (scalaBinaryVersion.value.startsWith("2.13")) {
       Seq("-jdk-api-doc-base", s"https://docs.oracle.com/en/java/javase/${JavaDocLinkVersion}/docs/api/java.base/")
-    }
+    } else Nil
   },
   Compile / doc / scalacOptions -= "-Xfatal-warnings",
   // show full stack traces and test case durations


### PR DESCRIPTION
For releasing sbt-ci-release runs ScalaDoc for the Scala version publishing with. The `-jdk-api-doc-base` doesn't exist for Scala 2.12.