### PR TITLE
chore: exclude benchmarks and tests from dependency submission

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -30,5 +30,5 @@ jobs:
         # v2.1.2
         uses: scalacenter/sbt-dependency-submission@c1a4bf7781721f012d92248cc7da60655d2e2880
         with:
-          modules-ignore: benchmarks tests
+          modules-ignore: akka-stream-kafka-benchmarks_2.12 akka-stream-kafka-benchmarks_2.13 akka-stream-kafka-tests_2.12 akka-stream-kafka-tests_2.13
           configs-ignore: test It


### PR DESCRIPTION
Proper names for to be excluded modules.

References 
- #1611 
