### PR TITLE
fix: push based consumer group metadata

### DIFF
--- a/core/src/main/mima-filters/5.0.0.backwards.excludes
+++ b/core/src/main/mima-filters/5.0.0.backwards.excludes
@@ -6,3 +6,4 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.scaladsl.Transact
 
 # internal
 ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.ProducerSettings.this")
+ProblemFilters.exclude[DirectMissingMethodProblem]("akka.kafka.ConsumerSettings.this")

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -89,6 +89,11 @@ akka.kafka.consumer {
   # If commits take longer than this time a warning is logged
   commit-time-warning = 1s
 
+  # For transactional flows only, how often to push consumer group metadata to the producers
+  # a shorter interval makes the risk of dropping batched elements smaller but at the cost
+  # of more work sending those updates
+  consumer-group-update-interval = 100ms
+
   # Not relevant for Kafka after version 2.1.0.
   # If set to a finite duration, the consumer will re-send the last committed offsets periodically
   # for all assigned partitions. See https://issues.apache.org/jira/browse/KAFKA-4682.

--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -8,6 +8,7 @@ package akka.kafka
 import java.util.Objects
 import java.util.concurrent.CompletionStage
 import akka.Done
+import akka.actor.ActorRef
 import akka.annotation.{DoNotInherit, InternalApi}
 import akka.kafka.internal.{CommittableOffsetBatchImpl, CommittedMarker}
 import org.apache.kafka.clients.consumer.{ConsumerGroupMetadata, ConsumerRecord}
@@ -133,7 +134,7 @@ object ConsumerMessage {
       override val offset: Long,
       private[kafka] val committedMarker: CommittedMarker,
       private[kafka] val fromPartitionedSource: Boolean,
-      requestConsumerGroupMetadata: () => Future[ConsumerGroupMetadata]
+      consumerActor: ActorRef
   ) extends PartitionOffset(key, offset)
 
   /**

--- a/core/src/main/scala/akka/kafka/internal/DefaultProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/DefaultProducerStage.scala
@@ -83,7 +83,7 @@ private class DefaultProducerStageLogic[K, V, P, IN <: Envelope[K, V, P], OUT <:
       }
     }
 
-  override def onCompletionSuccess(): Unit = if (readyToShutdown()) completeStage()
+  override def onCompletionSuccess(): Unit = completeStage()
 
   override def onCompletionFailure(ex: Throwable): Unit = failStage(ex)
 
@@ -209,8 +209,4 @@ private class DefaultProducerStageLogic[K, V, P, IN <: Envelope[K, V, P], OUT <:
     log.debug("ProducerStage postStop")
     closeProducer()
   }
-
-  // Specifically for transactional producer that needs to defer shutdown to let an async task
-  // complete before actually shutting down
-  protected def readyToShutdown(): Boolean = true
 }

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -303,7 +303,7 @@ import scala.util.control.NonFatal
 
     case SubscribeToGroupMetaData(subscriber) =>
       if (metadataSubscribers.isEmpty)
-        timers.startTimerAtFixedRate(GroupMetadataTick, GroupMetadataTick, 100.millis) // FIXME configurable interval?
+        timers.startTimerAtFixedRate(GroupMetadataTick, GroupMetadataTick, _settings.consumerGroupUpdateInterval)
       metadataSubscribers += subscriber
       subscriber ! consumer.groupMetadata()
 

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -308,7 +308,7 @@ import scala.util.control.NonFatal
       subscriber ! consumer.groupMetadata()
 
     case GroupMetadataTick =>
-     sendConsumerGroupMetadataToSubscribers()
+      sendConsumerGroupMetadataToSubscribers()
 
     case req: Metadata.Request =>
       sender() ! handleMetadataRequest(req)

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -74,8 +74,9 @@ import scala.util.control.NonFatal
     final case class CommitSingle(tp: TopicPartition, offsetAndMetadata: OffsetAndMetadata)
         extends NoSerializationVerificationNeeded
 
-    // Used for transactions/EOS returns the current ConsumerGroupMetadata
-    case object GetConsumerGroupMetadata extends NoSerializationVerificationNeeded
+    // Used for transactions/EOS periodically and when needed, pushes the current ConsumerGroupMetadata to the subscriber (producer stage)
+    case class SubscribeToGroupMetaData(subscriber: ActorRef) extends NoSerializationVerificationNeeded
+    case object GroupMetadataTick extends NoSerializationVerificationNeeded
 
     //responses
     final case class Assigned(partition: List[TopicPartition]) extends NoSerializationVerificationNeeded
@@ -209,6 +210,8 @@ import scala.util.control.NonFatal
   private var resetProtection: ConsumerResetProtection = _
   private var stopInProgress = false
 
+  private var metadataSubscribers = Set.empty[ActorRef]
+
   /**
    * Collect commit offset maps until the next poll.
    */
@@ -298,11 +301,22 @@ import scala.util.control.NonFatal
       stageActorsMap = stageActorsMap.filterNot(_._2 == ref)
       requests -= ref
 
-    case GetConsumerGroupMetadata =>
-      sender() ! consumer.groupMetadata()
+    case SubscribeToGroupMetaData(subscriber) =>
+      if (metadataSubscribers.isEmpty)
+        timers.startTimerAtFixedRate(GroupMetadataTick, GroupMetadataTick, 100.millis) // FIXME configurable interval?
+      metadataSubscribers += subscriber
+      subscriber ! consumer.groupMetadata()
+
+    case GroupMetadataTick =>
+     sendConsumerGroupMetadataToSubscribers()
 
     case req: Metadata.Request =>
       sender() ! handleMetadataRequest(req)
+  }
+
+  private def sendConsumerGroupMetadataToSubscribers(): Unit = {
+    val metaData = consumer.groupMetadata()
+    metadataSubscribers.foreach(_ ! metaData)
   }
 
   def expectSettings: Receive = LoggingReceive.withLabel("expectSettings") {
@@ -788,6 +802,7 @@ import scala.util.control.NonFatal
     override def onPartitionsRevoked(partitions: java.util.Collection[TopicPartition]): Unit = {
       val revokedTps = partitions.asScala.toSet
       val startTime = System.nanoTime()
+      updateGroupMetadataSubscribers()
       partitionAssignmentHandler.onRevoke(revokedTps, restrictedConsumer)
       checkDuration(startTime, "onRevoke")
       progressTracker.revoke(revokedTps)
@@ -796,6 +811,7 @@ import scala.util.control.NonFatal
     override def onPartitionsLost(partitions: java.util.Collection[TopicPartition]): Unit = {
       val lostTps = partitions.asScala.toSet
       val startTime = System.nanoTime()
+      updateGroupMetadataSubscribers()
       partitionAssignmentHandler.onLost(lostTps, restrictedConsumer)
       checkDuration(startTime, "onLost")
       progressTracker.revoke(lostTps)
@@ -805,6 +821,7 @@ import scala.util.control.NonFatal
       val currentTps = consumer.assignment()
       consumer.pause(currentTps)
       val startTime = System.nanoTime()
+      updateGroupMetadataSubscribers()
       partitionAssignmentHandler.onStop(currentTps.asScala.toSet, restrictedConsumer)
       checkDuration(startTime, "onStop")
     }
@@ -815,6 +832,12 @@ import scala.util.control.NonFatal
         log.warning("Partition assignment handler `{}` took longer than `partition-handler-warning`: {} ms",
                     method,
                     duration / 1000000L)
+      }
+    }
+
+    def updateGroupMetadataSubscribers(): Unit = {
+      if (metadataSubscribers.nonEmpty) {
+        sendConsumerGroupMetadataToSubscribers()
       }
     }
   }

--- a/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
+++ b/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
@@ -9,7 +9,13 @@ import akka.Done
 import akka.actor.ActorRef
 import akka.annotation.InternalApi
 import akka.kafka.ConsumerMessage
-import akka.kafka.ConsumerMessage.{CommittableMessage, CommittableOffsetMetadata, GroupTopicPartition, TransactionalMessage, _}
+import akka.kafka.ConsumerMessage.{
+  CommittableMessage,
+  CommittableOffsetMetadata,
+  GroupTopicPartition,
+  TransactionalMessage,
+  _
+}
 import org.apache.kafka.clients.consumer.{ConsumerRecord, OffsetAndMetadata}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.requests.OffsetFetchResponse

--- a/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
+++ b/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
@@ -6,16 +6,11 @@
 package akka.kafka.internal
 import java.util.concurrent.CompletionStage
 import akka.Done
+import akka.actor.ActorRef
 import akka.annotation.InternalApi
 import akka.kafka.ConsumerMessage
-import akka.kafka.ConsumerMessage.{
-  CommittableMessage,
-  CommittableOffsetMetadata,
-  GroupTopicPartition,
-  TransactionalMessage,
-  _
-}
-import org.apache.kafka.clients.consumer.{ConsumerGroupMetadata, ConsumerRecord, OffsetAndMetadata}
+import akka.kafka.ConsumerMessage.{CommittableMessage, CommittableOffsetMetadata, GroupTopicPartition, TransactionalMessage, _}
+import org.apache.kafka.clients.consumer.{ConsumerRecord, OffsetAndMetadata}
 import org.apache.kafka.common.TopicPartition
 import org.apache.kafka.common.requests.OffsetFetchResponse
 
@@ -46,7 +41,7 @@ private[kafka] trait TransactionalMessageBuilderBase[K, V, Msg] extends MessageB
 
   def fromPartitionedSource: Boolean
 
-  def requestConsumerGroupMetadata(): Future[ConsumerGroupMetadata]
+  def consumerActorRef(): ActorRef
 }
 
 /** Internal API */
@@ -64,7 +59,7 @@ private[kafka] trait TransactionalMessageBuilder[K, V]
       offset = rec.offset,
       committedMarker,
       fromPartitionedSource,
-      requestConsumerGroupMetadata _
+      consumerActorRef()
     )
     ConsumerMessage.TransactionalMessage(rec, offset)
   }
@@ -85,7 +80,7 @@ private[kafka] trait TransactionalOffsetContextBuilder[K, V]
       offset = rec.offset,
       committedMarker,
       fromPartitionedSource,
-      requestConsumerGroupMetadata _
+      consumerActorRef()
     )
     (rec, offset)
   }

--- a/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
@@ -186,22 +186,22 @@ private final class TransactionalProducerStageLogic[K, V, P](
     }
 
   private def commitTransaction(beginNewTransaction: Boolean = true,
-                                     abortEmptyTransactionOnComplete: Boolean = false): Unit = {
+                                abortEmptyTransactionOnComplete: Boolean = false): Unit = {
     val awaitingConf = awaitingConfirmationValue
     batchOffsets match {
       case batch: NonemptyTransactionBatch if awaitingConf == 0 =>
         try {
           log.debug("Committing transaction for transactional id '{}' consumer group '{}' with offsets: {}",
-            transactionalId,
-            latestSeenConsumerGroupMetadata,
-            batch.offsets)
+                    transactionalId,
+                    latestSeenConsumerGroupMetadata,
+                    batch.offsets)
           val offsetMap = batch.offsetMap()
           producer.sendOffsetsToTransaction(offsetMap.asJava, latestSeenConsumerGroupMetadata)
           producer.commitTransaction()
           log.debug("Committed transaction for transactional id '{}' consumer group '{}' with offsets: {}",
-            transactionalId,
-            latestSeenConsumerGroupMetadata,
-            batch.offsets)
+                    transactionalId,
+                    latestSeenConsumerGroupMetadata,
+                    batch.offsets)
           batchOffsets = TransactionBatch.empty
           batch
             .internalCommit()

--- a/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
@@ -6,6 +6,8 @@
 package akka.kafka.internal
 
 import akka.Done
+import akka.actor.ActorRef
+import akka.actor.Terminated
 import akka.annotation.InternalApi
 import akka.dispatch.{Dispatchers, ExecutionContexts}
 import akka.kafka.ConsumerMessage.{GroupTopicPartition, PartitionOffsetCommittedMarker}
@@ -17,7 +19,9 @@ import akka.stream.stage._
 import akka.stream.{Attributes, FlowShape}
 import org.apache.kafka.clients.consumer.{ConsumerGroupMetadata, OffsetAndMetadata}
 import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.KafkaException
 import org.apache.kafka.common.TopicPartition
+import org.apache.kafka.common.errors.ProducerFencedException
 
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
@@ -117,12 +121,10 @@ private final class TransactionalProducerStageLogic[K, V, P](
   private val messageDrainInterval = 10.milliseconds
   private var batchOffsets = TransactionBatch.empty
   private var demandSuspended = false
-  private var commitInProgress = false
+  private var latestSeenConsumerGroupMetadata: ConsumerGroupMetadata = null
 
   private var firstMessage: Option[Envelope[K, V, P]] = None
-
-  private val commitTransactionCB: Try[CommitTransaction] => Unit =
-    createAsyncCallback[Try[CommitTransaction]](commitTransaction _).invoke _
+  private var waitingForLastCommitAck = false
 
   private val onInternalCommitAckCb: Try[Done] => Unit =
     getAsyncCallback[Try[Done]] { maybeDone =>
@@ -130,14 +132,21 @@ private final class TransactionalProducerStageLogic[K, V, P](
         case Failure(ex) => log.debug("Internal commit failed: {}", ex)
         case _ =>
       }
-      scheduleOnce(commitSchedulerKey, producerSettings.eosCommitInterval)
+      if (waitingForLastCommitAck) completeStage()
+      else scheduleOnce(commitSchedulerKey, producerSettings.eosCommitInterval)
     }.invoke _
 
   override protected def logSource: Class[_] = classOf[TransactionalProducerStage[_, _, _]]
 
-  // FIXME no longer true
-  // we need to peek at the first message to generate the producer transactional id for partitioned sources
-  override def preStart(): Unit = resumeDemand()
+  override def preStart(): Unit = {
+    resumeDemand()
+    getStageActor {
+      case (_, newMetadata: ConsumerGroupMetadata) => latestSeenConsumerGroupMetadata = newMetadata
+      case (_, Terminated(_)) =>
+        abortTransaction("Consumer actor stopped")
+        failStage(new RuntimeException("Consumer actor stopped, no transactions can be committed without consumer"))
+    }
+  }
 
   override protected def producerAssigned(): Unit = {
     producingInHandler()
@@ -173,25 +182,44 @@ private final class TransactionalProducerStageLogic[K, V, P](
 
   override protected def onTimer(timerKey: Any): Unit =
     if (timerKey == commitSchedulerKey) {
-      maybeCommitTransaction()
+      commitTransaction()
     }
 
-  private def maybeCommitTransaction(beginNewTransaction: Boolean = true,
+  private def commitTransaction(beginNewTransaction: Boolean = true,
                                      abortEmptyTransactionOnComplete: Boolean = false): Unit = {
     val awaitingConf = awaitingConfirmationValue
     batchOffsets match {
       case batch: NonemptyTransactionBatch if awaitingConf == 0 =>
-        if (commitInProgress) {
-          // batch will end up in next commit
-          log.debug("Commit already in progress, ignoring request to commit")
-        } else {
-          commitInProgress = true
-          batch.head
-            .requestConsumerGroupMetadata()
-            .onComplete { consumerGroupMetadataTry =>
-              commitTransactionCB(consumerGroupMetadataTry.map(CommitTransaction(batch, beginNewTransaction, _)))
-            }(ExecutionContexts.parasitic)
+        try {
+          log.debug("Committing transaction for transactional id '{}' consumer group '{}' with offsets: {}",
+            transactionalId,
+            latestSeenConsumerGroupMetadata,
+            batch.offsets)
+          val offsetMap = batch.offsetMap()
+          producer.sendOffsetsToTransaction(offsetMap.asJava, latestSeenConsumerGroupMetadata)
+          producer.commitTransaction()
+          log.debug("Committed transaction for transactional id '{}' consumer group '{}' with offsets: {}",
+            transactionalId,
+            latestSeenConsumerGroupMetadata,
+            batch.offsets)
+          batchOffsets = TransactionBatch.empty
+          batch
+            .internalCommit()
+            .onComplete(onInternalCommitAckCb)(ExecutionContexts.parasitic)
+        } catch {
+          case e: ProducerFencedException =>
+            log.debug(s"Producer fenced: $e")
+            failStage(e)
+          case e: KafkaException =>
+            abortTransaction(s"Kafka threw exception: $e")
+            batch
+              .committingFailed()
         }
+        if (beginNewTransaction) {
+          beginTransaction()
+          resumeDemand()
+        }
+
       case _: EmptyTransactionBatch if awaitingConf == 0 && abortEmptyTransactionOnComplete =>
         abortTransaction("Transaction is empty and stage is completing")
       case _ if awaitingConf > 0 =>
@@ -203,9 +231,9 @@ private final class TransactionalProducerStageLogic[K, V, P](
   }
 
   /**
-   * When using partitioned sources we extract the transactional id, group id, and topic partition information from
-   * the first message in order to define a `transacitonal.id` before constructing the [[org.apache.kafka.clients.producer.KafkaProducer]]
-   * FIXME this is probably no longer true
+   * When using partitioned sources we need to have access to the ConsumerGroupMetadata from the Kafka consumer which
+   * is single thread-only, so we can't access it directly, instead we need to subscribe to get periodic updates of
+   * the latest consumer group metadata, we can only do that once the first message arrives
    */
   private def parseFirstMessage(msg: Envelope[K, V, P]): Boolean =
     producerAssignmentLifecycle match {
@@ -216,6 +244,16 @@ private final class TransactionalProducerStageLogic[K, V, P](
       case Unassigned =>
         // stash the first message so it can be sent after the producer is assigned
         firstMessage = Some(msg)
+
+        // Set up getting periodic group metadata as those can't be safely async-request fetched
+        // during partition rebalance drain which blocks the consumer actor
+        msg.passThrough match {
+          case o: ConsumerMessage.PartitionOffsetCommittedMarker =>
+            o.consumerActor ! KafkaConsumerActor.Internal.SubscribeToGroupMetaData(stageActor.ref)
+            // We depend on consumer actor now so couple lifecycles
+            stageActor.watch(o.consumerActor)
+          case _ =>
+        }
         // initiate async async producer request _after_ first message is stashed in case future eagerly resolves
         // instead of asynccallback
         resolveProducer(generatedTransactionalConfig)
@@ -246,12 +284,8 @@ private final class TransactionalProducerStageLogic[K, V, P](
 
   override def onCompletionSuccess(): Unit = {
     log.debug("Committing final transaction before shutdown")
-    if (commitInProgress)
-      log.warning(
-        "Stage onCompleteSuccess with commit in flight, this is a bug, please report at https://github.com/akka/alpakka-kafka/issues"
-      )
     cancelTimer(commitSchedulerKey)
-    maybeCommitTransaction(beginNewTransaction = false, abortEmptyTransactionOnComplete = true)
+    commitTransaction(beginNewTransaction = false, abortEmptyTransactionOnComplete = true)
     super.onCompletionSuccess()
   }
 
@@ -259,36 +293,6 @@ private final class TransactionalProducerStageLogic[K, V, P](
     abortTransaction(s"Stage failure ($ex)")
     batchOffsets.committingFailed()
     super.onCompletionFailure(ex)
-  }
-
-  private def commitTransaction(t: Try[CommitTransaction]): Unit = {
-    commitInProgress = false
-    t match {
-      case Failure(ex) =>
-        failStage(new RuntimeException("Failed to fetch consumer group metadata", ex))
-      case Success(CommitTransaction(batch, beginNewTransaction, consumerGroupMetadata)) =>
-        log.debug("Committing transaction for transactional id '{}' consumer group '{}' with offsets: {}",
-                  transactionalId,
-                  consumerGroupMetadata,
-                  batch.offsets)
-        val offsetMap = batch.offsetMap()
-        producer.sendOffsetsToTransaction(offsetMap.asJava, consumerGroupMetadata)
-        producer.commitTransaction()
-        log.debug("Committed transaction for transactional id '{}' consumer group '{}' with offsets: {}",
-                  transactionalId,
-                  consumerGroupMetadata,
-                  batch.offsets)
-        batchOffsets = TransactionBatch.empty
-        batch
-          .internalCommit()
-          .onComplete(onInternalCommitAckCb)(ExecutionContexts.parasitic)
-        if (beginNewTransaction) {
-          beginTransaction()
-          resumeDemand()
-        }
-    }
-    // in case stage wants to shut down but was waiting for commit to complete
-    checkForCompletion()
   }
 
   private def initTransactions(): Unit = {
@@ -304,15 +308,7 @@ private final class TransactionalProducerStageLogic[K, V, P](
   private def abortTransaction(reason: String): Unit = {
     log.debug("Aborting transaction: {}", reason)
     if (producerAssignmentLifecycle == Assigned) producer.abortTransaction()
+    batchOffsets.committingFailed()
   }
 
-  override protected def readyToShutdown(): Boolean = !commitInProgress
-
-  override def postStop(): Unit = {
-    if (commitInProgress)
-      log.warning(
-        "Stage postStop with commit in flight, this is a bug, please report at https://github.com/akka/alpakka-kafka/issues"
-      )
-    super.postStop()
-  }
 }

--- a/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
@@ -124,7 +124,6 @@ private final class TransactionalProducerStageLogic[K, V, P](
   private var latestSeenConsumerGroupMetadata: ConsumerGroupMetadata = null
 
   private var firstMessage: Option[Envelope[K, V, P]] = None
-  private var waitingForLastCommitAck = false
 
   private val onInternalCommitAckCb: Try[Done] => Unit =
     getAsyncCallback[Try[Done]] { maybeDone =>
@@ -132,8 +131,7 @@ private final class TransactionalProducerStageLogic[K, V, P](
         case Failure(ex) => log.debug("Internal commit failed: {}", ex)
         case _ =>
       }
-      if (waitingForLastCommitAck) completeStage()
-      else scheduleOnce(commitSchedulerKey, producerSettings.eosCommitInterval)
+      scheduleOnce(commitSchedulerKey, producerSettings.eosCommitInterval)
     }.invoke _
 
   override protected def logSource: Class[_] = classOf[TransactionalProducerStage[_, _, _]]

--- a/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
@@ -82,7 +82,7 @@ class ProducerSpec(_system: ActorSystem)
                                      consumerMessage.offset,
                                      committer,
                                      fromPartitionedSource = false,
-                                     () => Future.successful(ProducerSpec.consumerGroupMetadata))
+        system.deadLetters)
     ProducerMessage.Message(
       tuple._1,
       partitionOffsetCommittedMarker

--- a/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
@@ -82,7 +82,7 @@ class ProducerSpec(_system: ActorSystem)
                                      consumerMessage.offset,
                                      committer,
                                      fromPartitionedSource = false,
-        system.deadLetters)
+                                     system.deadLetters)
     ProducerMessage.Message(
       tuple._1,
       partitionOffsetCommittedMarker

--- a/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
@@ -5,8 +5,11 @@
 
 package akka.kafka.internal
 
+import akka.actor.Actor
+
 import java.util.concurrent.CompletableFuture
 import akka.actor.ActorSystem
+import akka.actor.Props
 import akka.kafka.ConsumerMessage.{GroupTopicPartition, PartitionOffset, PartitionOffsetCommittedMarker}
 import akka.kafka.ProducerMessage._
 import akka.kafka.scaladsl.Producer
@@ -42,6 +45,15 @@ import scala.util.{Failure, Success, Try}
 object ProducerSpec {
   val group = "group"
   val consumerGroupMetadata = new ConsumerGroupMetadata(group, 1, "memberId", Optional.of("groupInstanceId"))
+
+  // fake publisher of group metadata for transactional producer stage, normally done by the Kafka consumer actor
+  class GroupMetadataPublisherActor extends Actor {
+
+    override def receive: Receive = {
+      case KafkaConsumerActor.Internal.SubscribeToGroupMetaData(subscriber) =>
+        subscriber ! consumerGroupMetadata
+    }
+  }
 }
 
 class ProducerSpec(_system: ActorSystem)
@@ -73,6 +85,7 @@ class ProducerSpec(_system: ActorSystem)
     new ProducerRecord("test", seed.toString, seed.toString) ->
     new RecordMetadata(new TopicPartition("test", seed), seed.toLong, seed, System.currentTimeMillis(), -1, -1)
 
+  val metadataMockActor = system.actorOf(Props(new ProducerSpec.GroupMetadataPublisherActor()))
   def toMessage(tuple: (Record, RecordMetadata)) = Message(tuple._1, NotUsed)
   private[kafka] def toTxMessage(tuple: (Record, RecordMetadata), committer: CommittedMarker) = {
     val consumerMessage = ConsumerMessage
@@ -82,7 +95,7 @@ class ProducerSpec(_system: ActorSystem)
                                      consumerMessage.offset,
                                      committer,
                                      fromPartitionedSource = false,
-                                     system.deadLetters)
+                                     metadataMockActor)
     ProducerMessage.Message(
       tuple._1,
       partitionOffsetCommittedMarker

--- a/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TransactionsSpec.scala
@@ -221,8 +221,9 @@ class TransactionsSpec extends SpecBase with TestcontainersKafkaLike with Transa
       val probeConsumer = valuesProbeConsumer(probeConsumerSettings(probeGroup), sinkTopic)
 
       probeConsumer
-        .request(100)
+        .request(101)
         .expectNextN((1 to 100).filterNot(_ % 10 == 0).map(_.toString))
+      probeConsumer.expectNoMessage(500.millis) // exactly as many as produced (no +1), no duplicates
 
       probeConsumer.cancel()
       Await.result(innerControl.shutdown(), remainingOrDefault)
@@ -256,8 +257,9 @@ class TransactionsSpec extends SpecBase with TestcontainersKafkaLike with Transa
       val probeConsumer = valuesProbeConsumer(probeConsumerSettings(probeConsumerGroup), sinkTopic)
 
       probeConsumer
-        .request(elements.toLong)
+        .request(elements.toLong + 1)
         .expectNextUnorderedN((1 to elements).map(_.toString))
+      probeConsumer.expectNoMessage(500.millis) // exactly as many as produced (no +1), no duplicates
 
       probeConsumer.cancel()
 


### PR DESCRIPTION
When rebalance triggers draining, it blocks the consumer actor so that it could not reply to the request for consumer group metadata, this would often if not always cause the stream to crash on rebalance (new consumer added, consumer leaving).