### PR TITLE
bump: kafka-clients 4.1.2 (was 4.1.0)

### DIFF
--- a/artifact-bom/akka-stream-kafka-cluster-sharding/pom.xml
+++ b/artifact-bom/akka-stream-kafka-cluster-sharding/pom.xml
@@ -7,6 +7,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>at.yawk.lz4</groupId>
+                <artifactId>lz4-java</artifactId>
+                <version>1.10.1</version>
+            </dependency>
+            <dependency>
                 <groupId>com.github.jnr</groupId>
                 <artifactId>jffi</artifactId>
                 <version>1.3.13</version>
@@ -129,17 +134,12 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>4.1.0</version>
+                <version>4.1.2</version>
             </dependency>
             <dependency>
                 <groupId>org.lmdbjava</groupId>
                 <artifactId>lmdbjava</artifactId>
                 <version>0.9.1</version>
-            </dependency>
-            <dependency>
-                <groupId>org.lz4</groupId>
-                <artifactId>lz4-java</artifactId>
-                <version>1.8.0</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
@@ -189,6 +189,11 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <dependency>
+            <groupId>at.yawk.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+            <version>1.10.1</version>
+        </dependency>
         <dependency>
             <groupId>com.github.jnr</groupId>
             <artifactId>jffi</artifactId>
@@ -312,17 +317,12 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>4.1.0</version>
+            <version>4.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.lmdbjava</groupId>
             <artifactId>lmdbjava</artifactId>
             <version>0.9.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.lz4</groupId>
-            <artifactId>lz4-java</artifactId>
-            <version>1.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.ow2.asm</groupId>

--- a/artifact-bom/akka-stream-kafka-testkit/pom.xml
+++ b/artifact-bom/akka-stream-kafka-testkit/pom.xml
@@ -7,6 +7,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>at.yawk.lz4</groupId>
+                <artifactId>lz4-java</artifactId>
+                <version>1.10.1</version>
+            </dependency>
+            <dependency>
                 <groupId>com.github.luben</groupId>
                 <artifactId>zstd-jni</artifactId>
                 <version>1.5.6-10</version>
@@ -44,12 +49,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>4.1.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.lz4</groupId>
-                <artifactId>lz4-java</artifactId>
-                <version>1.8.0</version>
+                <version>4.1.2</version>
             </dependency>
             <dependency>
                 <groupId>org.reactivestreams</groupId>
@@ -74,6 +74,11 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <dependency>
+            <groupId>at.yawk.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+            <version>1.10.1</version>
+        </dependency>
         <dependency>
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
@@ -112,12 +117,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>4.1.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.lz4</groupId>
-            <artifactId>lz4-java</artifactId>
-            <version>1.8.0</version>
+            <version>4.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.reactivestreams</groupId>

--- a/artifact-bom/akka-stream-kafka/pom.xml
+++ b/artifact-bom/akka-stream-kafka/pom.xml
@@ -7,6 +7,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>at.yawk.lz4</groupId>
+                <artifactId>lz4-java</artifactId>
+                <version>1.10.1</version>
+            </dependency>
+            <dependency>
                 <groupId>com.github.luben</groupId>
                 <artifactId>zstd-jni</artifactId>
                 <version>1.5.6-10</version>
@@ -34,12 +39,7 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>4.1.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.lz4</groupId>
-                <artifactId>lz4-java</artifactId>
-                <version>1.8.0</version>
+                <version>4.1.2</version>
             </dependency>
             <dependency>
                 <groupId>org.reactivestreams</groupId>
@@ -64,6 +64,11 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
+        <dependency>
+            <groupId>at.yawk.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+            <version>1.10.1</version>
+        </dependency>
         <dependency>
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
@@ -92,12 +97,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>4.1.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.lz4</groupId>
-            <artifactId>lz4-java</artifactId>
-            <version>1.8.0</version>
+            <version>4.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.reactivestreams</groupId>

--- a/build.sbt
+++ b/build.sbt
@@ -21,15 +21,15 @@ val AkkaBinaryVersionForDocs = VersionNumber(akkaVersion).numbers match {
   case Seq(major, minor, _*) => s"$major.$minor"
 }
 
-val kafkaVersion = "4.1.0"
+val kafkaVersion = "4.1.2"
 val KafkaVersionForDocs = VersionNumber(kafkaVersion).numbers match {
   case Seq(major, minor, _*) => s"$major$minor" // e.g. https://kafka.apache.org/41/documentation/
 }
 // This should align with the ScalaTest version used in the Akka testkit
 // https://github.com/akka/akka/blob/main/project/Dependencies.scala#L44
-val scalatestVersion = "3.2.16"
-val testcontainersVersion = "1.21.3"
-val logbackVersion = "1.5.18"
+val scalatestVersion = "3.2.17"
+val testcontainersVersion = "1.21.4"
+val logbackVersion = "1.5.37"
 val slf4jVersion = "2.0.17"
 // this depends on Kafka, and should be upgraded to such latest version
 // that depends on the same Kafka version, as is defined above


### PR DESCRIPTION
`org.apache.kafka:kafka-clients` versions <4.1.2 were affected by CVE-2026-33557, CVE-2026-35554.

The bump implicitly updates `lz4-java` to refer to the alive fork of the original library.

Also bumping some dependencies used for testing.

References
- https://mvnrepository.com/artifact/org.apache.kafka/kafka-clients/4.1.2