### PR TITLE
fix: thread safe partition assignment handler

### DIFF
--- a/core/src/main/scala/akka/kafka/internal/SourceLogicSubscription.scala
+++ b/core/src/main/scala/akka/kafka/internal/SourceLogicSubscription.scala
@@ -68,6 +68,8 @@ private[kafka] trait SourceLogicSubscription {
 
   /**
    * Opportunity for subclasses to add a different logic to the partition assignment callbacks.
+   *
+   * Note: called from consumer actor, returned handler must be thread safe
    */
   protected def addToPartitionAssignmentHandler(handler: PartitionAssignmentHandler): PartitionAssignmentHandler =
     handler

--- a/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
+++ b/core/src/main/scala/akka/kafka/internal/SubSourceLogic.scala
@@ -305,12 +305,14 @@ private class SubSourceLogic[K, V, Msg](
       override def onAssign(assignedTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit =
         for {
           tp <- lastRevoked -- assignedTps
+          // FIXME subSources is mutable internal state of logic, this is not thread safe
           control <- subSources.get(tp)
         } control.filterRevokedPartitionsCB.invoke(Set(tp))
 
       override def onLost(lostTps: Set[TopicPartition], consumer: RestrictedConsumer): Unit =
         for {
           tp <- lostTps
+          // FIXME subSources is mutable internal state of logic, this is not thread safe
           control <- subSources.get(tp)
         } control.filterRevokedPartitionsCB.invoke(Set(tp))
 

--- a/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
@@ -257,6 +257,10 @@ private final class TransactionalProducerStageLogic[K, V, P](
 
   override def onCompletionFailure(ex: Throwable): Unit = {
     abortTransaction(s"Stage failure ($ex)")
+    if (commitInProgress)
+      log.warning(
+        "Stage onCompleteFailure with commit in flight"
+      )
     batchOffsets.committingFailed()
     super.onCompletionFailure(ex)
   }


### PR DESCRIPTION
Additional fixes/cleanup on top of #1728 

Doesn't pass TransactionsSourceSpec though, I think, but have not verified, that the consumer actor shuts down too early.