### PR TITLE
chore: dependency submission to GitHub

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,34 @@
+name: Dependency Graph submission
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - master
+    tags: ["*"]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-graph:
+    name: Update Dependency Graph
+    if: github.event.repository.fork == false
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        # https://github.com/actions/checkout/releases
+        # v3.5.0
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+        with:
+          fetch-depth: 0
+      - name: Submit dependencies to GitHub
+        # https://github.com/scalacenter/sbt-dependency-submission/releases
+        # v2.1.1
+        uses: scalacenter/sbt-dependency-submission@739438984674d708fd182ca0c288eaa793f9120a
+        with:
+          modules-ignore: benchmarks tests
+          configs-ignore: test It

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -27,8 +27,8 @@ jobs:
           fetch-depth: 0
       - name: Submit dependencies to GitHub
         # https://github.com/scalacenter/sbt-dependency-submission/releases
-        # v2.1.1
-        uses: scalacenter/sbt-dependency-submission@739438984674d708fd182ca0c288eaa793f9120a
+        # v2.1.2
+        uses: scalacenter/sbt-dependency-submission@c1a4bf7781721f012d92248cc7da60655d2e2880
         with:
           modules-ignore: benchmarks tests
           configs-ignore: test It


### PR DESCRIPTION
Use Scala Center's action to report sbt dependencies to the GitHub API.

References
- https://github.com/akka/akka-projection/pull/792