### PR TITLE
bump: kafka-clients 3.7.0 (was 3.5.2)

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -5,7 +5,7 @@ updates.ignore = [
   { groupId = "org.scalameta", artifactId = "scalafmt-core" }
 ]
 updates.pin = [
-  { groupId = "org.apache.kafka", artifactId="kafka-clients", version="3.5." }
+  { groupId = "org.apache.kafka", artifactId="kafka-clients", version="3.7." }
   # To be updated in tandem with upstream Akka
   { groupId = "org.scalatest", artifactId = "scalatest", version = "3.1." }
   { groupId = "org.slf4j", artifactId = "log4j-over-slf4j", version = "1." }

--- a/build.sbt
+++ b/build.sbt
@@ -21,8 +21,8 @@ val AkkaBinaryVersionForDocs = "2.9"
 val akkaVersion = "2.9.0"
 
 // Keep .scala-steward.conf pin in sync
-val kafkaVersion = "3.5.2"
-val KafkaVersionForDocs = "35"
+val kafkaVersion = "3.7.0"
+val KafkaVersionForDocs = "37"
 // This should align with the ScalaTest version used in the Akka testkit
 // https://github.com/akka/akka/blob/main/project/Dependencies.scala#L44
 val scalatestVersion = "3.2.16"

--- a/docs/src/main/paradox/home.md
+++ b/docs/src/main/paradox/home.md
@@ -1,6 +1,6 @@
 # Overview
 
-The [Alpakka project](https://doc.akka.io/docs/alpakka/current/) is an open source initiative to implement stream-aware and reactive integration pipelines for Java and Scala. It is built on top of @extref[Akka Streams](akka:stream/index.html), and has been designed from the ground up to understand streaming natively and provide a DSL for reactive and stream-oriented programming, with built-in support for backpressure. Akka Streams is a [Reactive Streams](https://www.reactive-streams.org/) and JDK 9+ @extref[java.util.concurrent.Flow](java-docs:docs/api/java.base/java/util/concurrent/Flow.html)-compliant implementation and therefore @extref[fully interoperable](akka:general/stream/stream-design.html#interoperation-with-other-reactive-streams-implementations) with other implementations.
+The [Alpakka project](https://doc.akka.io/docs/alpakka/current/) is an open source initiative to implement stream-aware and reactive integration pipelines for Java and Scala. It is built on top of @extref[Akka Streams](akka:stream/index.html), and has been designed from the ground up to understand streaming natively and provide a DSL for reactive and stream-oriented programming, with built-in support for backpressure. Akka Streams is a [Reactive Streams](https://www.reactive-streams.org/) and JDK @extref[java.util.concurrent.Flow](java-docs:docs/api/java.base/java/util/concurrent/Flow.html)-compliant implementation and therefore @extref[fully interoperable](akka:general/stream/stream-design.html#interoperation-with-other-reactive-streams-implementations) with other implementations.
 
 This **Alpakka Kafka connector** lets you connect [Apache Kafka](https://kafka.apache.org/) to Akka Streams. It was formerly known as **Akka Streams Kafka** and even **Reactive Kafka**.
 
@@ -14,6 +14,7 @@ See all releases in [GitHub releases](https://github.com/akka/alpakka-kafka/rele
 
 | Kafka client                                                            | Scala Versions   | Akka version    | Alpakka Kafka Connector
 |-------------------------------------------------------------------------|------------------|-----------------|-------------------------
+| 3.7.0                                                                   | 3.3, 2.13        | 2.9.0+          | [release 6.0.0](https://github.com/akka/alpakka-kafka/releases/tag/v6.0.0)
 | 3.5.1                                                                   | 3.3, 2.13        | 2.9.0+          | [release 5.0.0](https://github.com/akka/alpakka-kafka/releases/tag/v5.0.0)
 | 3.3.1                                                                   | 2.13, 2.12       | 2.7.0+          | [release 4.0.0](https://github.com/akka/alpakka-kafka/releases/tag/v4.0.0)
 | 3.0.1                                                                   | 2.13             | 2.6.18+         | [release 3.0.1](https://github.com/akka/alpakka-kafka/releases/tag/v3.0.0)

--- a/tests/src/test/scala/akka/kafka/internal/ConsumerDummy.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConsumerDummy.scala
@@ -33,6 +33,7 @@ abstract class ConsumerDummy[K, V] extends Consumer[K, V] {
   private val firstPausingPromise = Promise[Done]()
   def started = firstPausingPromise.future
 
+  override def clientInstanceId(timeout: java.time.Duration): org.apache.kafka.common.Uuid = ???
   override def assignment(): java.util.Set[TopicPartition] = ???
   override def subscription(): java.util.Set[String] = ???
   override def subscribe(topics: java.util.Collection[String]): Unit = ???


### PR DESCRIPTION
Bumps the Kafka client library to the current 3.7.0 version.

References
- https://downloads.apache.org/kafka/3.7.0/RELEASE_NOTES.html
- https://github.com/akka/alpakka-kafka/pull/1707