### PR TITLE
Replace hardcoded repo.akka.io resolver with tokenized URLs

### DIFF
--- a/docs/src/main/paradox/snapshots.md
+++ b/docs/src/main/paradox/snapshots.md
@@ -3,7 +3,7 @@ project.description: Snapshot builds of Alpakka Kafka.
 ---
 # Snapshots
 
-Snapshots are published to https://repo.akka.io/snapshots repository after every successful build on main.
+Snapshots are published to https://repo.akka.io/TOKEN/secure/snapshots repository after every successful build on main. The snapshot repository requires a secure, tokenized URL: replace TOKEN in the URLs below with a token generated at https://account.akka.io/token.
 Add the following to your project build definition to resolve Alpakka Kafka connector snapshots:
 
 ## Configure repository
@@ -17,7 +17,7 @@ Maven
             <repository>
               <id>akka-repository</id>
               <name>Akka library snapshot repository</name>
-              <url>https://repo.akka.io/snapshots</url>
+              <url>https://repo.akka.io/TOKEN/secure/snapshots</url>
             </repository>
           </repositories>
         </repositories>
@@ -27,14 +27,14 @@ Maven
 
 sbt
 :   ```scala
-    resolvers += "Akka library snapshot repository".at("https://repo.akka.io/snapshots")
+    resolvers += "Akka library snapshot repository".at("https://repo.akka.io/TOKEN/secure/snapshots")
     ```
 
 Gradle
 :   ```gradle
     repositories {
       maven {
-        url  "https://repo.akka.io/snapshots"
+        url  "https://repo.akka.io/TOKEN/secure/snapshots"
       }
     }
     ```


### PR DESCRIPTION
Akka library artifacts are now served from a secure, per-user tokenized repository.

- Release repository: use the tokenized URL from https://account.akka.io/token
- Snapshot repository: `https://repo.akka.io/TOKEN/secure/snapshots` (replace `TOKEN` with a token from https://account.akka.io/token)

This aligns the documentation/config with the canonical form in akka-core's `project/links` page. The old non-tokenized `https://repo.akka.io/snapshots` (and `/maven`) URLs no longer work for external consumers.