### PR TITLE
chore: bump kafka-clients to 3.8.1

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -5,7 +5,7 @@ updates.ignore = [
   { groupId = "org.scalameta", artifactId = "scalafmt-core" }
 ]
 updates.pin = [
-  { groupId = "org.apache.kafka", artifactId="kafka-clients", version="3.7." }
+  { groupId = "org.apache.kafka", artifactId="kafka-clients", version="3.8." }
   # To be updated in tandem with upstream Akka
   { groupId = "org.scalatest", artifactId = "scalatest", version = "3.1." }
   { groupId = "org.slf4j", artifactId = "log4j-over-slf4j", version = "1." }

--- a/build.sbt
+++ b/build.sbt
@@ -22,8 +22,8 @@ val AkkaBinaryVersionForDocs = VersionNumber(akkaVersion).numbers match {
 }
 
 // Keep .scala-steward.conf pin in sync
-val kafkaVersion = "3.7.1"
-val KafkaVersionForDocs = "37"
+val kafkaVersion = "3.8.1"
+val KafkaVersionForDocs = "38"
 // This should align with the ScalaTest version used in the Akka testkit
 // https://github.com/akka/akka/blob/main/project/Dependencies.scala#L44
 val scalatestVersion = "3.2.16"


### PR DESCRIPTION
Going one minor at a time, incase we want to make intermediate releases of alpakka-kafka until we support 4.0.0.