### PR TITLE
fix: only attach callbacks in DrainingControl.isShutdown once

### DIFF
--- a/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
@@ -92,11 +92,11 @@ object Consumer {
     def drainAndShutdown(ec: Executor): CompletionStage[T] =
       control.drainAndShutdown(streamCompletion, ec)
 
-    override def isShutdown: CompletionStage[Done] = _isShutdown
-
-    private[this] lazy val _isShutdown =
-      control.isShutdown.thenCompose { _ =>
-        streamCompletion.thenApply(_ => Done.done())
+    override val isShutdown: CompletionStage[Done] =
+      control.isShutdown.thenCompose[Done] { _: Any =>  // Scala 2.12 needs the types here
+        streamCompletion.thenApply[Done] { _: Any => // Scala 2.12 needs the types here
+          Done.done()
+        }
       }
 
     override def getMetrics: CompletionStage[java.util.Map[MetricName, Metric]] = control.getMetrics

--- a/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
@@ -93,8 +93,8 @@ object Consumer {
       control.drainAndShutdown(streamCompletion, ec)
 
     override val isShutdown: CompletionStage[Done] =
-      control.isShutdown.thenCompose[Done] { _: Any =>  // Scala 2.12 needs the types here
-        streamCompletion.thenApply[Done] { _: Any => // Scala 2.12 needs the types here
+      control.isShutdown.thenCompose[Done] { (_: Any) => // Scala 2.12 needs the types here
+        streamCompletion.thenApply[Done] { (_: Any) => // Scala 2.12 needs the types here
           Done.done()
         }
       }

--- a/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
@@ -92,7 +92,12 @@ object Consumer {
     def drainAndShutdown(ec: Executor): CompletionStage[T] =
       control.drainAndShutdown(streamCompletion, ec)
 
-    override def isShutdown: CompletionStage[Done] = control.isShutdown
+    override def isShutdown: CompletionStage[Done] = _isShutdown
+
+    private[this] lazy val _isShutdown =
+      control.isShutdown.thenCompose { _ =>
+        streamCompletion.thenApply(_ => Done.done())
+      }
 
     override def getMetrics: CompletionStage[java.util.Map[MetricName, Metric]] = control.getMetrics
   }

--- a/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
@@ -117,7 +117,7 @@ object Consumer {
      */
     def drainAndShutdown()(implicit ec: ExecutionContext): Future[T] = control.drainAndShutdown(streamCompletion)(ec)
 
-    override def isShutdown: Future[Done] =
+    override lazy val isShutdown: Future[Done] =
       control.isShutdown
         .flatMap(_ => streamCompletion)(ExecutionContexts.parasitic)
         .map(_ => Done)(ExecutionContexts.parasitic)

--- a/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Consumer.scala
@@ -117,7 +117,7 @@ object Consumer {
      */
     def drainAndShutdown()(implicit ec: ExecutionContext): Future[T] = control.drainAndShutdown(streamCompletion)(ec)
 
-    override lazy val isShutdown: Future[Done] =
+    override val isShutdown: Future[Done] =
       control.isShutdown
         .flatMap(_ => streamCompletion)(ExecutionContexts.parasitic)
         .map(_ => Done)(ExecutionContexts.parasitic)

--- a/tests/src/test/scala/akka/kafka/scaladsl/ControlSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/ControlSpec.scala
@@ -29,7 +29,7 @@ object ControlSpec {
       shutdownCalled.set(true)
       shutdownFuture
     }
-    override def isShutdown: Future[Done] = ???
+    override def isShutdown: Future[Done] = Future.failed(new NotImplementedError(""))
     override def metrics: Future[Map[MetricName, Metric]] = ???
   }
 }


### PR DESCRIPTION
References #1642.

Also brings `javadsl.DrainingControl.isShutdown` behavior into line with `scaladsl` by not completing until both the source and overall stream have completed.