### PR TITLE
chore: remove warnings filters

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -124,9 +124,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: "Test (Scala 2.13, JDK 11)", scalaVersion: '2.13', java-version: 'temurin:1.11', sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
-          - { name: "Test (Scala 2.13, JDK 21)", scalaVersion: '2.13', java-version: 'temurin:1.21', sbt-opts: '' }
-          - { name: "Test (Scala 3.3, JDK 21)", scalaVersion: '3.3', java-version: 'temurin:1.21', sbt-opts: '' }
+          - { name: "Scala 2.13, JDK 11", scalaVersion: '2.13', java-version: 'temurin:1.11', sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { name: "Scala 2.13, JDK 21", scalaVersion: '2.13', java-version: 'temurin:1.21', sbt-opts: '' }
+          - { name: "Scala 3.3, JDK 21", scalaVersion: '3.3', java-version: 'temurin:1.21', sbt-opts: '' }
     steps:
       - name: Checkout
         # https://github.com/actions/checkout/releases

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -124,9 +124,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { scalaVersion: '2.13', java-version: 'temurin:1.11', sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
-          - { scalaVersion: '2.13', java-version: 'temurin:1.21', sbt-opts: '' }
-          - { scalaVersion: '3.3', java-version: 'temurin:1.21', sbt-opts: '' }
+          - { name: "Test (Scala 2.13, JDK 11)", scalaVersion: '2.13', java-version: 'temurin:1.11', sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { name: "Test (Scala 2.13, JDK 21)", scalaVersion: '2.13', java-version: 'temurin:1.21', sbt-opts: '' }
+          - { name: "Test (Scala 3.3, JDK 21)", scalaVersion: '3.3', java-version: 'temurin:1.21', sbt-opts: '' }
     steps:
       - name: Checkout
         # https://github.com/actions/checkout/releases

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/InflightMetrics.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/InflightMetrics.scala
@@ -18,7 +18,7 @@ import javax.management.{Attribute, MBeanServerConnection, ObjectName}
 
 import scala.concurrent.duration.{FiniteDuration, _}
 import scala.concurrent.{ExecutionContext, Future}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 private[benchmarks] trait InflightMetrics {
   import InflightMetrics._

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaConsumerBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaConsumerBenchmarks.scala
@@ -14,7 +14,7 @@ import org.apache.kafka.clients.consumer.{OffsetAndMetadata, OffsetCommitCallbac
 import org.apache.kafka.common.TopicPartition
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object KafkaConsumerBenchmarks extends LazyLogging {
   val pollTimeoutMs: Duration = Duration.ofMillis(50L)

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaConsumerFixtureGen.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaConsumerFixtureGen.scala
@@ -9,7 +9,7 @@ import akka.kafka.benchmarks.app.RunTestCommand
 import org.apache.kafka.clients.consumer.{ConsumerConfig, KafkaConsumer}
 import org.apache.kafka.common.serialization.{ByteArrayDeserializer, StringDeserializer}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 case class KafkaConsumerTestFixture(topic: String, msgCount: Int, consumer: KafkaConsumer[Array[Byte], String]) {
   def close(): Unit = consumer.close()

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaTransactionBenchmarks.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaTransactionBenchmarks.scala
@@ -13,7 +13,7 @@ import org.apache.kafka.clients.producer.{Callback, ProducerRecord, RecordMetada
 import org.apache.kafka.common.TopicPartition
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration.FiniteDuration
 
 object KafkaTransactionBenchmarks extends LazyLogging {

--- a/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaTransactionFixtureGen.scala
+++ b/benchmarks/src/main/scala/akka/kafka/benchmarks/KafkaTransactionFixtureGen.scala
@@ -18,7 +18,7 @@ import org.apache.kafka.common.serialization.{
   StringSerializer
 }
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 case class KafkaTransactionTestFixture(sourceTopic: String,
                                        sinkTopic: String,

--- a/build.sbt
+++ b/build.sbt
@@ -106,8 +106,7 @@ val commonSettings = Def.settings(
       "-encoding",
       "UTF-8", // yes, this is 2 args
       "-release",
-      "11",
-      "-Wconf:cat=feature:w,cat=deprecation&msg=.*JavaConverters.*:s,cat=unchecked:w,cat=lint:w,cat=unused:w,cat=w-flag:w"
+      "11"
     ) ++ {
       if (scalaVersion.value != Scala3) Seq("-Werror")
       else Seq.empty
@@ -170,9 +169,9 @@ lazy val `alpakka-kafka` =
     .disablePlugins(SitePlugin, MimaPlugin, CiReleasePlugin)
     .settings(commonSettings)
     .settings(
+      crossScalaVersions := Nil,
       publish / skip := true,
-      // TODO: add clusterSharding to unidocProjectFilter when we drop support for Akka 2.5
-      ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(core, testkit),
+      ScalaUnidoc / unidoc / unidocProjectFilter := inProjects(core, testkit, clusterSharding),
       onLoadMessage :=
         """
             |** Welcome to the Alpakka Kafka connector! **
@@ -405,10 +404,3 @@ lazy val benchmarks = project
         "org.scalatest" %% "scalatest" % scalatestVersion % IntegrationTest
       )
   )
-
-val isJdk11orHigher: Boolean = {
-  val result = VersionNumber(sys.props("java.specification.version")).matchesSemVer(SemanticSelector(">=11"))
-  if (!result)
-    throw new IllegalArgumentException("JDK 11 or higher is required")
-  result
-}

--- a/core/src/main/scala/akka/kafka/ConsumerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerMessage.scala
@@ -180,7 +180,7 @@ object ConsumerMessage {
    * Create an offset batch out of a list of offsets.
    */
   def createCommittableOffsetBatch[T <: Committable](offsets: java.util.List[T]): CommittableOffsetBatch = {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     CommittableOffsetBatch(offsets.asScala.toList)
   }
 

--- a/core/src/main/scala/akka/kafka/ConsumerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ConsumerSettings.scala
@@ -15,7 +15,7 @@ import com.typesafe.config.Config
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerConfig, KafkaConsumer}
 import org.apache.kafka.common.serialization.Deserializer
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.OptionConverters._
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.{ExecutionContext, Future}

--- a/core/src/main/scala/akka/kafka/Metadata.scala
+++ b/core/src/main/scala/akka/kafka/Metadata.scala
@@ -11,7 +11,7 @@ import akka.actor.NoSerializationVerificationNeeded
 import org.apache.kafka.clients.consumer.{OffsetAndMetadata, OffsetAndTimestamp}
 import org.apache.kafka.common.{PartitionInfo, TopicPartition}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 /**

--- a/core/src/main/scala/akka/kafka/ProducerMessage.scala
+++ b/core/src/main/scala/akka/kafka/ProducerMessage.scala
@@ -9,7 +9,7 @@ import akka.NotUsed
 import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata}
 
 import scala.collection.immutable
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * Classes that are used in both [[javadsl.Producer]] and

--- a/core/src/main/scala/akka/kafka/ProducerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ProducerSettings.scala
@@ -14,7 +14,7 @@ import com.typesafe.config.Config
 import org.apache.kafka.clients.producer.{KafkaProducer, Producer, ProducerConfig}
 import org.apache.kafka.common.serialization.Serializer
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration._
 import akka.util.JavaDurationConverters._

--- a/core/src/main/scala/akka/kafka/Subscriptions.scala
+++ b/core/src/main/scala/akka/kafka/Subscriptions.scala
@@ -12,7 +12,7 @@ import akka.kafka.internal.PartitionAssignmentHelpers.EmptyPartitionAssignmentHa
 import org.apache.kafka.common.TopicPartition
 
 import scala.annotation.varargs
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 sealed trait Subscription {
 

--- a/core/src/main/scala/akka/kafka/internal/ConfigSettings.scala
+++ b/core/src/main/scala/akka/kafka/internal/ConfigSettings.scala
@@ -11,7 +11,7 @@ import akka.annotation.InternalApi
 import com.typesafe.config.{Config, ConfigObject}
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration.Duration
 import akka.util.JavaDurationConverters._
 

--- a/core/src/main/scala/akka/kafka/internal/ConsumerProgressTracking.scala
+++ b/core/src/main/scala/akka/kafka/internal/ConsumerProgressTracking.scala
@@ -8,7 +8,7 @@ import akka.annotation.InternalApi
 import org.apache.kafka.clients.consumer.{Consumer, ConsumerRecords, OffsetAndMetadata}
 import org.apache.kafka.common.TopicPartition
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * Maintain our own OffsetAndTimestamp which can tolerate negative timestamps, which happen for old clients that

--- a/core/src/main/scala/akka/kafka/internal/ConsumerResetProtection.scala
+++ b/core/src/main/scala/akka/kafka/internal/ConsumerResetProtection.scala
@@ -15,7 +15,7 @@ import akka.kafka.internal.KafkaConsumerActor.Internal.Seek
 import org.apache.kafka.clients.consumer.{ConsumerRecord, ConsumerRecords, OffsetAndMetadata}
 import org.apache.kafka.common.TopicPartition
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * Added as part of https://github.com/akka/alpakka-kafka/issues/1286 to avoid reprocessing data in case of Kafka

--- a/core/src/main/scala/akka/kafka/internal/ControlImplementations.scala
+++ b/core/src/main/scala/akka/kafka/internal/ControlImplementations.scala
@@ -17,7 +17,7 @@ import akka.stream.stage.GraphStageLogic
 import akka.util.Timeout
 import org.apache.kafka.common.{Metric, MetricName}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.FutureConverters.{CompletionStageOps, FutureOps}
 import scala.concurrent.{ExecutionContext, Future, Promise}
 

--- a/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
+++ b/core/src/main/scala/akka/kafka/internal/KafkaConsumerActor.scala
@@ -34,7 +34,7 @@ import org.apache.kafka.common.errors.{
 }
 import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
 import scala.annotation.nowarn
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 import scala.util.{Success, Try}

--- a/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
+++ b/core/src/main/scala/akka/kafka/internal/MessageBuilder.scala
@@ -22,7 +22,7 @@ import org.apache.kafka.common.requests.OffsetFetchResponse
 
 import scala.compat.java8.FutureConverters.FutureOps
 import scala.concurrent.Future
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /** Internal API */
 @InternalApi

--- a/core/src/main/scala/akka/kafka/internal/PartitionAssignmentHelpers.scala
+++ b/core/src/main/scala/akka/kafka/internal/PartitionAssignmentHelpers.scala
@@ -13,7 +13,7 @@ import akka.kafka.{AutoSubscription, RestrictedConsumer, TopicPartitionsAssigned
 import akka.stream.stage.AsyncCallback
 import org.apache.kafka.common.TopicPartition
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * Internal API.

--- a/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
+++ b/core/src/main/scala/akka/kafka/internal/TransactionalProducerStage.scala
@@ -24,7 +24,7 @@ import org.apache.kafka.common.errors.ProducerFencedException
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Try}
 
 /**

--- a/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/Consumer.scala
@@ -19,7 +19,7 @@ import akka.{Done, NotUsed}
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.{Metric, MetricName, TopicPartition}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.duration.FiniteDuration
 

--- a/core/src/main/scala/akka/kafka/javadsl/MetadataClient.scala
+++ b/core/src/main/scala/akka/kafka/javadsl/MetadataClient.scala
@@ -16,7 +16,7 @@ import org.apache.kafka.common.{PartitionInfo, TopicPartition}
 
 import scala.compat.java8.FutureConverters._
 import scala.concurrent.ExecutionContextExecutor
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class MetadataClient private (metadataClient: akka.kafka.scaladsl.MetadataClient) {
 

--- a/testkit/src/main/scala/akka/kafka/testkit/ProducerResultFactory.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/ProducerResultFactory.scala
@@ -10,7 +10,7 @@ import akka.kafka.ProducerMessage
 import org.apache.kafka.clients.producer.{ProducerRecord, RecordMetadata}
 import org.apache.kafka.common.TopicPartition
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.immutable
 
 /**

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/KafkaTestKit.scala
@@ -18,7 +18,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.common.serialization.{Deserializer, Serializer, StringDeserializer, StringSerializer}
 import org.slf4j.Logger
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 /**
  * Common functions for scaladsl and javadsl Testkit.

--- a/testkit/src/main/scala/akka/kafka/testkit/internal/TestcontainersKafka.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/internal/TestcontainersKafka.scala
@@ -12,7 +12,7 @@ import org.testcontainers.containers.GenericContainer
 import org.testcontainers.utility.DockerImageName
 
 import scala.compat.java8.OptionConverters._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object TestcontainersKafka {
   trait Spec extends KafkaSpec {

--- a/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
+++ b/testkit/src/main/scala/akka/kafka/testkit/scaladsl/KafkaSpec.scala
@@ -29,7 +29,7 @@ import org.slf4j.{Logger, LoggerFactory}
 import scala.collection.immutable
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 abstract class KafkaSpec(_kafkaPort: Int, val zooKeeperPort: Int, actorSystem: ActorSystem)

--- a/tests/src/it/scala/akka/kafka/IntegrationTests.scala
+++ b/tests/src/it/scala/akka/kafka/IntegrationTests.scala
@@ -11,7 +11,7 @@ import org.apache.kafka.common.TopicPartition
 import org.slf4j.Logger
 import org.testcontainers.containers.GenericContainer
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object IntegrationTests {
   val MessageLogInterval = 500L

--- a/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/CommittingProducerSinkSpec.scala
@@ -33,7 +33,7 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.immutable
 import scala.concurrent.duration._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.ExecutionContext
 
 class CommittingProducerSinkSpec(_system: ActorSystem)

--- a/tests/src/test/scala/akka/kafka/internal/ConsumerMock.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConsumerMock.scala
@@ -17,7 +17,7 @@ import org.mockito.stubbing.Answer
 import org.mockito.verification.VerificationMode
 import org.mockito.{ArgumentMatchers, Mockito}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 

--- a/tests/src/test/scala/akka/kafka/internal/ConsumerProgressTrackingSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConsumerProgressTrackingSpec.scala
@@ -12,7 +12,7 @@ import org.mockito.Mockito
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.language.reflectiveCalls
 
 class ConsumerProgressTrackingSpec extends AnyFlatSpecLike with Matchers with LogCapturing {

--- a/tests/src/test/scala/akka/kafka/internal/ConsumerResetProtectionSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConsumerResetProtectionSpec.scala
@@ -22,7 +22,7 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import java.util.Optional
 import scala.concurrent.duration._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class ConsumerResetProtectionSpec
     extends TestKit(ActorSystem("ConsumerResetProtectionSpec"))

--- a/tests/src/test/scala/akka/kafka/internal/ConsumerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ConsumerSpec.scala
@@ -28,7 +28,7 @@ import org.scalatest.matchers.should.Matchers
 import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object ConsumerSpec {
   type K = String

--- a/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/PartitionedSourceSpec.scala
@@ -31,7 +31,7 @@ import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class PartitionedSourceSpec(_system: ActorSystem)
     extends TestKit(_system)

--- a/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
+++ b/tests/src/test/scala/akka/kafka/internal/ProducerSpec.scala
@@ -39,7 +39,7 @@ import org.scalatest.matchers.should.Matchers
 import java.util.Optional
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future, Promise}
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.{Failure, Success, Try}
 
 object ProducerSpec {

--- a/tests/src/test/scala/akka/kafka/scaladsl/RebalanceSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/RebalanceSpec.scala
@@ -23,7 +23,7 @@ import org.scalatest.Inside
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.concurrent.duration._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.util.Random
 
 class RebalanceSpec extends SpecBase with TestcontainersKafkaLike with Inside {

--- a/tests/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/RetentionPeriodSpec.scala
@@ -17,7 +17,7 @@ import akka.stream.testkit.scaladsl.TestSink
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 class RetentionPeriodSpec extends SpecBase with TestcontainersKafkaPerClassLike {
   private final val confluentPlatformVersion = "5.0.0"

--- a/tests/src/test/scala/akka/kafka/scaladsl/TimestampSpec.scala
+++ b/tests/src/test/scala/akka/kafka/scaladsl/TimestampSpec.scala
@@ -13,7 +13,7 @@ import org.apache.kafka.common.TopicPartition
 import org.scalatest.Inside
 import org.scalatest.concurrent.IntegrationPatience
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 

--- a/tests/src/test/scala/akka/kafka/tests/CapturingAppender.scala
+++ b/tests/src/test/scala/akka/kafka/tests/CapturingAppender.scala
@@ -76,7 +76,7 @@ import ch.qos.logback.core.AppenderBase
    * Also clears the buffer..
    */
   def flush(): Unit = synchronized {
-    import scala.collection.JavaConverters._
+    import scala.jdk.CollectionConverters._
     val logbackLogger = getLogbackLogger(classOf[CapturingAppender].getName + "Delegate")
     val appenders = logbackLogger.iteratorForAppenders().asScala.filterNot(_ == this).toList
     for (event <- buffer; appender <- appenders) {

--- a/tests/src/test/scala/docs/scaladsl/SchemaRegistrySerializationSpec.scala
+++ b/tests/src/test/scala/docs/scaladsl/SchemaRegistrySerializationSpec.scala
@@ -32,7 +32,7 @@ import org.apache.kafka.clients.producer.ProducerRecord
 // #imports
 import org.apache.kafka.common.serialization._
 // #imports
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 // #schema-registry-settings
 class SchemaRegistrySerializationSpec extends DocsSpecBase with TestcontainersKafkaPerClassLike {


### PR DESCRIPTION
The Scalac filters are no longer needed as Scala 2.12 has been dropped a while ago.