### PR TITLE
Adding more kafka producer properties that are allowed to be logged

### DIFF
--- a/core/src/main/scala/akka/kafka/ProducerSettings.scala
+++ b/core/src/main/scala/akka/kafka/ProducerSettings.scala
@@ -425,7 +425,10 @@ class ProducerSettings[K, V] @InternalApi private[kafka] (
     "queue.buffering.max.ms",
     "request.timeout.ms",
     "retries",
-    "security.protocol"
+    "security.protocol",
+    "compression.type",
+    "enable.idempotence",
+    "max.request.size"
   )
 
   override def toString: String = {


### PR DESCRIPTION
Adding more allowed Kafka producer properties that can be logged plainly without redaction.
