### PR TITLE
feat: kip447 transactions

### DIFF
--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaTransactionFixtures.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/ReactiveKafkaTransactionFixtures.scala
@@ -63,7 +63,7 @@ object ReactiveKafkaTransactionFixtures extends PerfFixtureHelpers {
           Transactional.source(consumerSettings, Subscriptions.topics(c.filledTopic.topic))
 
         val producerSettings = createProducerSettings(c.kafkaHost).withEosCommitInterval(commitInterval)
-        val flow: Flow[KProducerMessage, KResult, NotUsed] = Transactional.flow(producerSettings, randomId())
+        val flow: Flow[KProducerMessage, KResult, NotUsed] = Transactional.flow(producerSettings)
 
         ReactiveKafkaTransactionTestFixture[KTransactionMessage, KProducerMessage, KResult](c.filledTopic.topic,
                                                                                             sinkTopic,

--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,7 @@ val commonSettings = Def.settings(
       "11",
       "-Wconf:cat=feature:w,cat=deprecation&msg=.*JavaConverters.*:s,cat=unchecked:w,cat=lint:w,cat=unused:w,cat=w-flag:w"
     ) ++ {
-      if (insideCI.value && !Nightly && scalaVersion.value != Scala3) Seq("-Werror")
+      if (scalaVersion.value != Scala3) Seq("-Werror")
       else Seq.empty
     },
   Compile / doc / scalacOptions := scalacOptions.value ++ Seq(

--- a/core/src/main/mima-filters/5.0.0.backwards.excludes
+++ b/core/src/main/mima-filters/5.0.0.backwards.excludes
@@ -1,0 +1,5 @@
+# ApiMayChange
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.javadsl.Transactional.flowWithOffsetContext")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.javadsl.Transactional.sinkWithOffsetContext")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.scaladsl.Transactional.flowWithOffsetContext")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.scaladsl.Transactional.sinkWithOffsetContext")

--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -7,11 +7,10 @@ package akka.kafka
 
 import java.util.Objects
 import java.util.concurrent.CompletionStage
-
 import akka.Done
 import akka.annotation.{DoNotInherit, InternalApi}
 import akka.kafka.internal.{CommittableOffsetBatchImpl, CommittedMarker}
-import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.consumer.{ConsumerGroupMetadata, ConsumerRecord}
 import org.apache.kafka.common.TopicPartition
 
 import scala.concurrent.Future
@@ -133,7 +132,8 @@ object ConsumerMessage {
       override val key: GroupTopicPartition,
       override val offset: Long,
       private[kafka] val committedMarker: CommittedMarker,
-      private[kafka] val fromPartitionedSource: Boolean
+      private[kafka] val fromPartitionedSource: Boolean,
+      requestConsumerGroupMetadata: () => Future[ConsumerGroupMetadata]
   ) extends PartitionOffset(key, offset)
 
   /**

--- a/core/src/main/scala/akka/kafka/internal/DefaultProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/DefaultProducerStage.scala
@@ -71,7 +71,6 @@ private class DefaultProducerStageLogic[K, V, P, IN <: Envelope[K, V, P], OUT <:
   }
 
   override def preStart(): Unit = {
-    super.preStart()
     resolveProducer(stage.settings)
   }
 

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -73,6 +73,10 @@ import scala.util.control.NonFatal
     /** Special case commit for non-batched committing. */
     final case class CommitSingle(tp: TopicPartition, offsetAndMetadata: OffsetAndMetadata)
         extends NoSerializationVerificationNeeded
+
+    // Used for transactions/EOS returns the current ConsumerGroupMetadata
+    final case object GetConsumerGroupMetadata extends NoSerializationVerificationNeeded
+
     //responses
     final case class Assigned(partition: List[TopicPartition]) extends NoSerializationVerificationNeeded
     final case class Revoked(partition: List[TopicPartition]) extends NoSerializationVerificationNeeded
@@ -293,6 +297,9 @@ import scala.util.control.NonFatal
     case Terminated(ref) =>
       stageActorsMap = stageActorsMap.filterNot(_._2 == ref)
       requests -= ref
+
+    case GetConsumerGroupMetadata =>
+      sender() ! consumer.groupMetadata()
 
     case req: Metadata.Request =>
       sender() ! handleMetadataRequest(req)

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -75,7 +75,7 @@ import scala.util.control.NonFatal
         extends NoSerializationVerificationNeeded
 
     // Used for transactions/EOS returns the current ConsumerGroupMetadata
-    final case object GetConsumerGroupMetadata extends NoSerializationVerificationNeeded
+    case object GetConsumerGroupMetadata extends NoSerializationVerificationNeeded
 
     //responses
     final case class Assigned(partition: List[TopicPartition]) extends NoSerializationVerificationNeeded

--- a/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
+++ b/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
@@ -8,7 +8,13 @@ import java.util.concurrent.CompletionStage
 import akka.Done
 import akka.annotation.InternalApi
 import akka.kafka.ConsumerMessage
-import akka.kafka.ConsumerMessage.{CommittableMessage, CommittableOffsetMetadata, GroupTopicPartition, TransactionalMessage, _}
+import akka.kafka.ConsumerMessage.{
+  CommittableMessage,
+  CommittableOffsetMetadata,
+  GroupTopicPartition,
+  TransactionalMessage,
+  _
+}
 import org.apache.kafka.clients.consumer.{ConsumerGroupMetadata, ConsumerRecord, OffsetAndMetadata}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.requests.OffsetFetchResponse

--- a/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
+++ b/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
@@ -5,18 +5,11 @@
 
 package akka.kafka.internal
 import java.util.concurrent.CompletionStage
-
 import akka.Done
 import akka.annotation.InternalApi
 import akka.kafka.ConsumerMessage
-import akka.kafka.ConsumerMessage.{
-  CommittableMessage,
-  CommittableOffsetMetadata,
-  GroupTopicPartition,
-  TransactionalMessage,
-  _
-}
-import org.apache.kafka.clients.consumer.{ConsumerRecord, OffsetAndMetadata}
+import akka.kafka.ConsumerMessage.{CommittableMessage, CommittableOffsetMetadata, GroupTopicPartition, TransactionalMessage, _}
+import org.apache.kafka.clients.consumer.{ConsumerGroupMetadata, ConsumerRecord, OffsetAndMetadata}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.requests.OffsetFetchResponse
 
@@ -46,6 +39,8 @@ private[kafka] trait TransactionalMessageBuilderBase[K, V, Msg] extends MessageB
   def onMessage(consumerMessage: ConsumerRecord[K, V]): Unit
 
   def fromPartitionedSource: Boolean
+
+  def requestConsumerGroupMetadata(): Future[ConsumerGroupMetadata]
 }
 
 /** Internal API */
@@ -62,7 +57,8 @@ private[kafka] trait TransactionalMessageBuilder[K, V]
       ),
       offset = rec.offset,
       committedMarker,
-      fromPartitionedSource
+      fromPartitionedSource,
+      requestConsumerGroupMetadata _
     )
     ConsumerMessage.TransactionalMessage(rec, offset)
   }
@@ -82,7 +78,8 @@ private[kafka] trait TransactionalOffsetContextBuilder[K, V]
       ),
       offset = rec.offset,
       committedMarker,
-      fromPartitionedSource
+      fromPartitionedSource,
+      requestConsumerGroupMetadata _
     )
     (rec, offset)
   }

--- a/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
@@ -233,7 +233,7 @@ private final class TransactionalProducerStageLogic[K, V, P](
   }
 
   override def onCompletionFailure(ex: Throwable): Unit = {
-    abortTransaction("Stage failure")
+    abortTransaction(s"Stage failure (${ex})")
     batchOffsets.committingFailed()
     super.onCompletionFailure(ex)
   }

--- a/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
@@ -213,7 +213,10 @@ private final class TransactionalProducerStageLogic[K, V, P](
       ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG -> true.toString,
       // FIXME only requirement is unique within cluster, is it fine leaving that up to the user?
       ProducerConfig.TRANSACTIONAL_ID_CONFIG -> transactionalId,
-      ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION -> 1.toString
+      ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION -> 1.toString,
+      // KIP-447: "We shall set `transaction.timout.ms` default to 10000 ms (10 seconds) on Kafka Streams. For non-stream users,
+      // we highly recommend you to do the same if you want to use the new semantics."
+      ProducerConfig.TRANSACTION_TIMEOUT_CONFIG -> 10000.toString
     )
   }
 

--- a/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
@@ -123,6 +123,7 @@ private final class TransactionalProducerStageLogic[K, V, P](
 
   private val commitTransactionCB: Try[CommitTransaction] => Unit =
     createAsyncCallback[Try[CommitTransaction]](commitTransaction _).invoke _
+
   private val onInternalCommitAckCb: Try[Done] => Unit =
     getAsyncCallback[Try[Done]] { maybeDone =>
       maybeDone match {
@@ -286,7 +287,7 @@ private final class TransactionalProducerStageLogic[K, V, P](
           resumeDemand()
         }
     }
-    // in case stage wats to shut down but was waiting for commit to complete
+    // in case stage wants to shut down but was waiting for commit to complete
     checkForCompletion()
   }
 

--- a/core/src/main/scala/akka/kafka/internal/TransactionalSources.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalSources.scala
@@ -186,7 +186,7 @@ private[internal] abstract class TransactionalSourceLogic[K, V, Msg](shape: Sour
     new PartitionAssignmentHelpers.Chain(handler, blockingRevokedCall)
   }
 
-  def requestConsumerGroupMetadata(): Future[ConsumerGroupMetadata] = {
+  override def requestConsumerGroupMetadata(): Future[ConsumerGroupMetadata] = {
     import akka.pattern.ask
     implicit val timeout: Timeout = 5.seconds // FIXME specific timeout config for this?
     ask(consumerActor, KafkaConsumerActor.Internal.GetConsumerGroupMetadata)(timeout)
@@ -375,7 +375,8 @@ private final class TransactionalSubSourceStageLogic[K, V](
 
   private val inFlightRecords = InFlightRecords.empty
 
-  lazy val committedMarker: CommittedMarker = CommittedMarkerRef(subSourceActor.ref, consumerSettings.commitTimeout)
+  override lazy val committedMarker: CommittedMarker =
+    CommittedMarkerRef(subSourceActor.ref, consumerSettings.commitTimeout)
 
   override val fromPartitionedSource: Boolean = true
   override def groupId: String = consumerSettings.properties(ConsumerConfig.GROUP_ID_CONFIG)
@@ -436,7 +437,7 @@ private final class TransactionalSubSourceStageLogic[K, V](
       completeStage()
   }
 
-  def requestConsumerGroupMetadata(): Future[ConsumerGroupMetadata] = {
+  override def requestConsumerGroupMetadata(): Future[ConsumerGroupMetadata] = {
     implicit val timeout: Timeout = 5.seconds // FIXME specific timeout config for this?
     akka.pattern
       .ask(consumerActor, KafkaConsumerActor.Internal.GetConsumerGroupMetadata)(timeout)

--- a/core/src/main/scala/akka/kafka/internal/TransactionalSources.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalSources.scala
@@ -10,6 +10,7 @@ import akka.{Done, NotUsed}
 import akka.actor.{ActorRef, Status, Terminated}
 import akka.actor.Status.Failure
 import akka.annotation.InternalApi
+import akka.dispatch.ExecutionContexts
 import akka.kafka.ConsumerMessage.{PartitionOffset, TransactionalMessage}
 import akka.kafka.internal.KafkaConsumerActor.Internal.Revoked
 import akka.kafka.internal.SubSourceLogic._
@@ -114,7 +115,7 @@ private[internal] abstract class TransactionalSourceLogic[K, V, Msg](shape: Sour
     case (sender, Committed(offsets)) =>
       inFlightRecords.committed(offsets.iterator.map { case (k, v) => k -> (v.offset() - 1L) }.toMap)
       sender.tell(Done, sourceActor.ref)
-    case (sender, CommittingFailure) => {
+    case (_, CommittingFailure) => {
       log.info("Committing failed, resetting in flight offsets")
       inFlightRecords.reset()
     }
@@ -126,20 +127,15 @@ private[internal] abstract class TransactionalSourceLogic[K, V, Msg](shape: Sour
         log.debug(s"Draining partitions {}", partitions)
         materializer.scheduleOnce(
           consumerSettings.drainingCheckInterval,
-          new Runnable {
-            override def run(): Unit =
-              sourceActor.ref.tell(Drain(partitions, ack.orElse(Some(sender)), msg), sourceActor.ref)
-          }
+          () => sourceActor.ref.tell(Drain(partitions, ack.orElse(Some(sender)), msg), sourceActor.ref)
         )
       }
   }
 
   override val groupId: String = consumerSettings.properties(ConsumerConfig.GROUP_ID_CONFIG)
 
-  override lazy val committedMarker: CommittedMarker = {
-    val ec = materializer.executionContext
-    CommittedMarkerRef(sourceActor.ref, consumerSettings.commitTimeout)(ec)
-  }
+  override lazy val committedMarker: CommittedMarker =
+    CommittedMarkerRef(sourceActor.ref, consumerSettings.commitTimeout)
 
   override def onMessage(rec: ConsumerRecord[K, V]): Unit =
     inFlightRecords.add(Map(new TopicPartition(rec.topic(), rec.partition()) -> rec.offset()))
@@ -156,6 +152,8 @@ private[internal] abstract class TransactionalSourceLogic[K, V, Msg](shape: Sour
   override protected def addToPartitionAssignmentHandler(
       handler: PartitionAssignmentHandler
   ): PartitionAssignmentHandler = {
+    // FIXME this touches mutable internal stage fields (sourceActor, stageActor, consumerActor, subSources) from
+    //       another thread (consumer actor) not thread safe
     val blockingRevokedCall = new PartitionAssignmentHandler {
       override def onAssign(assignedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = ()
 
@@ -172,20 +170,20 @@ private[internal] abstract class TransactionalSourceLogic[K, V, Msg](shape: Sour
         onRevoke(lostTps, consumer)
 
       override def onStop(revokedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = ()
+
+      private def waitForDraining(partitions: Set[TopicPartition]): Boolean = {
+        import akka.pattern.ask
+        implicit val timeout = Timeout(consumerSettings.commitTimeout)
+        try {
+          Await.result(ask(stageActor.ref, Drain(partitions, None, Drained)), timeout.duration)
+          true
+        } catch {
+          case t: Throwable =>
+            false
+        }
+      }
     }
     new PartitionAssignmentHelpers.Chain(handler, blockingRevokedCall)
-  }
-
-  private def waitForDraining(partitions: Set[TopicPartition]): Boolean = {
-    import akka.pattern.ask
-    implicit val timeout = Timeout(consumerSettings.commitTimeout)
-    try {
-      Await.result(ask(stageActor.ref, Drain(partitions, None, Drained)), timeout.duration)
-      true
-    } catch {
-      case t: Throwable =>
-        false
-    }
   }
 
   def requestConsumerGroupMetadata(): Future[ConsumerGroupMetadata] = {
@@ -246,6 +244,8 @@ private[kafka] final class TransactionalSubSource[K, V](
       override protected def addToPartitionAssignmentHandler(
           handler: PartitionAssignmentHandler
       ): PartitionAssignmentHandler = {
+        // FIXME this touches mutable internal stage fields (sourceActor, stageActor, consumerActor, subSources) from
+        //       another thread (consumer actor) not thread safe
         val blockingRevokedCall = new PartitionAssignmentHandler {
           override def onAssign(assignedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit = ()
 
@@ -299,14 +299,13 @@ private object TransactionalSourceLogic {
   final case class Committed(offsets: Map[TopicPartition, OffsetAndMetadata])
   case object CommittingFailure
 
-  private[internal] final case class CommittedMarkerRef(sourceActor: ActorRef, commitTimeout: FiniteDuration)(
-      implicit ec: ExecutionContext
-  ) extends CommittedMarker {
+  private[internal] final case class CommittedMarkerRef(sourceActor: ActorRef, commitTimeout: FiniteDuration)
+      extends CommittedMarker {
     override def committed(offsets: Map[TopicPartition, OffsetAndMetadata]): Future[Done] = {
       import akka.pattern.ask
       sourceActor
         .ask(Committed(offsets))(Timeout(commitTimeout))
-        .map(_ => Done)
+        .map(_ => Done)(ExecutionContexts.parasitic)
     }
 
     override def failed(): Unit =
@@ -376,12 +375,13 @@ private final class TransactionalSubSourceStageLogic[K, V](
 
   private val inFlightRecords = InFlightRecords.empty
 
+  lazy val committedMarker: CommittedMarker = CommittedMarkerRef(subSourceActor.ref, consumerSettings.commitTimeout)
+
+  override val fromPartitionedSource: Boolean = true
   override def groupId: String = consumerSettings.properties(ConsumerConfig.GROUP_ID_CONFIG)
 
   override def onMessage(rec: ConsumerRecord[K, V]): Unit =
     inFlightRecords.add(Map(new TopicPartition(rec.topic(), rec.partition()) -> rec.offset()))
-
-  override val fromPartitionedSource: Boolean = true
 
   override protected def messageHandling: PartialFunction[(ActorRef, Any), Unit] =
     super.messageHandling.orElse(drainHandling).orElse {
@@ -429,25 +429,17 @@ private final class TransactionalSubSourceStageLogic[K, V](
         log.debug(s"Draining partitions {}", partitions)
         materializer.scheduleOnce(
           consumerSettings.drainingCheckInterval,
-          new Runnable {
-            override def run(): Unit =
-              subSourceActor.ref.tell(Drain(partitions, ack.orElse(Some(sender)), msg), stageActor.ref)
-          }
+          () => subSourceActor.ref.tell(Drain(partitions, ack.orElse(Some(sender)), msg), stageActor.ref)
         )
       }
     case (sender, DrainingComplete) =>
       completeStage()
   }
 
-  lazy val committedMarker: CommittedMarker = {
-    val ec = materializer.executionContext
-    CommittedMarkerRef(subSourceActor.ref, consumerSettings.commitTimeout)(ec)
-  }
-
   def requestConsumerGroupMetadata(): Future[ConsumerGroupMetadata] = {
-    import akka.pattern.ask
     implicit val timeout: Timeout = 5.seconds // FIXME specific timeout config for this?
-    ask(consumerActor, KafkaConsumerActor.Internal.GetConsumerGroupMetadata)(timeout)
+    akka.pattern
+      .ask(consumerActor, KafkaConsumerActor.Internal.GetConsumerGroupMetadata)(timeout)
       .mapTo[ConsumerGroupMetadata]
   }
 

--- a/core/src/main/scala/akka/kafka/scaladsl/Transactional.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Transactional.scala
@@ -113,8 +113,8 @@ object Transactional {
 
   /**
    * Publish records to Kafka topics and then continue the flow. The flow can only be used with a [[Transactional.source]] that
-   * emits a [[ConsumerMessage.TransactionalMessage]]. The flow requires a unique `transactional.id` across all app
-   * instances.  The flow will override producer properties to enable Kafka exactly-once transactional support.
+   * emits a [[ConsumerMessage.TransactionalMessage]].
+   * The flow will override producer properties to enable Kafka exactly-once transactional support.
    */
   @nowarn("msg=deprecated")
   def flow[K, V](

--- a/core/src/main/scala/akka/kafka/scaladsl/Transactional.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Transactional.scala
@@ -22,6 +22,8 @@ import akka.{Done, NotUsed}
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.TopicPartition
 
+import java.util.UUID
+import scala.annotation.nowarn
 import scala.concurrent.Future
 
 /**
@@ -76,11 +78,21 @@ object Transactional {
    * Sink that is aware of the [[ConsumerMessage.TransactionalMessage.partitionOffset]] from a [[Transactional.source]].  It will
    * initialize, begin, produce, and commit the consumer offset as part of a transaction.
    */
+  @deprecated("Use the 'sink' factory method without a transactionalId parameter")
   def sink[K, V](
       settings: ProducerSettings[K, V],
       transactionalId: String
   ): Sink[Envelope[K, V, ConsumerMessage.PartitionOffset], Future[Done]] =
     flow(settings, transactionalId).toMat(Sink.ignore)(Keep.right)
+
+  /**
+   * Sink that is aware of the [[ConsumerMessage.TransactionalMessage.partitionOffset]] from a [[Transactional.source]].  It will
+   * initialize, begin, produce, and commit the consumer offset as part of a transaction.
+   */
+  def sink[K, V](
+      settings: ProducerSettings[K, V]
+  ): Sink[Envelope[K, V, ConsumerMessage.PartitionOffset], Future[Done]] =
+    flow(settings).toMat(Sink.ignore)(Keep.right)
 
   /**
    * API MAY CHANGE
@@ -90,10 +102,9 @@ object Transactional {
    */
   @ApiMayChange
   def sinkWithOffsetContext[K, V](
-      settings: ProducerSettings[K, V],
-      transactionalId: String
+      settings: ProducerSettings[K, V]
   ): Sink[(Envelope[K, V, NotUsed], PartitionOffset), Future[Done]] =
-    sink(settings, transactionalId)
+    sink(settings)
       .contramap {
         case (env, offset) =>
           env.withPassThrough(offset)
@@ -104,6 +115,18 @@ object Transactional {
    * emits a [[ConsumerMessage.TransactionalMessage]]. The flow requires a unique `transactional.id` across all app
    * instances.  The flow will override producer properties to enable Kafka exactly-once transactional support.
    */
+  @nowarn("msg=deprecation")
+  def flow[K, V](
+      settings: ProducerSettings[K, V]
+  ): Flow[Envelope[K, V, ConsumerMessage.PartitionOffset], Results[K, V, ConsumerMessage.PartitionOffset], NotUsed] =
+    flow(settings, UUID.randomUUID().toString)
+
+  /**
+   * Publish records to Kafka topics and then continue the flow. The flow can only be used with a [[Transactional.source]] that
+   * emits a [[ConsumerMessage.TransactionalMessage]]. The flow requires a unique `transactional.id` across all app
+   * instances.  The flow will override producer properties to enable Kafka exactly-once transactional support.
+   */
+  @deprecated("Use the 'flow' factory without a transactionalId parameter")
   def flow[K, V](
       settings: ProducerSettings[K, V],
       transactionalId: String
@@ -132,15 +155,14 @@ object Transactional {
    */
   @ApiMayChange
   def flowWithOffsetContext[K, V](
-      settings: ProducerSettings[K, V],
-      transactionalId: String
+      settings: ProducerSettings[K, V]
   ): FlowWithContext[Envelope[K, V, NotUsed],
                      ConsumerMessage.PartitionOffset,
                      Results[K, V, ConsumerMessage.PartitionOffset],
                      ConsumerMessage.PartitionOffset,
                      NotUsed] = {
     val noContext: Flow[Envelope[K, V, PartitionOffset], Results[K, V, PartitionOffset], NotUsed] =
-      flow(settings, transactionalId)
+      flow(settings)
     noContext
       .asFlowWithContext[Envelope[K, V, NotUsed], PartitionOffset, PartitionOffset]({
         case (env, c) => env.withPassThrough(c)

--- a/core/src/main/scala/akka/kafka/scaladsl/Transactional.scala
+++ b/core/src/main/scala/akka/kafka/scaladsl/Transactional.scala
@@ -78,6 +78,7 @@ object Transactional {
    * Sink that is aware of the [[ConsumerMessage.TransactionalMessage.partitionOffset]] from a [[Transactional.source]].  It will
    * initialize, begin, produce, and commit the consumer offset as part of a transaction.
    */
+  @nowarn("msg=deprecated")
   @deprecated("Use the 'sink' factory method without a transactionalId parameter")
   def sink[K, V](
       settings: ProducerSettings[K, V],
@@ -115,7 +116,7 @@ object Transactional {
    * emits a [[ConsumerMessage.TransactionalMessage]]. The flow requires a unique `transactional.id` across all app
    * instances.  The flow will override producer properties to enable Kafka exactly-once transactional support.
    */
-  @nowarn("msg=deprecation")
+  @nowarn("msg=deprecated")
   def flow[K, V](
       settings: ProducerSettings[K, V]
   ): Flow[Envelope[K, V, ConsumerMessage.PartitionOffset], Results[K, V, ConsumerMessage.PartitionOffset], NotUsed] =

--- a/docs/src/main/paradox/transactions.md
+++ b/docs/src/main/paradox/transactions.md
@@ -55,7 +55,7 @@ For more details see [KIP-447](https://cwiki.apache.org/confluence/display/KAFKA
 The @apidoc[Transactional.sink](Transactional$) is similar to the @apidoc[Producer.committableSink](Producer$) in that messages will be automatically committed as part of a transaction.  The @apidoc[Transactional.flow](Transactional$) or @apidoc[Transactional.sink](Transactional$) are required when connecting a consumer to a producer to achieve a transactional workflow.
 
 They override producer properties `enable.idempotence` to `true` and `max.in.flight.requests.per.connection` to `1` as required by the Kafka producer to enable transactions.
-The `transaction.timeout.ms` is set to 10s as recommended in KIP-447.
+The `transaction.timeout.ms` is set to 10s as recommended in [KIP-447](https://cwiki.apache.org/confluence/display/KAFKA/KIP-447%3A+Producer+scalability+for+exactly+once+semantics).
 
 ## Consume-Transform-Produce Workflow
 

--- a/docs/src/main/paradox/transactions.md
+++ b/docs/src/main/paradox/transactions.md
@@ -3,7 +3,7 @@ project.description: Alpakka has support for Kafka Transactions which provide gu
 ---
 # Transactions
 
-Kafka Transactions provide guarantees that messages processed in a consume-transform-produce workflow (consumed from a source topic, transformed, and produced to a destination topic) are processed exactly once or not at all.  This is achieved through coordination between the Kafka consumer group coordinator, transaction coordinator, and the consumer and producer clients used in the user application.  The Kafka producer marks messages that are consumed from the source topic as "committed" only once the transformed messages are successfully produced to the sink.  
+Kafka Transactions provide guarantees that messages processed in a consume-transform-produce workflow (consumed from a source topic, transformed, and produced to a destination topic) are processed exactly once or not at all.  This is achieved through coordination between the Kafka consumer group coordinator, transaction coordinator, and the consumer and producer clients used in the user application. The Kafka producer marks messages that are consumed from the source topic as "committed" only once the transformed messages are successfully produced to the sink.  
 
 For full details on how transactions are achieved in Kafka you may wish to review the Kafka Improvement Proposal [KIP-98: Exactly Once Delivery and Transactional Messaging](https://cwiki.apache.org/confluence/display/KAFKA/KIP-98+-+Exactly+Once+Delivery+and+Transactional+Messaging) and its associated [design document](https://docs.google.com/document/d/11Jqy_GjUGtdXJK94XGsEIK7CP1SnQGdp2eF0wSw9ra8/edit#heading=h.xq0ee1vnpz4o).   
 
@@ -55,18 +55,17 @@ For more details see [KIP-447](https://cwiki.apache.org/confluence/display/KAFKA
 The @apidoc[Transactional.sink](Transactional$) is similar to the @apidoc[Producer.committableSink](Producer$) in that messages will be automatically committed as part of a transaction.  The @apidoc[Transactional.flow](Transactional$) or @apidoc[Transactional.sink](Transactional$) are required when connecting a consumer to a producer to achieve a transactional workflow.
 
 They override producer properties `enable.idempotence` to `true` and `max.in.flight.requests.per.connection` to `1` as required by the Kafka producer to enable transactions.
-
-A `transactional.id` must be defined and unique for each instance of the application.
+The `transaction.timeout.ms` is set to 10s as recommended in KIP-447.
 
 ## Consume-Transform-Produce Workflow
 
-Kafka transactions are handled transparently to the user.  The @apidoc[Transactional.source](Transactional$) will enforce that a consumer group id is specified and the @apidoc[Transactional.flow](Transactional$) or @apidoc[Transactional.sink](Transactional$) will enforce that a `transactional.id` is specified.  All other Kafka consumer and producer properties required to enable transactions are overridden.
+Kafka transactions are handled transparently to the user.  The @apidoc[Transactional.source](Transactional$) will enforce that a consumer group id is specified. All other Kafka consumer and producer properties required to enable transactions are overridden.
 
 Transactions are committed on an interval which can be controlled with the producer config `akka.kafka.producer.eos-commit-interval`, similar to how exactly once works with Kafka Streams.  The default value is `100ms`.  The larger commit interval is the more records will need to be reprocessed in the event of failure and the transaction is aborted.
 
-When the stream is materialized the producer will initialize the transaction for the provided `transactional.id` and a transaction will begin.  Every commit interval (`eos-commit-interval`) we check if there are any offsets available to commit.  If offsets exist then we suspend backpressured demand while we drain all outstanding messages that have not yet been successfully acknowledged (if any) and then commit the transaction.  After the commit succeeds a new transaction is begun and we re-initialize demand for upstream messages.
+When the stream is materialized and the producer sees the first message it will initialize a transaction.  Every commit interval (`eos-commit-interval`) we check if there are any offsets available to commit.  If offsets exist then we suspend backpressured demand while we drain all outstanding messages that have not yet been successfully acknowledged (if any) and then commit the transaction.  After the commit succeeds a new transaction is begun and we re-initialize demand for upstream messages.
 
-Messages are also drained from the stream when the consumer gets a rebalance of partitions. In that case, the consumer will wait in the `onPartitionsRevoked` callback until all of the messages have been drained from the stream and the transaction is committed before allowing the rebalance to continue. The amount of total time the consumer will wait for draining is controlled by the `akka.kafka.consumer.commit-timeout`, and the interval between checks is controlled by the `akka.kafka.consuner.eos-draining-check-interval` configuration settings.
+Messages are also drained from the stream when the consumer gets a rebalance of partitions. In that case, the consumer will wait in the `onPartitionsRevoked` callback until all of the messages have been drained from the stream and the transaction is committed before allowing the rebalance to continue. The amount of total time the consumer will wait for draining is controlled by the `akka.kafka.consumer.commit-timeout`, and the interval between checks is controlled by the `akka.kafka.consumer.eos-draining-check-interval` configuration settings.
 
 To gracefully shutdown the stream and commit the current transaction you must call `shutdown()` on the @apidoc[(javadsl|scaladsl).Consumer.Control] materialized value to await all produced message acknowledgements and commit the final transaction.  
 
@@ -107,15 +106,13 @@ There are several scenarios that this library's implementation of Kafka transact
 
 All of the scenarios covered in the @ref[At-Least-Once Delivery documentation](atleastonce.md) (Multiple Effects per Commit, Non-Sequential Processing, and Conditional Message Processing) are applicable to transactional scenarios as well.
 
-Only one application instance per `transactional.id` is allowed.  If two application instances with the same `transactional.id` are run at the same time then the instance that registers with Kafka's transaction coordinator second will throw a @javadoc[ProducerFencedException](org.apache.kafka.common.errors.ProducerFencedException) so it doesn't interfere with transactions in process by the first instance.  To distribute multiple transactional workflows for the same subscription the user must manually subdivide the subscription across multiple instances of the application.  This may be handled internally in future versions.
-
 <!-- TODO: replace above with Transactional.partitionedSources is available
 When using `Transactional.source` only one application instance per `transactional.id` is allowed.  If two application instances with the same `transactional.id` are run at the same time then the instance that registers with Kafka's transaction coordinator second will throw a @javadoc[ProducerFencedException](org.apache.kafka.common.errors.ProducerFencedException) so it doesn't interfere with transactions in process by the first instance.  To distribute multiple transactional workflows for the same subscription you can use the @ref[Transactional Partitioned Source](#transactional-partitioned-source) `Transactional.partitionedSource`, which manages the `transactional.id` so that no producer fencing occurs.
 -->
 
 Any state in the transformation logic is not part of a transaction.  It's left to the user to rebuild state when applying stateful operations with transaction.  It's possible to encode state into messages produced to topics during a transaction.  For example you could produce messages to a topic that represents an event log as part of a transaction.  This event log can be replayed to reconstitute the correct state before the stateful stream resumes consuming again at startup.
 
-Any side effects that occur in the transformation logic is not part of a transaction (i.e. writes to an database).  
+Any side effects that occur in the transformation logic is not part of a transaction (i.e. writes to a database).  
 
 The exactly-once-semantics are guaranteed only when your flow consumes from and produces to the same Kafka cluster. Producing to partitions from a 3rd-party source or consuming partitions from one Kafka cluster and producing to another Kafka cluster are not supported.
 

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
@@ -72,11 +72,13 @@ trait KafkaTestKit {
   /**
    * Return a unique transactional id with a default suffix.
    */
+  @deprecated("Use flows and sinks that does not require an explicit transaction id")
   def createTransactionalId(): String = createTransactionalId(0)
 
   /**
    * Return a unique transactional id with a given suffix.
    */
+  @deprecated("Use flows and sinks that does not require an explicit transaction id")
   def createTransactionalId(suffix: Int): String = s"transactionalId-$suffix-${nextNumber()}"
 
   def system: ActorSystem

--- a/tests/src/it/scala/akka/kafka/TransactionsPartitionedSourceSpec.scala
+++ b/tests/src/it/scala/akka/kafka/TransactionsPartitionedSourceSpec.scala
@@ -59,7 +59,6 @@ class TransactionsPartitionedSourceSpec
       val sourceTopic = createTopic(1, sourcePartitions, replication)
       val sinkTopic = createTopic(2, destinationPartitions, replication)
       val group = createGroupId(1)
-      val transactionalId = createTransactionalId()
 
       val elements = 100 * 1000 // 100 * 1,000 = 100,000
       val restartAfter = (10 * 1000) / sourcePartitions // (10 * 1,000) / 10 = 100
@@ -76,7 +75,8 @@ class TransactionsPartitionedSourceSpec
       val completedCopy = new AtomicInteger(0)
       val completedWithTimeout = new AtomicInteger(0)
 
-      def runStream(id: String): UniqueKillSwitch =
+      def runStream(id: String): UniqueKillSwitch = {
+        val transactionalId = s"$group-$id"
         RestartSource
           .onFailuresWithBackoff(RestartSettings(10.millis, 100.millis, 0.2))(
             () => {
@@ -106,6 +106,7 @@ class TransactionsPartitionedSourceSpec
             case Failure(_) => // restart
           })(Keep.left)
           .run()
+      }
 
       val controls: Seq[UniqueKillSwitch] = (0 until consumers)
         .map(_.toString)

--- a/tests/src/it/scala/akka/kafka/TransactionsPartitionedSourceSpec.scala
+++ b/tests/src/it/scala/akka/kafka/TransactionsPartitionedSourceSpec.scala
@@ -76,7 +76,6 @@ class TransactionsPartitionedSourceSpec
       val completedWithTimeout = new AtomicInteger(0)
 
       def runStream(id: String): UniqueKillSwitch = {
-        val transactionalId = s"$group-$id"
         RestartSource
           .onFailuresWithBackoff(RestartSettings(10.millis, 100.millis, 0.2))(
             () => {
@@ -85,7 +84,6 @@ class TransactionsPartitionedSourceSpec
                 txProducerDefaults,
                 sourceTopic,
                 sinkTopic,
-                transactionalId,
                 idleTimeout = 10.seconds,
                 maxPartitions = sourcePartitions,
                 restartAfter = Some(restartAfter),

--- a/tests/src/it/scala/akka/kafka/TransactionsSourceSpec.scala
+++ b/tests/src/it/scala/akka/kafka/TransactionsSourceSpec.scala
@@ -169,7 +169,7 @@ class TransactionsSourceSpec
             .take(batchSize.toLong)
             .delay(3.seconds, strategy = DelayOverflowStrategy.backpressure)
             .addAttributes(Attributes.inputBuffer(10, maxBufferSize))
-            .via(Transactional.flow(producerDefaults, s"$group-$id"))
+            .via(Transactional.flow(producerDefaults))
             .map(_ => elementsWritten.incrementAndGet())
             .toMat(Sink.ignore)(Keep.left)
             .run()

--- a/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java
@@ -102,7 +102,6 @@ public class TransactionsExampleTest extends TestcontainersKafkaJunit4Test {
         consumerDefaults().withGroupId(createGroupId());
     String sourceTopic = createTopic(1);
     String targetTopic = createTopic(2);
-    String transactionalId = createTransactionalId();
     Consumer.DrainingControl<Done> control =
         Transactional.sourceWithOffsetContext(consumerSettings, Subscriptions.topics(sourceTopic))
             .via(business())
@@ -111,7 +110,7 @@ public class TransactionsExampleTest extends TestcontainersKafkaJunit4Test {
                     ProducerMessage.single(
                         new ProducerRecord<>(targetTopic, record.key(), record.value())))
             .toMat(
-                Transactional.sinkWithOffsetContext(producerSettings, transactionalId),
+                Transactional.sinkWithOffsetContext(producerSettings),
                 Consumer::createDrainingControl)
             .run(system);
 
@@ -131,7 +130,6 @@ public class TransactionsExampleTest extends TestcontainersKafkaJunit4Test {
         consumerDefaults().withGroupId(createGroupId());
     String sourceTopic = createTopic(1);
     String targetTopic = createTopic(2);
-    String transactionalId = createTransactionalId();
     // #transactionalFailureRetry
     AtomicReference<Consumer.Control> innerControl =
         new AtomicReference<>(Consumer.createNoopControl());
@@ -159,7 +157,7 @@ public class TransactionsExampleTest extends TestcontainersKafkaJunit4Test {
                               innerControl.set(control);
                               return control;
                             })
-                        .via(Transactional.flow(producerSettings, transactionalId)));
+                        .via(Transactional.flow(producerSettings)));
 
     CompletionStage<Done> streamCompletion = stream.runWith(Sink.ignore(), system);
 

--- a/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java
@@ -75,9 +75,7 @@ public class TransactionsExampleTest extends TestcontainersKafkaJunit4Test {
                     ProducerMessage.single(
                         new ProducerRecord<>(targetTopic, msg.record().key(), msg.record().value()),
                         msg.partitionOffset()))
-            .toMat(
-                Transactional.sink(producerSettings),
-                Consumer::createDrainingControl)
+            .toMat(Transactional.sink(producerSettings), Consumer::createDrainingControl)
             .run(system);
 
     // ...

--- a/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java
+++ b/tests/src/test/java/docs/javadsl/TransactionsExampleTest.java
@@ -66,7 +66,6 @@ public class TransactionsExampleTest extends TestcontainersKafkaJunit4Test {
         consumerDefaults().withGroupId(createGroupId());
     String sourceTopic = createTopic(1);
     String targetTopic = createTopic(2);
-    String transactionalId = createTransactionalId();
     // #transactionalSink
     Consumer.DrainingControl<Done> control =
         Transactional.source(consumerSettings, Subscriptions.topics(sourceTopic))
@@ -77,7 +76,7 @@ public class TransactionsExampleTest extends TestcontainersKafkaJunit4Test {
                         new ProducerRecord<>(targetTopic, msg.record().key(), msg.record().value()),
                         msg.partitionOffset()))
             .toMat(
-                Transactional.sink(producerSettings, transactionalId),
+                Transactional.sink(producerSettings),
                 Consumer::createDrainingControl)
             .run(system);
 

--- a/tests/src/test/scala/akka/kafka/TransactionsOps.scala
+++ b/tests/src/test/scala/akka/kafka/TransactionsOps.scala
@@ -58,7 +58,6 @@ trait TransactionsOps extends TestSuite with Matchers {
       producerSettings: ProducerSettings[String, String],
       sourceTopic: String,
       sinkTopic: String,
-      transactionalId: String,
       idleTimeout: FiniteDuration,
       maxPartitions: Int,
       restartAfter: Option[Int] = None,
@@ -85,7 +84,7 @@ trait TransactionsOps extends TestSuite with Matchers {
                                                                           msg.record.value),
                                        msg.partitionOffset)
               }
-              .via(Transactional.flow(producerSettings, transactionalId))
+              .via(Transactional.flow(producerSettings))
             results
         }
       )

--- a/tests/src/test/scala/akka/kafka/TransactionsOps.scala
+++ b/tests/src/test/scala/akka/kafka/TransactionsOps.scala
@@ -31,7 +31,6 @@ trait TransactionsOps extends TestSuite with Matchers {
       producerSettings: ProducerSettings[String, String],
       sourceTopic: String,
       sinkTopic: String,
-      transactionalId: String,
       idleTimeout: FiniteDuration,
       restartAfter: Option[Int] = None,
       maxRestarts: Option[AtomicInteger] = None
@@ -49,7 +48,7 @@ trait TransactionsOps extends TestSuite with Matchers {
       .map { msg =>
         ProducerMessage.single(new ProducerRecord[String, String](sinkTopic, msg.record.value), msg.partitionOffset)
       }
-      .via(Transactional.flow(producerSettings, transactionalId))
+      .via(Transactional.flow(producerSettings))
 
   /**
    * Copy messages from a source to sink topic. Source and sink must have exactly the same number of partitions.
@@ -196,7 +195,7 @@ trait TransactionsOps extends TestSuite with Matchers {
     val expectedValues: immutable.Seq[String] = (1 to elements).map(_.toString)
 
     for (partition <- 0 until maxPartitions) {
-      println(s"Asserting values for partition: $partition")
+      // println(s"Asserting values for partition: $partition")
 
       val partitionMessages: immutable.Seq[String] =
         values.filter(_._1 == partition).map { case (_, _, value) => value }

--- a/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
@@ -76,7 +76,7 @@ class ProducerSpec(_system: ActorSystem)
   def toMessage(tuple: (Record, RecordMetadata)) = Message(tuple._1, NotUsed)
   private[kafka] def toTxMessage(tuple: (Record, RecordMetadata), committer: CommittedMarker) = {
     val consumerMessage = ConsumerMessage
-      .PartitionOffset(GroupTopicPartition(group, tuple._1.topic(), 1), tuple._2.offset())
+      .PartitionOffset(GroupTopicPartition(ProducerSpec.group, tuple._1.topic(), 1), tuple._2.offset())
     val partitionOffsetCommittedMarker =
       PartitionOffsetCommittedMarker(consumerMessage.key,
                                      consumerMessage.offset,

--- a/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
@@ -83,7 +83,7 @@ class ProducerSpec(_system: ActorSystem)
                                      consumerMessage.offset,
                                      committer,
                                      fromPartitionedSource = false,
-        () => Future.successful(consumerGroupMetadata))
+                                     () => Future.successful(consumerGroupMetadata))
     ProducerMessage.Message(
       tuple._1,
       partitionOffsetCommittedMarker

--- a/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
@@ -50,7 +50,6 @@ class ProducerSpec(_system: ActorSystem)
     with Matchers
     with BeforeAndAfterAll
     with LogCapturing {
-  import ProducerSpec._
 
   def this() =
     this(
@@ -83,7 +82,7 @@ class ProducerSpec(_system: ActorSystem)
                                      consumerMessage.offset,
                                      committer,
                                      fromPartitionedSource = false,
-                                     () => Future.successful(consumerGroupMetadata))
+                                     () => Future.successful(ProducerSpec.consumerGroupMetadata))
     ProducerMessage.Message(
       tuple._1,
       partitionOffsetCommittedMarker

--- a/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
@@ -73,7 +73,7 @@ class TransactionsSpec extends SpecBase with TestcontainersKafkaLike with Transa
             ProducerMessage.single(new ProducerRecord(sinkTopic, msg.record.key, msg.record.value), msg.partitionOffset)
           }
         }
-        .via(Transactional.flow(producerDefaults, group))
+        .via(Transactional.flow(producerDefaults))
         .toMat(Sink.ignore)(Keep.left)
         .run()
 
@@ -262,7 +262,7 @@ class TransactionsSpec extends SpecBase with TestcontainersKafkaLike with Transa
               msgs.map(_.partitionOffset).maxBy(_.offset)
             )
           }
-          .via(Transactional.flow(producerDefaults, group))
+          .via(Transactional.flow(producerDefaults))
           .toMat(Sink.ignore)(Keep.left)
           .run()
       }

--- a/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
@@ -29,7 +29,6 @@ class TransactionsExample extends DocsSpecBase with TestcontainersKafkaLike with
     val producerSettings = txProducerDefaults
     val sourceTopic = createTopic(1)
     val sinkTopic = createTopic(2)
-    val transactionalId = createTransactionalId()
     // #transactionalSink
     val control =
       Transactional
@@ -38,7 +37,7 @@ class TransactionsExample extends DocsSpecBase with TestcontainersKafkaLike with
         .map { msg =>
           ProducerMessage.single(new ProducerRecord(sinkTopic, msg.record.key, msg.record.value), msg.partitionOffset)
         }
-        .toMat(Transactional.sink(producerSettings, transactionalId))(DrainingControl.apply)
+        .toMat(Transactional.sink(producerSettings))(DrainingControl.apply)
         .run()
 
     // ...
@@ -91,7 +90,6 @@ class TransactionsExample extends DocsSpecBase with TestcontainersKafkaLike with
     val producerSettings = txProducerDefaults
     val sourceTopic = createTopic(1)
     val sinkTopic = createTopic(2)
-    val transactionalId = createTransactionalId()
     // #transactionalFailureRetry
     val innerControl = new AtomicReference[Control](Consumer.NoopControl)
 
@@ -110,7 +108,7 @@ class TransactionsExample extends DocsSpecBase with TestcontainersKafkaLike with
         }
         // side effect out the `Control` materialized value because it can't be propagated through the `RestartSource`
         .mapMaterializedValue(c => innerControl.set(c))
-        .via(Transactional.flow(producerSettings, transactionalId))
+        .via(Transactional.flow(producerSettings))
     }
 
     stream.runWith(Sink.ignore)

--- a/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
+++ b/tests/src/test/scala/docs/scaladsl/TransactionsExample.scala
@@ -71,7 +71,7 @@ class TransactionsExample extends DocsSpecBase with TestcontainersKafkaLike with
         .map { record =>
           ProducerMessage.single(new ProducerRecord(sinkTopic, record.key, record.value))
         }
-        .toMat(Transactional.sinkWithOffsetContext(producerSettings, createTransactionalId()))(DrainingControl.apply)
+        .toMat(Transactional.sinkWithOffsetContext(producerSettings))(DrainingControl.apply)
         .run()
 
     val testConsumerGroup = createGroupId(2)


### PR DESCRIPTION
This uses the new APIs added for KIP447 to pass the right consumer group metadata along when committing the transaction. This should avoid the need to use any specific scheme for the transaction id other than making sure it is unique per consumer-producer stream (so could be a UUID for example)