### PR TITLE
build: use global action step

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -34,6 +34,9 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
         # v6.4.5
@@ -67,6 +70,9 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
         # v6.4.5
@@ -99,6 +105,9 @@ jobs:
         run: |-
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
+
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
 
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
@@ -142,6 +151,9 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
         # v6.4.5
@@ -179,6 +191,9 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
         # v6.4.5
@@ -214,6 +229,9 @@ jobs:
         run: |-
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
+
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
 
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -24,6 +24,10 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
+
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Submit dependencies to GitHub
         # https://github.com/scalacenter/sbt-dependency-submission/releases
         # v2.3.1

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -22,6 +22,9 @@ jobs:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
         # v6.4.5

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Fetch tags
         run: git fetch --depth=100 origin +refs/tags/*:refs/tags/*
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
         # v6.4.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
           git fetch origin pull/${{ github.event.pull_request.number }}/merge:scratch
           git checkout scratch
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Cache Coursier cache
         # https://github.com/coursier/cache-action/releases
         # v6.4.5
@@ -66,6 +69,9 @@ jobs:
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
+
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
 
       - name: Set up JDK 25
         # https://github.com/coursier/setup-action/releases

--- a/README.md
+++ b/README.md
@@ -25,6 +25,13 @@ This repository contains the sources for the **Alpakka Kafka connector**. Which 
 Akka Stream connectors to other technologies are listed in the [Alpakka repository](https://github.com/akka/alpakka).
 
 
+## Build Token
+
+To build locally, you need to fetch a token at https://account.akka.io/token that you have to place into `~/.sbt/1.0/akka-commercial.sbt` file like this:
+```
+ThisBuild / resolvers += "lightbend-akka".at("your token resolver here")
+```
+
 Reference Documentation
 -----------------------
 

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,6 @@ val confluentLibsExclusionRules = Seq(
 )
 
 ThisBuild / resolvers ++= Seq(
-  "Akka library repository".at("https://repo.akka.io/maven/github_actions"),
   // for Jupiter interface (JUnit 5)
   Resolver.jcenterRepo
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions")
-
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.3")
 addSbtPlugin("net.aichler" % "sbt-jupiter-interface" % "0.11.1")


### PR DESCRIPTION
## Summary
- Add `akka/github-actions-scripts/setup_global_resolver@main` step to all workflow files (check-build-test, release, fossa, dependency-submission, link-validator)
- Remove `https://repo.akka.io/maven/github_actions` resolver from `build.sbt` and `project/plugins.sbt`
- Add `## Build Token` section to README.md with instructions for local builds

## Test plan
- [ ] CI workflows run successfully with the new global resolver step
- [ ] Verify local builds work after removing the hardcoded resolver

🤖 Generated with [Claude Code](https://claude.com/claude-code)